### PR TITLE
Add support for custom profiles and update dependencies

### DIFF
--- a/vrcosc-magicchatbox/App.xaml.cs
+++ b/vrcosc-magicchatbox/App.xaml.cs
@@ -35,33 +35,56 @@ namespace vrcosc_magicchatbox
             // Process command-line arguments
             if (e.Args != null && e.Args.Length > 0)
             {
-                switch (e.Args[0])
+                foreach (string arg in e.Args)
                 {
-                    case "-update":
-                        loadingWindow.UpdateProgress("Go, go, go! Update, update, update!", 75);
-                        await Task.Run(() => updater.UpdateApplication());
-                        Shutdown();
-                        return;
-                    case "-updateadmin":
-                        loadingWindow.UpdateProgress("Admin style update, now that's fancy!", 85);
-                        await Task.Run(() => updater.UpdateApplication(true));
-                        Shutdown();
-                        return;
-                    case "-rollback":
-                        loadingWindow.UpdateProgress("Oops! Let's roll back.", 50);
-                        await Task.Run(() => updater.RollbackApplication(loadingWindow));
-                        Shutdown();
-                        return;
-                    case "-clearbackup":
-                        loadingWindow.UpdateProgress("Rolling back and clearing the slate. Fresh start!", 50);
-                        await Task.Run(() => updater.ClearBackUp());
-                        break;
-                    default:
-                        loadingWindow.Hide();
-                        Logging.WriteException(new Exception($"Invalid command line argument '{e.Args[0]}'"), MSGBox: true, exitapp: true);
-                        return;
+                    if (arg.StartsWith("-profile="))
+                    {
+                        string profileNumberString = arg.Substring(9);
+                        if (int.TryParse(profileNumberString, out int profileNumber))
+                        {
+                            ViewModel.Instance.ProfileNumber = profileNumber;
+                            ViewModel.Instance.UseCustomProfile = true;
+                            ViewModel.Instance.SetDataPath();
+                        }
+                        else
+                        {
+                            loadingWindow.Hide();
+                            Logging.WriteException(new Exception($"Invalid profile number '{profileNumberString}'"), MSGBox: true, exitapp: true);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        switch (arg)
+                        {
+                            case "-update":
+                                loadingWindow.UpdateProgress("Go, go, go! Update, update, update!", 75);
+                                await Task.Run(() => updater.UpdateApplication());
+                                Shutdown();
+                                return;
+                            case "-updateadmin":
+                                loadingWindow.UpdateProgress("Admin style update, now that's fancy!", 85);
+                                await Task.Run(() => updater.UpdateApplication(true));
+                                Shutdown();
+                                return;
+                            case "-rollback":
+                                loadingWindow.UpdateProgress("Oops! Let's roll back.", 50);
+                                await Task.Run(() => updater.RollbackApplication(loadingWindow));
+                                Shutdown();
+                                return;
+                            case "-clearbackup":
+                                loadingWindow.UpdateProgress("Rolling back and clearing the slate. Fresh start!", 50);
+                                await Task.Run(() => updater.ClearBackUp());
+                                break;
+                            default:
+                                loadingWindow.Hide();
+                                Logging.WriteException(new Exception($"Invalid command line argument '{arg}'"), MSGBox: true, exitapp: true);
+                                return;
+                        }
+                    }
                 }
             }
+
 
             // Initialize various components with progress updates
             await InitializeComponentsWithProgress(loadingWindow);
@@ -152,6 +175,9 @@ namespace vrcosc_magicchatbox
 
             loadingWindow.UpdateProgress("Turbocharging MediaLink engines... Fast & Furious: Data Drift!", 95);
             ApplicationMediaController = new MediaLinkModule(ViewModel.Instance.IntgrScanMediaLink);
+
+            loadingWindow.UpdateProgress("Starting the modules... Ready, set, go!", 96);
+            await Task.Run(() => ViewModel.Instance.StartModules());
 
             loadingWindow.UpdateProgress("Loading MediaLink styles... Fashion show, here we come!", 98);
             await Task.Run(() => DataController.LoadAndSaveMediaLinkStyles());

--- a/vrcosc-magicchatbox/Classes/Modules/AfkModule.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/AfkModule.cs
@@ -29,7 +29,7 @@ namespace vrcosc_magicchatbox.Classes.Modules
         }
 
         private const string SettingsFileName = "AfkModuleSettings.json";
