### PR TITLE
Update output path settings in project file

### DIFF
--- a/vrcosc-magicchatbox/MagicChatbox.csproj
+++ b/vrcosc-magicchatbox/MagicChatbox.csproj
@@ -12,7 +12,7 @@
     <ApplicationIcon>Img\MagicOSC_icon.ico</ApplicationIcon>
     <TargetFrameworks></TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <StartupObject>vrcosc_magicchatbox.App</StartupObject>
     <SupportedOSPlatformVersion>10.0.26100.0</SupportedOSPlatformVersion>
 	  <GenerateBootstrapperOnBuild>true</GenerateBootstrapperOnBuild>
@@ -262,4 +262,6 @@
   </ItemGroup>
 
 </Project>
+
+
 


### PR DESCRIPTION
Update output path settings in project file

Removed explicit RuntimeIdentifier and set AppendRuntimeIdentifierToOutputPath to false to prevent runtime identifier from being added to output path. Also added blank lines at end of project file for formatting.