### PR TITLE
Exclude IPv6 statistics (network stats), and adjusted UI padding

### DIFF
--- a/vrcosc-magicchatbox/Classes/Modules/NetworkStatisticsModule.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/NetworkStatisticsModule.cs
@@ -170,7 +170,7 @@ namespace vrcosc_magicchatbox.Classes.Modules
 
         /// <summary>
         /// Asynchronously determines the active network interface.
-        /// Includes both IPv4 and IPv6 statistics.
+        /// Includes only IPv4 statistics.
         /// </summary>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The selected active NetworkInterface or null if none found.</returns>
@@ -240,18 +240,18 @@ namespace vrcosc_magicchatbox.Classes.Modules
         }
 
         /// <summary>
-        /// Retrieves total bytes sent and received, including both IPv4 and IPv6.
+        /// Retrieves total bytes sent and received, including only IPv4 statistics.
         /// </summary>
         /// <param name="ni">NetworkInterface.</param>
         /// <returns>TotalBytes struct containing BytesReceived and BytesSent.</returns>
         private TotalBytes GetTotalBytes(NetworkInterface ni)
         {
             var ipv4Stats = ni.GetIPv4Statistics();
-            var ipv6Stats = ni.GetIPStatistics();
+            // Removed IPv6 statistics to avoid duplication
             return new TotalBytes
             {
-                BytesReceived = ipv4Stats.BytesReceived + ipv6Stats.BytesReceived,
-                BytesSent = ipv4Stats.BytesSent + ipv6Stats.BytesSent
+                BytesReceived = ipv4Stats.BytesReceived,
+                BytesSent = ipv4Stats.BytesSent
             };
         }
 
@@ -297,7 +297,6 @@ namespace vrcosc_magicchatbox.Classes.Modules
             {
                 if (_activeNetworkInterface == null)
                 {
-                    // Attempt to re-initialize if the active interface is null
                     InitializeNetworkStatsAsync().ConfigureAwait(false);
                     if (_activeNetworkInterface == null)
                         return;

--- a/vrcosc-magicchatbox/MainWindow.xaml
+++ b/vrcosc-magicchatbox/MainWindow.xaml
@@ -7622,6 +7622,7 @@
                     Height="auto"
                     VerticalAlignment="Bottom">
                     <TextBlock
+                        Padding="0,0,0,30"
                         HorizontalAlignment="Center"
                         VerticalAlignment="Stretch"
                         FontFamily="Albert Sans Thin"


### PR DESCRIPTION
#### PR Classification
Code cleanup and UI adjustment.

#### PR Summary
Updated comments and method to exclude IPv6 statistics, and adjusted UI padding.
- `NetworkStatisticsModule.cs`: Updated comments and modified `GetTotalBytes` method to use only IPv4 statistics; removed redundant comment.
- `MainWindow.xaml`: Added `Padding` attribute to a `TextBlock` element.
