### PR TITLE
Update NuGet packages and bump project version

### DIFF
--- a/vrcosc-magicchatbox/MagicChatbox.csproj
+++ b/vrcosc-magicchatbox/MagicChatbox.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-	<Version>0.9.125</Version>
+	<Version>0.9.126</Version>
     <TargetFramework>net9.0-windows10.0.26100.0</TargetFramework>
     <RootNamespace>vrcosc_magicchatbox</RootNamespace>
     <Nullable>enable</Nullable>
@@ -201,14 +201,14 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Dubya.WindowsMediaController" Version="2.5.6" />
-    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.6-pre600" />
+    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.5" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
     <PackageReference Include="NAudio" Version="2.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.5-beta1" />
     <PackageReference Include="NHotkey.Wpf" Version="3.0.0" />
     <PackageReference Include="NLog" Version="6.0.7" />
 	  <PackageReference Include="OpenAI-DotNet" Version="8.8.8" />
-	  <PackageReference Include="System.Management" Version="10.0.1" />
+	  <PackageReference Include="System.Management" Version="10.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update NuGet packages and bump project version

Bump project version to 0.9.126. Downgrade LibreHardwareMonitorLib to 0.9.5 and upgrade System.Management to 10.0.2 for improved compatibility and stability.

#### PR Classification
Dependency update and version management.

#### PR Summary
This pull request updates project dependencies and increments the application version. Key changes include:
- MagicChatbox.csproj: Updated project version to 0.9.126.
- MagicChatbox.csproj: Downgraded LibreHardwareMonitorLib from 0.9.6-pre600 to 0.9.5.
- MagicChatbox.csproj: Upgraded System.Management from 10.0.1 to 10.0.2.
