### PR TITLE
fix: update Spotify OAuth redirect URI from 127.0.0.1 to localhost

### DIFF
--- a/vrcosc-magicchatbox/Core/Constants.cs
+++ b/vrcosc-magicchatbox/Core/Constants.cs
@@ -62,7 +62,7 @@ public static class Constants
     public const string SpotifyApiBaseUrl = "https://api.spotify.com/v1/";
     public const string SpotifyOAuthEndpoint = "https://accounts.spotify.com/authorize";
     public const string SpotifyTokenEndpoint = "https://accounts.spotify.com/api/token";
-    public const string SpotifyOAuthRedirectUri = "http://127.0.0.1:7387/callback/";
+    public const string SpotifyOAuthRedirectUri = "http://localhost:7387/callback/";
     public const string SpotifyDeveloperDashboardUrl = "https://developer.spotify.com/dashboard";
     public const string SpotifyScopes = "user-read-playback-state user-read-currently-playing user-modify-playback-state user-library-read user-library-modify";
 


### PR DESCRIPTION
Required by Spotify since 9th of April 2025.

<img width="885" height="192" alt="image" src="https://github.com/user-attachments/assets/af576bdd-247b-4ecc-87e2-5c156aa97f5a" />

Ref: https://developer.spotify.com/documentation/web-api/concepts/redirect_uri

> Since we at Spotify, take security very seriously you must follow these requirements when defining your redirect URI:
> 
> - Use HTTPS for your redirect URI, unless you are using a loopback address, when HTTP is permitted.
> - If you are using a loopback address, use the explicit IPv4 or IPv6, like http://127.0.0.1:PORT or http://[::1]:PORT as your redirect URI.
> - localhost is not allowed as redirect URI.

Closes #181 