-        private static readonly string SettingsPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Vrcosc-MagicChatbox", SettingsFileName);
+        private static readonly string SettingsPath = Path.Combine(ViewModel.Instance.DataPath, SettingsFileName);
 
         [ObservableProperty]
         private int afkTimeout = 120;

--- a/vrcosc-magicchatbox/Classes/Modules/PulsoidModule.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/PulsoidModule.cs
@@ -151,7 +151,7 @@ namespace vrcosc_magicchatbox.Classes.Modules
 
         public static string GetFullSettingsPath()
         {
-            return Path.Combine(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Vrcosc-MagicChatbox"), SettingsFileName);
+            return Path.Combine(ViewModel.Instance.DataPath, SettingsFileName);
         }
 
         public static PulsoidModuleSettings LoadSettings()

--- a/vrcosc-magicchatbox/MagicChatbox.csproj
+++ b/vrcosc-magicchatbox/MagicChatbox.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-	<Version>0.9.040</Version>
+	<Version>0.9.039</Version>
     <TargetFramework>net8.0-windows10.0.22000.0</TargetFramework>
     <RootNamespace>vrcosc_magicchatbox</RootNamespace>
     <Nullable>enable</Nullable>
@@ -192,7 +192,7 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <PackageReference Include="Dubya.WindowsMediaController" Version="2.5.5" />
-    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.4-pre351" />
+    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.4-pre353" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
     <PackageReference Include="NAudio" Version="2.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/vrcosc-magicchatbox/MainWindow.xaml.cs
+++ b/vrcosc-magicchatbox/MainWindow.xaml.cs
@@ -681,11 +681,18 @@ namespace vrcosc_magicchatbox
 
         private void NewVersion_MouseUp(object sender, MouseButtonEventArgs e)
         {
+            if(ViewModel.Instance.UseCustomProfile)
+            {
+                Logging.WriteException(new Exception("Cannot update while using a custom profile."), MSGBox: true);
+                return;
+            }
+
+
             if (ViewModel.Instance.CanUpdate)
             {
                 ViewModel.Instance.CanUpdate = false;
                 ViewModel.Instance.CanUpdateLabel = false;
-                UpdateApp updateApp = new UpdateApp();
+                UpdateApp updateApp = new UpdateApp(true);
                 Task.Run(() => updateApp.PrepareUpdate());
             }
             else
@@ -1559,7 +1566,13 @@ namespace vrcosc_magicchatbox
 
         private void UpdateByZipFile_Click(object sender, RoutedEventArgs e)
         {
-            UpdateApp updateApp = new UpdateApp();
+            if (ViewModel.Instance.UseCustomProfile)
+            {
+                Logging.WriteException(new Exception("Cannot update by zip while using a custom profile."), MSGBox: true);
+                return;
+            }
+
+            UpdateApp updateApp = new UpdateApp(true);
             updateApp.SelectCustomZip();
         }
 
@@ -1633,7 +1646,13 @@ namespace vrcosc_magicchatbox
 
         private void Rollback_Click(object sender, RoutedEventArgs e)
         {
-            UpdateApp updateApp = new UpdateApp();
+            if (ViewModel.Instance.UseCustomProfile)
+            {
+                Logging.WriteException(new Exception("Cannot rollback while using a custom profile."), MSGBox: true);
+                return;
+            }
+
+            UpdateApp updateApp = new UpdateApp(true);
             updateApp.StartRollback();
         }
 

--- a/vrcosc-magicchatbox/Properties/launchSettings.json
+++ b/vrcosc-magicchatbox/Properties/launchSettings.json
@@ -6,6 +6,10 @@
     },
     "Normal": {
       "commandName": "Project"
+    },
+    "Profile 1": {
+      "commandName": "Project",
+      "commandLineArgs": "-profile=1"
     }
   }
 }

