### PR TITLE
Turn off ReadyToRun - it was doubling the release size

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -245,7 +245,7 @@ jobs:
     # Step 5: Restore Dependencies
     - name: Restore Dependencies
       if: steps.resolve_release.outputs.is_tag_release != 'true' || steps.check_release.outputs.release_exists == 'false'
-      run: dotnet restore ${{ env.Solution_Name }} -r win-x64 -p:Configuration=Release -p:PublishReadyToRun=true
+      run: dotnet restore ${{ env.Solution_Name }} -r win-x64
 
     # Step 6: Publish application to a stable output folder
     - name: Publish Application

--- a/vrcosc-magicchatbox/MagicChatbox.csproj
+++ b/vrcosc-magicchatbox/MagicChatbox.csproj
@@ -24,7 +24,7 @@
 		<WarningLevel>4</WarningLevel>
 		<DebugType>none</DebugType>
 		<Prefer32Bit>false</Prefer32Bit>
-		<PublishReadyToRun>true</PublishReadyToRun>
+		<PublishReadyToRun>false</PublishReadyToRun>
 		<SatelliteResourceLanguages>en</SatelliteResourceLanguages>
 	</PropertyGroup>
 


### PR DESCRIPTION
PublishReadyToRun compiles every referenced assembly's native code inline, not just the app's own. Measured locally: 49 MB publish output without it, 98 MB with it - SixLabors.ImageSharp.dll alone goes from 1.8 MB to 31.5 MB. That's what pushed the release zip past VirusTotal's 32 MB standard upload limit. The restore step no longer needs the Configuration/PublishReadyToRun overrides added for the NETSDK1094 fix, since publish isn't requesting a ReadyToRun runtime package anymore.

Verified locally: restore + publish with the exact CI command sequence succeeds and produces a 49 MB output, matching the non-R2R baseline.