### PR TITLE
Simplify app location update condition

### DIFF
--- a/vrcosc-magicchatbox/Classes/DataAndSecurity/UpdateApp.cs
+++ b/vrcosc-magicchatbox/Classes/DataAndSecurity/UpdateApp.cs
@@ -60,10 +60,8 @@ namespace vrcosc_magicchatbox.Classes.DataAndSecurity
                         currentAppPath = appLocation["currentAppPath"].ToString();
 
                         // Check if the current app path matches the actual current app path
-                        if (createNewAppLocation || !string.Equals(currentAppPath, actualCurrentAppPath, StringComparison.OrdinalIgnoreCase))
+                        if (createNewAppLocation)
                         {
-                            // The app has been moved to a new location
-                            Logging.WriteInfo("The application has been moved. Updating app_location.json.");
                             SetDefaultPaths();
                             SaveUpdateLocation();
                         }


### PR DESCRIPTION
Simplify app location update condition

Removed the redundant check for current app path match in `UpdateApp.cs`. Now, the code only verifies if `createNewAppLocation` is true before updating the app location, streamlining the conditional logic.

#### PR Classification
Code cleanup to streamline the logic for updating the app location.

#### PR Summary
Simplified the conditional logic for updating the app location in `UpdateApp.cs`.
- `UpdateApp.cs`: Removed the condition checking if the current app path matches the actual current app path, now only checks if `createNewAppLocation` is true.
