### PR TITLE
Fix CI publish failing with NETSDK1094

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -245,7 +245,7 @@ jobs:
     # Step 5: Restore Dependencies
     - name: Restore Dependencies
       if: steps.resolve_release.outputs.is_tag_release != 'true' || steps.check_release.outputs.release_exists == 'false'
-      run: dotnet restore ${{ env.Solution_Name }} -r win-x64
+      run: dotnet restore ${{ env.Solution_Name }} -r win-x64 -p:Configuration=Release -p:PublishReadyToRun=true
 
     # Step 6: Publish application to a stable output folder
     - name: Publish Application


### PR DESCRIPTION
Restore ran without knowing the publish step would need PublishReadyToRun, so the win-x64 crossgen runtime package it depends on was never pulled down - then publish ran with --no-restore and had nothing to compile against. Restore now passes the same Configuration and PublishReadyToRun the publish step uses, so the right runtime package lands during restore.

Reproduced locally: dotnet restore with the old command followed by the workflow's publish command hits the exact same NETSDK1094 failure; with the fix, restore pulls the runtime package and publish succeeds.