--- a/vrcosc-magicchatbox/UI/Dialogs/ApplicationError.xaml.cs
+++ b/vrcosc-magicchatbox/UI/Dialogs/ApplicationError.xaml.cs
@@ -60,7 +60,7 @@ namespace vrcosc_magicchatbox.UI.Dialogs
 
         private void Update_Click(object sender, RoutedEventArgs e)
         {
-            UpdateApp updater = new UpdateApp();
+            UpdateApp updater = new UpdateApp(true);
             updater.SelectCustomZip();
         }
 
@@ -70,7 +70,7 @@ namespace vrcosc_magicchatbox.UI.Dialogs
             {
                 ViewModel.Instance.CanUpdate = false;
                 ViewModel.Instance.CanUpdateLabel = false;
-                UpdateApp updateApp = new UpdateApp();
+                UpdateApp updateApp = new UpdateApp(true);
                 Task.Run(() => updateApp.PrepareUpdate());
             }
             else
@@ -91,7 +91,7 @@ namespace vrcosc_magicchatbox.UI.Dialogs
 
         private void rollback_Click(object sender, RoutedEventArgs e)
         {
-            UpdateApp updater = new UpdateApp();
+            UpdateApp updater = new UpdateApp(true);
             updater.StartRollback();
         }
     }

--- a/vrcosc-magicchatbox/ViewModels/ViewModel.cs
+++ b/vrcosc-magicchatbox/ViewModels/ViewModel.cs
@@ -325,13 +325,6 @@ namespace vrcosc_magicchatbox.ViewModels
                 { nameof(Settings_Status), value => Settings_Status = value }
             };
 
-            HeartRateConnector = new PulsoidModule();
-            SoundpadModule = new(1000);
-
-
-            PropertyChanged += HeartRateConnector.PropertyChangedHandler;
-            PropertyChanged += SoundpadModule.PropertyChangedHandler;
-
             ShuffleEmojis(); 
             CurrentEmoji = GetNextEmoji(); 
         }
@@ -339,6 +332,16 @@ namespace vrcosc_magicchatbox.ViewModels
         private void ProcessInfo_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             Resort();
+        }
+
+        public void StartModules()
+        {
+            HeartRateConnector = new PulsoidModule();
+            SoundpadModule = new(1000);
+
+
+            PropertyChanged += HeartRateConnector.PropertyChangedHandler;
+            PropertyChanged += SoundpadModule.PropertyChangedHandler;
         }
 
 
@@ -2183,6 +2186,16 @@ namespace vrcosc_magicchatbox.ViewModels
             {
                 _OSCPOrtIN = value;
                 NotifyPropertyChanged(nameof(OSCPOrtIN));
+            }
+        }
+
+        public void SetDataPath()
+        {
+            if(UseCustomProfile)
+            {
+                DataPath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                    $"Vrcosc-MagicChatbox-profile-{ProfileNumber}");
             }
         }
 
@@ -4165,6 +4178,28 @@ namespace vrcosc_magicchatbox.ViewModels
             }
 
             return CurrentEmoji = _shuffledEmojis.Dequeue();
+        }
+
+        private int _profileNumber;
+        public int ProfileNumber
+        {
+            get => _profileNumber;
+            set
+            {
+                _profileNumber = value;
+                NotifyPropertyChanged(nameof(ProfileNumber));
+            }
+        }
+
+        private bool _useCustomProfile;
+        public bool UseCustomProfile
+        {
+            get => _useCustomProfile;
+            set
+            {
+                _useCustomProfile = value;
+                NotifyPropertyChanged(nameof(UseCustomProfile));
+            }
         }
 
         #endregion


### PR DESCRIPTION
Add support for custom profiles and update dependencies

Introduce support for custom profiles via -profile=<number> argument.
Update App.xaml.cs to handle multiple command-line arguments.
Modify UpdateApp.cs to support new application location creation.
Update AfkModule.cs and PulsoidModule.cs to use custom data path.
Downgrade MagicChatbox.csproj version and update dependencies.
Prevent updates and rollbacks while using custom profiles.
Add new profile configuration in launchSettings.json.
Handle updates and rollbacks in ApplicationError.xaml.cs.
Add ProfileNumber and UseCustomProfile properties in ViewModel.cs.