### PR TITLE
Release 0.9.226 - SteamVR startup, automatic updates, and a much faster interface

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -241,7 +241,7 @@ jobs:
     # ---- Build ----
     - name: Restore dependencies
       if: steps.resolve_release.outputs.is_tag_release != 'true' || steps.check_release.outputs.release_exists == 'false'
-      run: dotnet restore ${{ env.SOLUTION_PATH }} -r win-x64
+      run: dotnet restore ${{ env.SOLUTION_PATH }} -r win-x64 -p:Configuration=Release
 
     - name: Publish the application
       if: steps.resolve_release.outputs.is_tag_release != 'true' || steps.check_release.outputs.release_exists == 'false'

--- a/MagicChatbox.Tests/Classes/Modules/ComponentStatsPersistenceTests.cs
+++ b/MagicChatbox.Tests/Classes/Modules/ComponentStatsPersistenceTests.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Threading.Tasks;
+using vrcosc_magicchatbox.Classes.Modules;
+using vrcosc_magicchatbox.Core.Configuration;
+using vrcosc_magicchatbox.Core.Privacy;
+using vrcosc_magicchatbox.Core.State;
+using vrcosc_magicchatbox.Services;
+using vrcosc_magicchatbox.ViewModels;
+using vrcosc_magicchatbox.ViewModels.State;
+using Xunit;
+
+namespace MagicChatbox.Tests.Classes.Modules;
+
+public sealed class ComponentStatsPersistenceTests : IDisposable
+{
+    private sealed class StubSettingsProvider<T>(T value) : ISettingsProvider<T>
+        where T : class, new()
+    {
+        public T Value { get; } = value;
+
+        public int SaveCount { get; private set; }
+
+        public event EventHandler SettingsChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public void Save() => SaveCount++;
+
+        public void FlushPendingSave() => Save();
+
+        public void Reload() { }
+    }
+
+    private sealed class TestEnvironment(string dataPath) : IEnvironmentService
+    {
+        public string DataPath { get; } = dataPath;
+
+        public string LogPath => DataPath;
+
+        public string VrcPath => DataPath;
+
+        public void SetCustomProfile(int profileNumber) { }
+    }
+
+    private sealed class ImmediateDispatcher : IUiDispatcher
+    {
+        public void Invoke(Action action) => action();
+
+        public T Invoke<T>(Func<T> func) => func();
+
+        public Task InvokeAsync(Action action)
+        {
+            action();
+            return Task.CompletedTask;
+        }
+
+        public Task<T> InvokeAsync<T>(Func<T> func) => Task.FromResult(func());
+
+        public bool CheckAccess() => true;
+
+        public void BeginInvoke(Action action) => action();
+
+        public void Shutdown() { }
+    }
+
+    private sealed class FakeAppState : IAppState
+    {
+        public bool MasterSwitch { get; set; }
+
+        public bool IsVRRunning { get; set; }
+
+        public bool BussyBoysMode { get; set; }
+
+        public bool Egg_Dev { get; set; }
+
+        public bool PulsoidAuthConnected { get; set; }
+
+        public PulsoidAuthState PulsoidAuthState { get; set; }
+
+        public int MainWindowBlurEffect { get; set; }
+
+        public event PropertyChangedEventHandler? PropertyChanged
+        {
+            add { }
+            remove { }
+        }
+    }
+
+    private sealed class ApprovedConsent : IPrivacyConsentService
+    {
+        public bool IsApproved(PrivacyHook hook) => true;
+
+        public ConsentState GetState(PrivacyHook hook) => ConsentState.Approved;
+
+        public void Approve(PrivacyHook hook) { }
+
+        public void Deny(PrivacyHook hook) { }
+
+        public void Reset(PrivacyHook hook) { }
+
+        public IReadOnlyList<PrivacyHook> GetHooksRequiringConsent(IEnumerable<PrivacyHook> hooks)
+            => Array.Empty<PrivacyHook>();
+
+        public event EventHandler<ConsentChangedEventArgs> ConsentChanged
+        {
+            add { }
+            remove { }
+        }
+    }
+
+    private sealed class NoOpPersistence : IStatePersistenceCoordinator
+    {
+        public void PersistAllState() { }
+
+        public Task PrepareForShutdownAsync() => Task.CompletedTask;
+    }
+
+    private readonly string _dataPath = Path.Combine(
+        Path.GetTempPath(),
+        $"magicchatbox-component-stats-{Guid.NewGuid():N}");
+
+    [Fact]
+    public void Module_save_restores_all_custom_names_after_a_restart()
+    {
+        Directory.CreateDirectory(_dataPath);
+        var settings = new StubSettingsProvider<ComponentStatsSettings>(new ComponentStatsSettings());
+
+        using (ComponentStatsModule module = CreateModule(settings))
+        {
+            module.LoadComponentStats();
+            module.SetCustomHardwareName(StatsComponentType.CPU, "Main processor");
+            module.SetCustomHardwareName(StatsComponentType.GPU, "Rendering card");
+            module.SetCustomHardwareName(StatsComponentType.RAM, "System memory");
+            module.SetCustomHardwareName(StatsComponentType.VRAM, "Graphics memory");
+
+            module.SaveSettings();
+        }
+
+        Assert.Equal(1, settings.SaveCount);
+
+        using ComponentStatsModule restored = CreateModule(
+            new StubSettingsProvider<ComponentStatsSettings>(new ComponentStatsSettings()));
+        restored.LoadComponentStats();
+
+        Assert.Equal("Main processor", restored.GetCustomHardwareName(StatsComponentType.CPU));
+        Assert.Equal("Rendering card", restored.GetCustomHardwareName(StatsComponentType.GPU));
+        Assert.Equal("System memory", restored.GetCustomHardwareName(StatsComponentType.RAM));
+        Assert.Equal("Graphics memory", restored.GetCustomHardwareName(StatsComponentType.VRAM));
+    }
+
+    private ComponentStatsModule CreateModule(
+        ISettingsProvider<ComponentStatsSettings> componentSettings)
+        => new(
+            componentSettings,
+            new StubSettingsProvider<TimeSettings>(new TimeSettings()),
+            new StubSettingsProvider<AppSettings>(new AppSettings()),
+            new FakeAppState(),
+            new TestEnvironment(_dataPath),
+            new IntegrationDisplayState(),
+            new StubSettingsProvider<IntegrationSettings>(new IntegrationSettings()),
+            new ImmediateDispatcher(),
+            new Lazy<IStatePersistenceCoordinator>(() => new NoOpPersistence()),
+            new HardwareMonitorService(),
+            new ApprovedConsent());
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_dataPath))
+            Directory.Delete(_dataPath, recursive: true);
+    }
+}

--- a/MagicChatbox.Tests/Classes/Modules/DiscordReconnectSourceTests.cs
+++ b/MagicChatbox.Tests/Classes/Modules/DiscordReconnectSourceTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace MagicChatbox.Tests.Classes.Modules;
+
+public sealed class DiscordReconnectSourceTests
+{
+    [Fact]
+    public void Reconnect_keeps_trying_at_the_capped_delay_until_cancelled()
+    {
+        string source = File.ReadAllText(Path.Combine(
+            FindRepoRoot(),
+            "vrcosc-magicchatbox",
+            "Classes",
+            "Modules",
+            "DiscordModule.cs"));
+
+        Assert.Contains("while (!ct.IsCancellationRequested && !_disposed)", source, StringComparison.Ordinal);
+        Assert.Contains("DiscordReconnectMaxDelay", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("MaxAutoReconnectAttempts", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("Reconnect attempts exhausted", source, StringComparison.Ordinal);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null &&
+               !Directory.Exists(Path.Combine(directory.FullName, "vrcosc-magicchatbox", "Core")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName
+            ?? throw new DirectoryNotFoundException("repo root not found from " + AppContext.BaseDirectory);
+    }
+}

--- a/MagicChatbox.Tests/Classes/Modules/IntegrationModeVisibilityLyricsTests.cs
+++ b/MagicChatbox.Tests/Classes/Modules/IntegrationModeVisibilityLyricsTests.cs
@@ -1,0 +1,73 @@
+using vrcosc_magicchatbox.Classes.Modules;
+using Xunit;
+
+namespace MagicChatbox.Tests.Classes.Modules;
+
+public class IntegrationModeVisibilityLyricsTests
+{
+    [Fact]
+    public void Lyrics_are_not_reported_as_hidden_when_no_music_source_is_on()
+    {
+        // Lyrics render inside a music line and produce nothing on their own, so with no source
+        // switched on their mode switch changes nothing and pointing at it is wrong advice.
+        var settings = new IntegrationSettings
+        {
+            IntgrLyrics = true,
+            IntgrLyrics_VR = false,
+            IntgrLyrics_DESKTOP = false,
+            IntgrScanMediaLink = false,
+            IntgrSpotify = false,
+        };
+
+        Assert.DoesNotContain("Lyrics", IntegrationModeVisibility.BuildWarning(settings, isVR: true) ?? string.Empty);
+        Assert.DoesNotContain("Lyrics", IntegrationModeVisibility.BuildWarning(settings, isVR: false) ?? string.Empty);
+    }
+
+    [Fact]
+    public void Lyrics_are_not_reported_as_hidden_when_the_source_itself_is_hidden_here()
+    {
+        // The source already carries its own warning; repeating it for what rides along adds noise
+        // and a second switch to chase.
+        var settings = new IntegrationSettings
+        {
+            IntgrLyrics = true,
+            IntgrLyrics_VR = false,
+            IntgrScanMediaLink = true,
+            IntgrMediaLink_VR = false,
+            IntgrSpotify = false,
+        };
+
+        Assert.DoesNotContain("Lyrics", IntegrationModeVisibility.BuildWarning(settings, isVR: true) ?? string.Empty);
+    }
+
+    [Fact]
+    public void Lyrics_are_reported_as_hidden_when_the_source_is_showing_here()
+    {
+        // The one case worth saying out loud: music is on screen, lyrics are on, and only their own
+        // switch is keeping them off.
+        var settings = new IntegrationSettings
+        {
+            IntgrLyrics = true,
+            IntgrLyrics_VR = false,
+            IntgrScanMediaLink = true,
+            IntgrMediaLink_VR = true,
+        };
+
+        Assert.Contains("Lyrics", IntegrationModeVisibility.BuildWarning(settings, isVR: true) ?? string.Empty);
+    }
+
+    [Fact]
+    public void Spotify_counts_as_a_source_for_lyrics_too()
+    {
+        var settings = new IntegrationSettings
+        {
+            IntgrLyrics = true,
+            IntgrLyrics_VR = false,
+            IntgrScanMediaLink = false,
+            IntgrSpotify = true,
+            IntgrSpotify_VR = true,
+        };
+
+        Assert.Contains("Lyrics", IntegrationModeVisibility.BuildWarning(settings, isVR: true) ?? string.Empty);
+    }
+}

--- a/MagicChatbox.Tests/Classes/Modules/IntegrationTileCatalogTests.cs
+++ b/MagicChatbox.Tests/Classes/Modules/IntegrationTileCatalogTests.cs
@@ -173,7 +173,7 @@ public class IntegrationTileCatalogTests
             .Where(p => p.CanRead && p.GetIndexParameters().Length == 0)
             .OrderBy(p => p.Name, StringComparer.Ordinal))
         {
-            object value;
+            object? value;
             try { value = prop.GetValue(settings); }
             catch { continue; }
 

--- a/MagicChatbox.Tests/Classes/Modules/PulsoidAuthPersistenceTests.cs
+++ b/MagicChatbox.Tests/Classes/Modules/PulsoidAuthPersistenceTests.cs
@@ -17,7 +17,7 @@ internal sealed class UnprotectablePulsoidSettings : PulsoidModuleSettings
 {
     protected override bool TryProtectToken(string plaintext, out string ciphertext)
     {
-        ciphertext = null;
+        ciphertext = string.Empty;
         return false;
     }
 }

--- a/MagicChatbox.Tests/Classes/Modules/PulsoidModuleAuthRestoreTests.cs
+++ b/MagicChatbox.Tests/Classes/Modules/PulsoidModuleAuthRestoreTests.cs
@@ -114,7 +114,7 @@ public sealed class PulsoidModuleAuthRestoreTests : IDisposable
         }
 
         public Task DisconnectAsync() => Task.CompletedTask;
-        public Task<PulsoidStatisticsResponse> FetchStatisticsAsync(string accessToken, string timeRange) => Task.FromResult<PulsoidStatisticsResponse>(null!);
+        public Task<PulsoidStatisticsResponse?> FetchStatisticsAsync(string accessToken, string timeRange) => Task.FromResult<PulsoidStatisticsResponse?>(null);
         public void Dispose() { }
 
         public void RaiseConnectionFailed(PulsoidConnectionError error, string message)

--- a/MagicChatbox.Tests/Classes/Modules/PulsoidOAuthStateTests.cs
+++ b/MagicChatbox.Tests/Classes/Modules/PulsoidOAuthStateTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using vrcosc_magicchatbox.Classes.Modules;
+using Xunit;
+
+namespace MagicChatbox.Tests.Classes.Modules;
+
+public sealed class PulsoidOAuthStateTests
+{
+    [Fact]
+    public void Callback_state_must_match_the_state_that_started_the_flow()
+    {
+        const string expected = "a1b2c3d4";
+
+        Assert.True(PulsoidOAuthHandler.HasExpectedState(
+            $"access_token=token&state={expected}",
+            expected));
+        Assert.False(PulsoidOAuthHandler.HasExpectedState(
+            "access_token=token&state=some-other-flow",
+            expected));
+        Assert.False(PulsoidOAuthHandler.HasExpectedState(
+            "access_token=token",
+            expected));
+    }
+
+    [Fact]
+    public void Callback_listener_requires_a_bounded_post_from_the_bridge()
+    {
+        string source = File.ReadAllText(Path.Combine(
+            FindRepoRoot(),
+            "vrcosc-magicchatbox",
+            "Classes",
+            "Modules",
+            "PulsoidOAuthHandler.cs"));
+
+        Assert.Contains("MaxCallbackBodyChars", source, StringComparison.Ordinal);
+        Assert.Contains("request.HttpMethod, \"POST\"", source, StringComparison.Ordinal);
+        Assert.Contains("request.Headers[\"Origin\"]", source, StringComparison.Ordinal);
+        Assert.Contains("HasExpectedState(fragment, expectedState)", source, StringComparison.Ordinal);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null &&
+               !Directory.Exists(Path.Combine(directory.FullName, "vrcosc-magicchatbox", "Core")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName
+            ?? throw new DirectoryNotFoundException("repo root not found from " + AppContext.BaseDirectory);
+    }
+}

--- a/MagicChatbox.Tests/Classes/Modules/ScanningIntervalRoundingTests.cs
+++ b/MagicChatbox.Tests/Classes/Modules/ScanningIntervalRoundingTests.cs
@@ -1,0 +1,59 @@
+using vrcosc_magicchatbox.Classes.Modules;
+using Xunit;
+
+namespace MagicChatbox.Tests.Classes.Modules;
+
+public class ScanningIntervalRoundingTests
+{
+    [Theory]
+    [InlineData(9.799999999999999, 9.8)]
+    [InlineData(1.9000000000000001, 1.9)]
+    [InlineData(0.7999999999999999, 0.8)]
+    [InlineData(2.9999999999999996, 3.0)]
+    public void A_tick_that_drifted_off_a_tenth_is_stored_as_the_tenth(double drifted, double expected)
+    {
+        // The slider snaps to minimum plus whole steps of a tenth, which binary floating point
+        // cannot represent, so what arrives here is the drifted value the user never chose.
+        var settings = new AppSettings { ScanningInterval = drifted };
+
+        Assert.Equal(expected, settings.ScanningInterval);
+    }
+
+    [Fact]
+    public void Rounding_settles_instead_of_bouncing_between_two_values()
+    {
+        // The slider pushes its drifted value back every time the rounded one is handed to it, so
+        // the second pass has to agree with the first or the two sit there trading values forever.
+        var settings = new AppSettings { ScanningInterval = 9.799999999999999 };
+        double first = settings.ScanningInterval;
+
+        settings.ScanningInterval = 9.799999999999999;
+
+        Assert.Equal(first, settings.ScanningInterval);
+        Assert.Equal(9.8, settings.ScanningInterval);
+    }
+
+    [Fact]
+    public void The_bounds_still_hold()
+    {
+        Assert.Equal(
+            AppSettings.OscTickIntervalMinSeconds,
+            new AppSettings { ScanningInterval = 0.01 }.ScanningInterval);
+
+        Assert.Equal(
+            AppSettings.OscTickIntervalMaxSeconds,
+            new AppSettings { ScanningInterval = 99 }.ScanningInterval);
+
+        Assert.Equal(
+            AppSettings.OscTickIntervalDefaultSeconds,
+            new AppSettings { ScanningInterval = double.NaN }.ScanningInterval);
+    }
+
+    [Fact]
+    public void A_value_already_on_a_tenth_is_left_alone()
+    {
+        var settings = new AppSettings { ScanningInterval = 2.5 };
+
+        Assert.Equal(2.5, settings.ScanningInterval);
+    }
+}

--- a/MagicChatbox.Tests/Classes/Modules/Spotify/SpotifyTokenRefreshTests.cs
+++ b/MagicChatbox.Tests/Classes/Modules/Spotify/SpotifyTokenRefreshTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using vrcosc_magicchatbox.Classes.Modules;
+using vrcosc_magicchatbox.Classes.Modules.Spotify;
+using vrcosc_magicchatbox.Services;
+using Xunit;
+
+namespace MagicChatbox.Tests.Classes.Modules.Spotify;
+
+public sealed class SpotifyTokenRefreshTests
+{
+    private sealed class StubHandler(Func<HttpResponseMessage> responseFactory) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+            => Task.FromResult(responseFactory());
+    }
+
+    private sealed class StubHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+    }
+
+    private sealed class NoOpNavigation : INavigationService
+    {
+        public bool OpenUrl(string url) => true;
+        public bool OpenUrl(string url, string[] allowedDomains) => true;
+        public bool OpenFolder(string folderPath) => true;
+        public bool OpenFileInExplorer(string filePath) => true;
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.TooManyRequests)]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    public async Task Temporary_endpoint_failures_do_not_require_reauthentication(HttpStatusCode statusCode)
+    {
+        using var handler = new StubHandler(() => new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent("""{"error":"temporarily_unavailable"}"""),
+        });
+        using var oauth = new SpotifyOAuthHandler(
+            new NoOpNavigation(),
+            new StubHttpClientFactory(handler));
+
+        SpotifyTokenRefreshOutcome outcome = await oauth.RefreshTokenAsync("client", "refresh");
+
+        Assert.False(outcome.Succeeded);
+        Assert.Equal(SpotifyTokenRefreshFailureReason.Transient, outcome.FailureReason);
+        Assert.Equal(statusCode, outcome.StatusCode);
+    }
+
+    [Fact]
+    public async Task Invalid_grants_still_require_reauthentication()
+    {
+        using var handler = new StubHandler(() => new HttpResponseMessage(HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent(
+                """{"error":"invalid_grant","error_description":"Refresh token revoked"}"""),
+        });
+        using var oauth = new SpotifyOAuthHandler(
+            new NoOpNavigation(),
+            new StubHttpClientFactory(handler));
+
+        SpotifyTokenRefreshOutcome outcome = await oauth.RefreshTokenAsync("client", "refresh");
+
+        Assert.Equal(SpotifyTokenRefreshFailureReason.ReauthenticationRequired, outcome.FailureReason);
+        Assert.Equal("invalid_grant", outcome.SpotifyError);
+    }
+
+    [Fact]
+    public async Task OAuth_temporary_errors_are_transient_even_when_returned_as_bad_requests()
+    {
+        using var handler = new StubHandler(() => new HttpResponseMessage(HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent("""{"error":"temporarily_unavailable"}"""),
+        });
+        using var oauth = new SpotifyOAuthHandler(
+            new NoOpNavigation(),
+            new StubHttpClientFactory(handler));
+
+        SpotifyTokenRefreshOutcome outcome = await oauth.RefreshTokenAsync("client", "refresh");
+
+        Assert.Equal(SpotifyTokenRefreshFailureReason.Transient, outcome.FailureReason);
+    }
+
+    [Fact]
+    public async Task A_successful_refresh_returns_the_new_token()
+    {
+        using var handler = new StubHandler(() => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                """{"access_token":"new-access","refresh_token":"new-refresh","expires_in":3600}"""),
+        });
+        using var oauth = new SpotifyOAuthHandler(
+            new NoOpNavigation(),
+            new StubHttpClientFactory(handler));
+
+        SpotifyTokenRefreshOutcome outcome = await oauth.RefreshTokenAsync("client", "refresh");
+
+        Assert.True(outcome.Succeeded);
+        Assert.Equal("new-access", outcome.Token!.AccessToken);
+    }
+}

--- a/MagicChatbox.Tests/Classes/Modules/TwitchOutputTests.cs
+++ b/MagicChatbox.Tests/Classes/Modules/TwitchOutputTests.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Net.Http;
+using System.Reflection;
+using TwitchLib.Api.Core.Exceptions;
 using vrcosc_magicchatbox.Classes.Modules;
 using Xunit;
 
@@ -85,5 +89,32 @@ public sealed class TwitchOutputTests
         settings.OfflineMessage = "offline";
 
         Assert.Equal("offline", Build(settings, isLive: false));
+    }
+
+    [Fact]
+    public void TwitchLibs_expired_token_exception_is_treated_as_unauthorized()
+    {
+        using var response = new HttpResponseMessage();
+        var exception = new TokenExpiredException("expired", response);
+        MethodInfo? classifier = typeof(TwitchModule).GetMethod(
+            "IsUnauthorized",
+            BindingFlags.Static | BindingFlags.NonPublic);
+
+        Assert.NotNull(classifier);
+        Assert.True((bool)classifier!.Invoke(null, new object[] { exception })!);
+    }
+
+    [Fact]
+    public void Wrapped_expired_token_messages_are_treated_as_unauthorized()
+    {
+        var exception = new InvalidOperationException(
+            "outer",
+            new Exception("Your request was blocked due to an expired token."));
+        MethodInfo? classifier = typeof(TwitchModule).GetMethod(
+            "IsUnauthorized",
+            BindingFlags.Static | BindingFlags.NonPublic);
+
+        Assert.NotNull(classifier);
+        Assert.True((bool)classifier!.Invoke(null, new object[] { exception })!);
     }
 }

--- a/MagicChatbox.Tests/Classes/Modules/WeatherLocationFailureTests.cs
+++ b/MagicChatbox.Tests/Classes/Modules/WeatherLocationFailureTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using vrcosc_magicchatbox.Classes.Modules;
+using vrcosc_magicchatbox.Core.Configuration;
+using vrcosc_magicchatbox.Core.Privacy;
+using vrcosc_magicchatbox.Core.State;
+using vrcosc_magicchatbox.Core.Toast;
+using vrcosc_magicchatbox.Services;
+using vrcosc_magicchatbox.ViewModels;
+using vrcosc_magicchatbox.ViewModels.State;
+using Xunit;
+
+namespace MagicChatbox.Tests.Classes.Modules;
+
+public sealed class WeatherLocationFailureTests
+{
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"results":[]}"""),
+            });
+    }
+
+    private sealed class StubHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+    }
+
+    private sealed class StubSettingsProvider<T>(T value) : ISettingsProvider<T> where T : class, new()
+    {
+        public T Value { get; } = value;
+        public void Save() { }
+        public void FlushPendingSave() { }
+        public void Reload() { }
+        public event EventHandler SettingsChanged { add { } remove { } }
+    }
+
+    private sealed class ImmediateDispatcher : IUiDispatcher
+    {
+        public void Invoke(Action action) => action();
+        public T Invoke<T>(Func<T> func) => func();
+        public Task InvokeAsync(Action action) { action(); return Task.CompletedTask; }
+        public Task<T> InvokeAsync<T>(Func<T> func) => Task.FromResult(func());
+        public bool CheckAccess() => true;
+        public void BeginInvoke(Action action) => action();
+        public void Shutdown() { }
+    }
+
+    private sealed class FixedClock : ITimeFormattingService
+    {
+        public string GetFormattedCurrentTime() => "13:37";
+    }
+
+    private sealed class DeniedConsent : IPrivacyConsentService
+    {
+        public bool IsApproved(PrivacyHook hook) => false;
+        public ConsentState GetState(PrivacyHook hook) => ConsentState.Denied;
+        public void Approve(PrivacyHook hook) { }
+        public void Deny(PrivacyHook hook) { }
+        public void Reset(PrivacyHook hook) { }
+        public IReadOnlyList<PrivacyHook> GetHooksRequiringConsent(IEnumerable<PrivacyHook> hooks)
+            => Array.Empty<PrivacyHook>();
+        public event EventHandler<ConsentChangedEventArgs> ConsentChanged { add { } remove { } }
+    }
+
+    private sealed class RecordingToast : IToastService
+    {
+        public TaskCompletionSource<string> Message { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public ObservableCollection<ToastItemViewModel> Toasts { get; } = new();
+
+        public void Show(
+            string title,
+            string message,
+            ToastType type = ToastType.Info,
+            ToastAction? action = null,
+            int durationMs = 5000,
+            string? key = null)
+            => Message.TrySetResult(message);
+
+        public void Dismiss(ToastItemViewModel item) { }
+    }
+
+    [Fact]
+    public async Task Unknown_cities_surface_a_user_facing_error()
+    {
+        var settings = new WeatherSettings
+        {
+            ShowWeatherInTime = true,
+            WeatherLocationMode = WeatherLocationMode.CustomCity,
+            WeatherLocationCity = "definitely-not-a-real-city",
+        };
+        using var handler = new StubHandler();
+        var toast = new RecordingToast();
+        var service = new WeatherService(
+            new StubHttpClientFactory(handler),
+            new StubSettingsProvider<WeatherSettings>(settings),
+            new StubSettingsProvider<TimeSettings>(new TimeSettings()),
+            new IntegrationDisplayState(),
+            new StubSettingsProvider<ComponentStatsSettings>(new ComponentStatsSettings()),
+            new ImmediateDispatcher(),
+            new FixedClock(),
+            new DeniedConsent(),
+            toast);
+
+        service.TriggerManualRefresh();
+        string message = await toast.Message.Task.WaitAsync(TimeSpan.FromSeconds(3));
+
+        Assert.Contains("city", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("location", message, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/MagicChatbox.Tests/Core/Configuration/JsonSettingsProviderTests.cs
+++ b/MagicChatbox.Tests/Core/Configuration/JsonSettingsProviderTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Reflection;
 using Newtonsoft.Json;
 using vrcosc_magicchatbox.Classes.Modules;
 using vrcosc_magicchatbox.Core.Configuration;
@@ -188,5 +189,41 @@ public sealed class JsonSettingsProviderTests : IDisposable
 
         Assert.Equal(before, File.ReadAllText(SettingsFile));
         provider.Dispose();
+    }
+
+    [Fact]
+    public void Save_failure_notification_rearms_after_a_successful_write()
+    {
+        var provider = new JsonSettingsProvider<PulsoidModuleSettings>(_env);
+        provider.Value.CurrentHeartRateTitle = "Original";
+        provider.FlushPendingSave();
+
+        provider.Value.CurrentHeartRateTitle = "First blocked write";
+        using (new FileStream(SettingsFile, FileMode.Open, FileAccess.Read, FileShare.None))
+            provider.FlushPendingSave();
+
+        Assert.True(SaveFailureWasLogged(provider));
+
+        provider.Value.CurrentHeartRateTitle = "Recovered";
+        provider.FlushPendingSave();
+
+        Assert.False(SaveFailureWasLogged(provider));
+
+        provider.Value.CurrentHeartRateTitle = "Second blocked write";
+        using (new FileStream(SettingsFile, FileMode.Open, FileAccess.Read, FileShare.None))
+            provider.FlushPendingSave();
+
+        Assert.True(SaveFailureWasLogged(provider));
+        provider.Dispose();
+    }
+
+    private static bool SaveFailureWasLogged(JsonSettingsProvider<PulsoidModuleSettings> provider)
+    {
+        FieldInfo? field = typeof(JsonSettingsProvider<PulsoidModuleSettings>).GetField(
+            "_saveFailureLogged",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(field);
+        return (bool)field!.GetValue(provider)!;
     }
 }

--- a/MagicChatbox.Tests/Core/Diagnostics/PerfProbeArgumentTests.cs
+++ b/MagicChatbox.Tests/Core/Diagnostics/PerfProbeArgumentTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.IO;
+using vrcosc_magicchatbox.Core.Diagnostics;
+using Xunit;
+
+namespace MagicChatbox.Tests.Core.Diagnostics;
+
+public sealed class PerfProbeArgumentTests
+{
+    [Theory]
+    [InlineData("--perf")]
+    [InlineData("--PERF")]
+    [InlineData("-perf")]
+    public void Supported_performance_switches_are_recognized(string argument)
+        => Assert.True(PerfProbe.IsEnableArgument(argument));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("--performance")]
+    public void Unrelated_switches_are_not_recognized(string? argument)
+        => Assert.False(PerfProbe.IsEnableArgument(argument));
+
+    [Fact]
+    public void Startup_accepts_both_the_documented_and_legacy_switches()
+    {
+        string startup = File.ReadAllText(Path.Combine(
+            FindRepoRoot(),
+            "vrcosc-magicchatbox",
+            "App.xaml.cs"));
+
+        Assert.Contains("PerfProbe.IsEnableArgument(arg)", startup, StringComparison.Ordinal);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null &&
+               !Directory.Exists(Path.Combine(directory.FullName, "vrcosc-magicchatbox", "Core")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName
+            ?? throw new DirectoryNotFoundException("repo root not found from " + AppContext.BaseDirectory);
+    }
+}

--- a/MagicChatbox.Tests/Core/NonPersistedPropertyDoesNotSaveTests.cs
+++ b/MagicChatbox.Tests/Core/NonPersistedPropertyDoesNotSaveTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.IO;
+using System.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Newtonsoft.Json;
+using vrcosc_magicchatbox.Core.Configuration;
+using vrcosc_magicchatbox.Services;
+using Xunit;
+
+namespace MagicChatbox.Tests.Core;
+
+/// <summary>
+/// Auto-save listens to every PropertyChanged. Several modules write [JsonIgnore] display properties
+/// once a second, which beat the 2s debounce forever and so forced a byte-identical settings file to
+/// be serialized and written to disk every 30 seconds for the whole session.
+/// </summary>
+public partial class NonPersistedPropertyDoesNotSaveTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "mcb-settings-" + Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void Changing_a_JsonIgnore_property_never_writes_the_file()
+    {
+        var provider = new JsonSettingsProvider<ProbeSettings>(new FixedEnvironment(_dir));
+        ProbeSettings settings = provider.Value;
+
+        provider.Save();
+        string path = Path.Combine(_dir, nameof(ProbeSettings) + ".json");
+        Assert.True(File.Exists(path), "the provider never wrote a baseline file");
+
+        File.Delete(path);
+
+        for (int i = 0; i < 20; i++)
+            settings.DisplayOnly = i.ToString();
+
+        // Comfortably past the 2s debounce the writes would otherwise have armed.
+        Thread.Sleep(3500);
+
+        Assert.False(
+            File.Exists(path),
+            "a property that is never serialized triggered a settings save");
+    }
+
+    [Fact]
+    public void Changing_a_persisted_property_still_writes_the_file()
+    {
+        var provider = new JsonSettingsProvider<ProbeSettings>(new FixedEnvironment(_dir));
+        ProbeSettings settings = provider.Value;
+
+        provider.Save();
+        string path = Path.Combine(_dir, nameof(ProbeSettings) + ".json");
+        File.Delete(path);
+
+        settings.Persisted = "changed";
+        Thread.Sleep(3500);
+
+        Assert.True(File.Exists(path), "a real settings change did not reach disk");
+    }
+
+    public partial class ProbeSettings : ObservableObject
+    {
+        [ObservableProperty]
+        private string _persisted = string.Empty;
+
+        [ObservableProperty]
+        [property: JsonIgnore]
+        private string _displayOnly = string.Empty;
+    }
+
+    private sealed class FixedEnvironment : IEnvironmentService
+    {
+        public FixedEnvironment(string dataPath)
+        {
+            Directory.CreateDirectory(dataPath);
+            DataPath = dataPath;
+        }
+
+        public string DataPath { get; }
+
+        public string LogPath => DataPath;
+
+        public string VrcPath => DataPath;
+
+        public void SetCustomProfile(int profileNumber)
+        {
+        }
+    }
+}

--- a/MagicChatbox.Tests/Core/Updates/ReleaseVersionTests.cs
+++ b/MagicChatbox.Tests/Core/Updates/ReleaseVersionTests.cs
@@ -1,0 +1,202 @@
+using System;
+using vrcosc_magicchatbox.Core.Updates;
+using Xunit;
+
+namespace MagicChatbox.Tests.Core.Updates;
+
+public class ReleaseVersionTests
+{
+    private static readonly string[] Ladder =
+    [
+        "0.9.222",
+        "v0.9.223-rc1",
+        "0.9.223-rc2",
+        "v0.9.223",
+        "0.9.224",
+        "0.10.0",
+        "1.0.0",
+        "1.0.1",
+    ];
+
+    private static void AssertAscending(string? lower, string? higher)
+    {
+        Assert.True(ReleaseVersion.Compare(lower, higher) < 0, $"expected {lower} < {higher}");
+        Assert.True(ReleaseVersion.Compare(higher, lower) > 0, $"expected {higher} > {lower}");
+        Assert.Equal(0, ReleaseVersion.Compare(lower, lower));
+        Assert.Equal(0, ReleaseVersion.Compare(higher, higher));
+    }
+
+    private static void AssertEquivalent(string? left, string? right)
+    {
+        Assert.Equal(0, ReleaseVersion.Compare(left, right));
+        Assert.Equal(0, ReleaseVersion.Compare(right, left));
+    }
+
+    [Theory]
+    [InlineData("v0.9.223", "0.9.223")]
+    [InlineData("0.9.223", "0.9.223")]
+    [InlineData("v0.9.223-rc1", "0.9.223")]
+    [InlineData("0.9.223-rc1", "0.9.223")]
+    [InlineData("v0.9.223-rc1+build9", "0.9.223")]
+    [InlineData("1.2.3+build9", "1.2.3")]
+    [InlineData("  v1.2.3  ", "1.2.3")]
+    [InlineData("v1.0", "1.0")]
+    [InlineData("v1", "1")]
+    [InlineData("1.0.0.0", "1.0.0.0")]
+    public void Normalize_keeps_the_numbers_and_drops_everything_else(string tag, string expected)
+    {
+        Assert.Equal(expected, ReleaseVersion.Normalize(tag));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t\r\n")]
+    [InlineData("not-a-version")]
+    [InlineData("v")]
+    [InlineData("version 1.2.3")]
+    [InlineData("-rc1")]
+    [InlineData("beta")]
+    public void Normalize_returns_empty_for_anything_without_a_leading_number(string? tag)
+    {
+        Assert.Equal(string.Empty, ReleaseVersion.Normalize(tag));
+    }
+
+    [Fact]
+    public void Normalize_is_idempotent()
+    {
+        string once = ReleaseVersion.Normalize("v0.9.223-rc1");
+
+        Assert.Equal("0.9.223", once);
+        Assert.Equal(once, ReleaseVersion.Normalize(once));
+    }
+
+    [Theory]
+    [InlineData("0.9.223", "0.9.224")]
+    [InlineData("0.9.9", "0.9.10")]
+    [InlineData("0.9.223", "0.10.0")]
+    [InlineData("0.99.99", "1.0.0")]
+    [InlineData("1.2.3", "1.3.0")]
+    [InlineData("v0.9.223", "v1.0.0")]
+    public void Compare_orders_by_numeric_segments(string lower, string higher)
+    {
+        AssertAscending(lower, higher);
+    }
+
+    [Theory]
+    [InlineData("1.0", "1.0.0")]
+    [InlineData("1", "1.0.0")]
+    [InlineData("1.0.0.0", "1.0.0")]
+    [InlineData("v1.0", "1.0.0.0")]
+    [InlineData("1.02.3", "1.2.3")]
+    public void Compare_treats_missing_segments_as_zero(string left, string right)
+    {
+        AssertEquivalent(left, right);
+    }
+
+    [Fact]
+    public void Compare_ignores_the_leading_v()
+    {
+        AssertEquivalent("v0.9.223", "0.9.223");
+        AssertAscending("v0.9.223", "0.9.224");
+    }
+
+    [Fact]
+    public void A_release_candidate_ranks_below_the_release_it_is_a_candidate_for()
+    {
+        // The old implementation stripped non-digits instead of splitting on the suffix, so
+        // "v0.9.223-rc1" became "0.9.2231" and outranked the release it was a candidate for.
+        Assert.Equal("0.9.223", ReleaseVersion.Normalize("v0.9.223-rc1"));
+
+        Assert.True(ReleaseVersion.Compare("v0.9.223-rc1", "v0.9.223") < 0);
+        Assert.False(ReleaseVersion.Compare("v0.9.223-rc1", "v0.9.223") > 0);
+        Assert.True(ReleaseVersion.Compare("v0.9.223", "v0.9.223-rc1") > 0);
+
+        AssertAscending("v0.9.222", "v0.9.223-rc1");
+        AssertAscending("v0.9.223-rc1", "v0.9.224");
+    }
+
+    [Theory]
+    [InlineData("1.0.0-alpha", "1.0.0-beta")]
+    [InlineData("1.0.0-rc1", "1.0.0-rc2")]
+    [InlineData("1.0.0-rc10", "1.0.0-rc2")]
+    [InlineData("1.0.0.rc1", "1.0.0.rc2")]
+    public void Two_suffixed_builds_of_the_same_version_compare_ordinally(string lower, string higher)
+    {
+        // Ordinal, not numeric: "rc10" sorts before "rc2" because '1' precedes '2'.
+        AssertAscending(lower, higher);
+    }
+
+    [Theory]
+    [InlineData("1.0.0-rc1", "1.0.0-rc1")]
+    [InlineData("v1.0.0-rc1", "1.0.0-rc1")]
+    [InlineData("1.0-rc1", "1.0.0-rc1")]
+    public void Identical_suffixes_on_the_same_version_are_equal(string left, string right)
+    {
+        AssertEquivalent(left, right);
+    }
+
+    [Fact]
+    public void Build_metadata_after_a_plus_is_ignored()
+    {
+        AssertEquivalent("1.2.3+build9", "1.2.3");
+        AssertEquivalent("1.2.3+build9", "1.2.3+build10");
+        AssertEquivalent("1.2.3-rc1+build9", "1.2.3-rc1");
+        AssertAscending("1.2.3-rc1+build9", "1.2.3+build9");
+    }
+
+    [Fact]
+    public void Compare_handles_null_and_empty_on_either_side()
+    {
+        Assert.Equal(0, ReleaseVersion.Compare(null, null));
+        AssertEquivalent(null, string.Empty);
+        AssertEquivalent(null, "   ");
+        AssertEquivalent(string.Empty, "not-a-version");
+
+        AssertAscending(null, "1.0.0");
+        AssertAscending(string.Empty, "0.0.1");
+        AssertAscending("not-a-version", "0.0.1");
+
+        // An unreadable version carries no numbers at all, which puts it level with 0.0.0.
+        AssertEquivalent(null, "0.0.0");
+    }
+
+    [Fact]
+    public void Compare_is_antisymmetric_across_every_pairing()
+    {
+        foreach (string left in Ladder)
+        {
+            foreach (string right in Ladder)
+            {
+                int forward = Math.Sign(ReleaseVersion.Compare(left, right));
+                int backward = Math.Sign(ReleaseVersion.Compare(right, left));
+
+                Assert.True(forward == -backward, $"{left} vs {right} was not antisymmetric");
+            }
+        }
+    }
+
+    [Fact]
+    public void Compare_keeps_the_whole_ladder_in_order()
+    {
+        for (int i = 0; i < Ladder.Length; i++)
+        {
+            for (int j = i + 1; j < Ladder.Length; j++)
+            {
+                AssertAscending(Ladder[i], Ladder[j]);
+            }
+        }
+    }
+
+    [Fact]
+    public void Sorting_with_Compare_reproduces_the_ladder()
+    {
+        string[] shuffled = [.. Ladder];
+        Array.Reverse(shuffled);
+
+        Array.Sort(shuffled, ReleaseVersion.Compare);
+
+        Assert.Equal(Ladder, shuffled);
+    }
+}

--- a/MagicChatbox.Tests/Core/Updates/UpdateDecisionTests.cs
+++ b/MagicChatbox.Tests/Core/Updates/UpdateDecisionTests.cs
@@ -1,0 +1,309 @@
+using vrcosc_magicchatbox.Core.Updates;
+using Xunit;
+
+namespace MagicChatbox.Tests.Core.Updates;
+
+public class UpdateDecisionTests
+{
+    private static readonly UpdateOffer NoStable = UpdateOffer.Absent(UpdateChannel.Stable);
+    private static readonly UpdateOffer NoPreRelease = UpdateOffer.Absent(UpdateChannel.PreRelease);
+
+    private static UpdateOffer StableOffer(string version) => OfferOf(UpdateChannel.Stable, version);
+
+    private static UpdateOffer PreReleaseOffer(string version) => OfferOf(UpdateChannel.PreRelease, version);
+
+    private static UpdateOffer OfferOf(UpdateChannel channel, string version)
+        => new(channel, version, $"https://example.test/{version}/MagicChatbox.zip", "sha256:" + version);
+
+    [Fact]
+    public void An_armed_stable_channel_installs_a_newer_stable_build()
+    {
+        UpdateVerdict verdict = UpdateDecision.Decide(
+            "0.9.220",
+            StableOffer("0.9.224"),
+            NoPreRelease,
+            stableMode: UpdateChannelMode.Auto,
+            preReleaseMode: UpdateChannelMode.Off);
+
+        Assert.Equal(UpdateStanding.UpdateAvailable, verdict.Standing);
+        Assert.Equal(UpdateAction.AutoInstall, verdict.Action);
+        Assert.Equal(UpdateChannel.Stable, verdict.Channel);
+        Assert.Equal("0.9.224", verdict.Version);
+        Assert.Equal("https://example.test/0.9.224/MagicChatbox.zip", verdict.Url);
+        Assert.Equal("sha256:0.9.224", verdict.Digest);
+    }
+
+    [Fact]
+    public void A_watched_stable_channel_only_notifies()
+    {
+        UpdateVerdict verdict = UpdateDecision.Decide(
+            "0.9.220",
+            StableOffer("0.9.224"),
+            NoPreRelease,
+            stableMode: UpdateChannelMode.Notify,
+            preReleaseMode: UpdateChannelMode.Off);
+
+        Assert.Equal(UpdateStanding.UpdateAvailable, verdict.Standing);
+        Assert.Equal(UpdateAction.Notify, verdict.Action);
+        Assert.Equal(UpdateChannel.Stable, verdict.Channel);
+        Assert.Equal("0.9.224", verdict.Version);
+    }
+
+    [Fact]
+    public void A_disabled_stable_channel_offers_nothing()
+    {
+        UpdateVerdict verdict = UpdateDecision.Decide(
+            "0.9.220",
+            StableOffer("0.9.224"),
+            NoPreRelease,
+            stableMode: UpdateChannelMode.Off,
+            preReleaseMode: UpdateChannelMode.Off);
+
+        Assert.Equal(UpdateAction.None, verdict.Action);
+        Assert.NotEqual(UpdateStanding.UpdateAvailable, verdict.Standing);
+        Assert.Equal("0.9.220", verdict.Version);
+    }
+
+    [Fact]
+    public void A_disabled_pre_release_channel_is_never_offered_even_when_it_is_newest()
+    {
+        UpdateVerdict verdict = UpdateDecision.Decide(
+            "0.9.224",
+            StableOffer("0.9.224"),
+            PreReleaseOffer("0.9.230"),
+            stableMode: UpdateChannelMode.Auto,
+            preReleaseMode: UpdateChannelMode.Off);
+
+        Assert.Equal(UpdateStanding.UpToDate, verdict.Standing);
+        Assert.Equal(UpdateAction.None, verdict.Action);
+        Assert.Equal(UpdateChannel.Stable, verdict.Channel);
+        Assert.NotEqual("0.9.230", verdict.Version);
+    }
+
+    [Fact]
+    public void An_armed_pre_release_channel_installs_a_newer_pre_release()
+    {
+        UpdateVerdict verdict = UpdateDecision.Decide(
+            "0.9.224",
+            StableOffer("0.9.224"),
+            PreReleaseOffer("0.9.225"),
+            stableMode: UpdateChannelMode.Auto,
+            preReleaseMode: UpdateChannelMode.Auto);
+
+        Assert.Equal(UpdateStanding.UpdateAvailable, verdict.Standing);
+        Assert.Equal(UpdateAction.AutoInstall, verdict.Action);
+        Assert.Equal(UpdateChannel.PreRelease, verdict.Channel);
+        Assert.Equal("0.9.225", verdict.Version);
+    }
+
+    [Fact]
+    public void A_stranded_pre_release_user_still_moves_forward_to_stable()
+    {
+        // The mode belongs to the channel an update comes FROM, not to the build being run:
+        // someone left on an abandoned pre-release with pre-releases switched off must still
+        // be carried forward by the stable channel they did arm.
+        UpdateVerdict verdict = UpdateDecision.Decide(
+            "0.9.225",
+            StableOffer("0.9.226"),
+            PreReleaseOffer("0.9.225"),
+            stableMode: UpdateChannelMode.Auto,
+            preReleaseMode: UpdateChannelMode.Off);
+
+        Assert.Equal(UpdateStanding.UpdateAvailable, verdict.Standing);
+        Assert.Equal(UpdateAction.AutoInstall, verdict.Action);
+        Assert.Equal(UpdateChannel.Stable, verdict.Channel);
+        Assert.Equal("0.9.226", verdict.Version);
+    }
+
+    [Fact]
+    public void An_armed_channel_is_never_starved_by_a_merely_watched_one()
+    {
+        // The pre-release is the newer build, but it is only being watched. Picking it would
+        // downgrade the install the user armed on stable into a notification they must click.
+        UpdateVerdict verdict = UpdateDecision.Decide(
+            "0.9.220",
+            StableOffer("0.9.224"),
+            PreReleaseOffer("0.9.225"),
+            stableMode: UpdateChannelMode.Auto,
+            preReleaseMode: UpdateChannelMode.Notify);
+
+        Assert.Equal(UpdateAction.AutoInstall, verdict.Action);
+        Assert.Equal(UpdateChannel.Stable, verdict.Channel);
+        Assert.Equal("0.9.224", verdict.Version);
+    }
+
+    [Fact]
+    public void When_both_channels_are_armed_the_highest_version_wins()
+    {
+        UpdateVerdict preReleaseAhead = UpdateDecision.Decide(
+            "0.9.220",
+            StableOffer("0.9.224"),
+            PreReleaseOffer("0.9.226"),
+            stableMode: UpdateChannelMode.Auto,
+            preReleaseMode: UpdateChannelMode.Auto);
+
+        Assert.Equal(UpdateAction.AutoInstall, preReleaseAhead.Action);
+        Assert.Equal(UpdateChannel.PreRelease, preReleaseAhead.Channel);
+        Assert.Equal("0.9.226", preReleaseAhead.Version);
+
+        UpdateVerdict stableAhead = UpdateDecision.Decide(
+            "0.9.220",
+            StableOffer("0.9.227"),
+            PreReleaseOffer("0.9.226"),
+            stableMode: UpdateChannelMode.Auto,
+            preReleaseMode: UpdateChannelMode.Auto);
+
+        Assert.Equal(UpdateAction.AutoInstall, stableAhead.Action);
+        Assert.Equal(UpdateChannel.Stable, stableAhead.Channel);
+        Assert.Equal("0.9.227", stableAhead.Version);
+    }
+
+    [Fact]
+    public void A_tie_between_channels_resolves_to_stable()
+    {
+        UpdateVerdict verdict = UpdateDecision.Decide(
+            "0.9.220",
+            StableOffer("0.9.224"),
+            PreReleaseOffer("0.9.224"),
+            stableMode: UpdateChannelMode.Auto,
+            preReleaseMode: UpdateChannelMode.Auto);
+
+        Assert.Equal(UpdateChannel.Stable, verdict.Channel);
+        Assert.Equal("0.9.224", verdict.Version);
+    }
+
+    [Fact]
+    public void An_offer_equal_to_the_current_version_is_not_an_update()
+    {
+        UpdateVerdict verdict = UpdateDecision.Decide(
+            "0.9.224",
+            StableOffer("0.9.224"),
+            NoPreRelease,
+            stableMode: UpdateChannelMode.Auto,
+            preReleaseMode: UpdateChannelMode.Auto);
+
+        Assert.Equal(UpdateStanding.UpToDate, verdict.Standing);
+        Assert.Equal(UpdateAction.None, verdict.Action);
+        Assert.Equal(UpdateChannel.Stable, verdict.Channel);
+    }
+
+    [Fact]
+    public void An_older_offer_is_never_installed()
+    {
+        UpdateVerdict verdict = UpdateDecision.Decide(
+            "0.9.230",
+            StableOffer("0.9.224"),
+            PreReleaseOffer("0.9.229"),
+            stableMode: UpdateChannelMode.Auto,
+            preReleaseMode: UpdateChannelMode.Auto);
+
+        Assert.Equal(UpdateAction.None, verdict.Action);
+        Assert.Equal("0.9.230", verdict.Version);
+        Assert.NotEqual("0.9.224", verdict.Version);
+        Assert.NotEqual("0.9.229", verdict.Version);
+    }
+
+    [Theory]
+    [InlineData(UpdateChannelMode.Notify)]
+    [InlineData(UpdateChannelMode.Auto)]
+    public void A_blocked_version_is_never_offered_on_either_channel(UpdateChannelMode mode)
+    {
+        UpdateVerdict verdict = UpdateDecision.Decide(
+            "0.9.220",
+            StableOffer("0.9.224"),
+            PreReleaseOffer("0.9.225"),
+            stableMode: mode,
+            preReleaseMode: mode,
+            blockedVersions: ["0.9.224", "0.9.225"]);
+
+        Assert.Equal(UpdateAction.None, verdict.Action);
+        Assert.NotEqual(UpdateStanding.UpdateAvailable, verdict.Standing);
+        Assert.Equal("0.9.220", verdict.Version);
+    }
+
+    [Fact]
+    public void A_blocked_version_still_matches_when_it_was_recorded_with_a_tag_prefix()
+    {
+        UpdateVerdict verdict = UpdateDecision.Decide(
+            "0.9.220",
+            StableOffer("0.9.224"),
+            NoPreRelease,
+            stableMode: UpdateChannelMode.Auto,
+            preReleaseMode: UpdateChannelMode.Off,
+            blockedVersions: ["v0.9.224"]);
+
+        Assert.Equal(UpdateAction.None, verdict.Action);
+    }
+
+    [Fact]
+    public void Blocking_one_channel_still_leaves_the_other_free_to_offer()
+    {
+        UpdateVerdict verdict = UpdateDecision.Decide(
+            "0.9.220",
+            StableOffer("0.9.224"),
+            PreReleaseOffer("0.9.225"),
+            stableMode: UpdateChannelMode.Auto,
+            preReleaseMode: UpdateChannelMode.Auto,
+            blockedVersions: ["0.9.225"]);
+
+        Assert.Equal(UpdateAction.AutoInstall, verdict.Action);
+        Assert.Equal(UpdateChannel.Stable, verdict.Channel);
+        Assert.Equal("0.9.224", verdict.Version);
+    }
+
+    [Fact]
+    public void Running_newer_than_every_release_is_ahead_of_releases()
+    {
+        UpdateVerdict verdict = UpdateDecision.Decide(
+            "0.9.300",
+            StableOffer("0.9.224"),
+            PreReleaseOffer("0.9.226"),
+            stableMode: UpdateChannelMode.Notify,
+            preReleaseMode: UpdateChannelMode.Notify);
+
+        Assert.Equal(UpdateStanding.AheadOfReleases, verdict.Standing);
+        Assert.Equal(UpdateAction.None, verdict.Action);
+        Assert.Null(verdict.Channel);
+    }
+
+    [Theory]
+    [InlineData(UpdateChannelMode.Notify)]
+    [InlineData(UpdateChannelMode.Auto)]
+    public void Running_the_newest_pre_release_is_up_to_date_on_that_channel(UpdateChannelMode preReleaseMode)
+    {
+        UpdateVerdict verdict = UpdateDecision.Decide(
+            "0.9.225",
+            StableOffer("0.9.224"),
+            PreReleaseOffer("0.9.225"),
+            stableMode: UpdateChannelMode.Auto,
+            preReleaseMode: preReleaseMode);
+
+        Assert.Equal(UpdateStanding.UpToDate, verdict.Standing);
+        Assert.Equal(UpdateAction.None, verdict.Action);
+        Assert.Equal(UpdateChannel.PreRelease, verdict.Channel);
+    }
+
+    [Fact]
+    public void An_offer_without_a_url_or_a_version_counts_as_absent()
+    {
+        UpdateVerdict noUrl = UpdateDecision.Decide(
+            "0.9.220",
+            new UpdateOffer(UpdateChannel.Stable, "0.9.224", string.Empty, string.Empty),
+            NoPreRelease,
+            stableMode: UpdateChannelMode.Auto,
+            preReleaseMode: UpdateChannelMode.Auto);
+
+        Assert.Equal(UpdateAction.None, noUrl.Action);
+        Assert.Equal(UpdateStanding.UpToDate, noUrl.Standing);
+
+        UpdateVerdict noVersion = UpdateDecision.Decide(
+            "0.9.220",
+            NoStable,
+            new UpdateOffer(UpdateChannel.PreRelease, string.Empty, "https://example.test/x.zip", string.Empty),
+            stableMode: UpdateChannelMode.Auto,
+            preReleaseMode: UpdateChannelMode.Auto);
+
+        Assert.Equal(UpdateAction.None, noVersion.Action);
+        Assert.Equal(UpdateStanding.UpToDate, noVersion.Standing);
+    }
+}

--- a/MagicChatbox.Tests/Core/Updates/UpdateStateStoreTests.cs
+++ b/MagicChatbox.Tests/Core/Updates/UpdateStateStoreTests.cs
@@ -1,0 +1,332 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using vrcosc_magicchatbox.Core.Updates;
+using Xunit;
+
+namespace MagicChatbox.Tests.Core.Updates;
+
+public class UpdateStateStoreTests : IDisposable
+{
+    private static readonly DateTimeOffset StagedAt = new(2026, 8, 22, 13, 45, 12, 340, TimeSpan.Zero);
+
+    private readonly string _root;
+
+    public UpdateStateStoreTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "mcb-updatestate-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    private string NewProfile()
+    {
+        string dir = Path.Combine(_root, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private string MissingProfile() => Path.Combine(_root, "never-created-" + Guid.NewGuid().ToString("N"));
+
+    [Theory]
+    [InlineData(UpdateChannel.Stable)]
+    [InlineData(UpdateChannel.PreRelease)]
+    public void A_staged_update_reads_back_field_for_field(UpdateChannel channel)
+    {
+        string dir = NewProfile();
+        var written = new PendingUpdateInfo(
+            "0.9.231",
+            channel,
+            Path.Combine(dir, "staged", "MagicChatbox.zip"),
+            "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+            StagedAt);
+
+        Assert.True(PendingUpdate.Write(dir, written));
+
+        PendingUpdateInfo read = PendingUpdate.Read(dir);
+
+        Assert.NotNull(read);
+        Assert.Equal(written.Version, read.Version);
+        Assert.Equal(written.Channel, read.Channel);
+        Assert.Equal(written.StagedPath, read.StagedPath);
+        Assert.Equal(written.Sha256, read.Sha256);
+    }
+
+    [Fact]
+    public void The_staging_time_survives_the_round_trip()
+    {
+        // Newtonsoft turns an ISO timestamp back into a Date token while parsing, so reading it
+        // as a string hands back a localised "MM/dd/yyyy HH:mm:ss" rendering instead of what was
+        // written. Outside a US-style locale that no longer parses at all and the staging time
+        // silently becomes DateTimeOffset.MinValue.
+        string dir = NewProfile();
+        PendingUpdate.Write(
+            dir,
+            new PendingUpdateInfo("0.9.231", UpdateChannel.Stable, "staged.zip", "abc", StagedAt));
+
+        PendingUpdateInfo read = PendingUpdate.Read(dir);
+
+        Assert.NotNull(read);
+        Assert.Equal(StagedAt, read.StagedAtUtc);
+    }
+
+    [Fact]
+    public void Nothing_is_pending_when_no_record_was_ever_written()
+    {
+        Assert.Null(PendingUpdate.Read(NewProfile()));
+        Assert.Null(PendingUpdate.Read(MissingProfile()));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("{ not json")]
+    [InlineData("[]")]
+    [InlineData("half a file, truncated by a crash mid-w")]
+    public void A_damaged_record_reads_as_nothing_pending(string contents)
+    {
+        string dir = NewProfile();
+        File.WriteAllText(PendingUpdate.PathFor(dir), contents);
+
+        Assert.Null(PendingUpdate.Read(dir));
+    }
+
+    [Fact]
+    public void Clear_removes_the_record()
+    {
+        string dir = NewProfile();
+        PendingUpdate.Write(dir, new PendingUpdateInfo("0.9.231", UpdateChannel.Stable, "staged.zip", "abc", DateTimeOffset.UtcNow));
+        Assert.NotNull(PendingUpdate.Read(dir));
+
+        PendingUpdate.Clear(dir);
+
+        Assert.Null(PendingUpdate.Read(dir));
+        Assert.False(File.Exists(PendingUpdate.PathFor(dir)));
+    }
+
+    [Fact]
+    public void Clear_with_nothing_to_clear_is_harmless()
+    {
+        PendingUpdate.Clear(NewProfile());
+        PendingUpdate.Clear(MissingProfile());
+    }
+
+    [Theory]
+    [InlineData("Nightly")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void An_unknown_channel_falls_back_to_stable(string? channel)
+    {
+        // The channel is stored by name, so a record written by a build that knew more channels
+        // than this one must still be usable rather than dropped.
+        string dir = NewProfile();
+        string encoded = channel is null ? "null" : "\"" + channel + "\"";
+        File.WriteAllText(
+            PendingUpdate.PathFor(dir),
+            "{ \"version\": \"0.9.231\", \"channel\": " + encoded + ", \"stagedPath\": \"staged.zip\", \"sha256\": \"abc\" }");
+
+        PendingUpdateInfo read = PendingUpdate.Read(dir);
+
+        Assert.NotNull(read);
+        Assert.Equal(UpdateChannel.Stable, read.Channel);
+        Assert.Equal("0.9.231", read.Version);
+    }
+
+    [Fact]
+    public void The_first_start_on_a_clean_profile_reports_no_earlier_failure()
+    {
+        StartupHealthCheck check = StartupHealthBeacon.MarkStarting(NewProfile());
+
+        Assert.False(check.PreviousStartFailed);
+        Assert.Equal(0, check.ConsecutiveFailures);
+        Assert.False(check.WasAutoInstalled);
+    }
+
+    [Fact]
+    public void A_run_that_reached_healthy_resets_the_streak()
+    {
+        string dir = NewProfile();
+
+        StartupHealthBeacon.MarkStarting(dir);
+        StartupHealthBeacon.MarkStarting(dir);
+        StartupHealthBeacon.MarkHealthy(dir);
+
+        StartupHealthCheck check = StartupHealthBeacon.MarkStarting(dir);
+
+        Assert.False(check.PreviousStartFailed);
+        Assert.Equal(0, check.ConsecutiveFailures);
+    }
+
+    [Fact]
+    public void Starts_that_never_reach_healthy_count_up_one_at_a_time()
+    {
+        // The rollback fires at three consecutive failures, so the exact sequence matters:
+        // an off-by-one here either rolls a working build back or lets a crash loop run forever.
+        string dir = NewProfile();
+
+        StartupHealthCheck first = StartupHealthBeacon.MarkStarting(dir);
+        Assert.False(first.PreviousStartFailed);
+        Assert.Equal(0, first.ConsecutiveFailures);
+
+        StartupHealthCheck second = StartupHealthBeacon.MarkStarting(dir);
+        Assert.True(second.PreviousStartFailed);
+        Assert.Equal(1, second.ConsecutiveFailures);
+
+        StartupHealthCheck third = StartupHealthBeacon.MarkStarting(dir);
+        Assert.True(third.PreviousStartFailed);
+        Assert.Equal(2, third.ConsecutiveFailures);
+
+        StartupHealthCheck fourth = StartupHealthBeacon.MarkStarting(dir);
+        Assert.True(fourth.PreviousStartFailed);
+        Assert.Equal(3, fourth.ConsecutiveFailures);
+    }
+
+    [Fact]
+    public void An_auto_installed_version_is_reported_on_the_next_start()
+    {
+        string dir = NewProfile();
+
+        StartupHealthBeacon.RecordAutoInstall(dir, "0.9.231");
+        StartupHealthCheck check = StartupHealthBeacon.MarkStarting(dir);
+
+        Assert.True(check.WasAutoInstalled);
+        Assert.Equal("0.9.231", check.AutoInstalledVersion);
+    }
+
+    [Fact]
+    public void Probation_ends_once_a_build_starts_cleanly()
+    {
+        string dir = NewProfile();
+
+        StartupHealthBeacon.RecordAutoInstall(dir, "0.9.231");
+        Assert.True(StartupHealthBeacon.MarkStarting(dir).WasAutoInstalled);
+
+        StartupHealthBeacon.MarkHealthy(dir);
+        StartupHealthCheck check = StartupHealthBeacon.MarkStarting(dir);
+
+        Assert.False(check.WasAutoInstalled);
+        Assert.Equal(string.Empty, check.AutoInstalledVersion);
+        Assert.False(check.PreviousStartFailed);
+    }
+
+    [Fact]
+    public void An_auto_install_recorded_mid_streak_keeps_the_streak()
+    {
+        string dir = NewProfile();
+
+        StartupHealthBeacon.MarkStarting(dir);
+        StartupHealthBeacon.RecordAutoInstall(dir, "0.9.231");
+
+        StartupHealthCheck check = StartupHealthBeacon.MarkStarting(dir);
+
+        Assert.True(check.PreviousStartFailed);
+        Assert.Equal(1, check.ConsecutiveFailures);
+        Assert.Equal("0.9.231", check.AutoInstalledVersion);
+    }
+
+    [Fact]
+    public void A_beacon_that_was_never_written_reads_clean()
+    {
+        Assert.Equal(StartupHealth.Clean, StartupHealthBeacon.Read(NewProfile()));
+        Assert.Equal(StartupHealth.Clean, StartupHealthBeacon.Read(MissingProfile()));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("{ not json")]
+    [InlineData("[]")]
+    public void A_damaged_beacon_reads_clean_rather_than_throwing(string contents)
+    {
+        string dir = NewProfile();
+        File.WriteAllText(StartupHealthBeacon.PathFor(dir), contents);
+
+        Assert.Equal(StartupHealth.Clean, StartupHealthBeacon.Read(dir));
+    }
+
+    [Fact]
+    public void A_clean_profile_blocks_nothing()
+    {
+        Assert.Empty(UpdateBlocklist.Read(NewProfile()));
+        Assert.Empty(UpdateBlocklist.Read(MissingProfile()));
+    }
+
+    [Fact]
+    public void A_blocked_version_reads_back()
+    {
+        string dir = NewProfile();
+
+        Assert.Equal(new[] { "0.9.231" }, UpdateBlocklist.Add(dir, "0.9.231"));
+        Assert.Equal(new[] { "0.9.231" }, UpdateBlocklist.Read(dir));
+    }
+
+    [Theory]
+    [InlineData("0.9.231", "0.9.231")]
+    [InlineData("v1.2.3", "1.2.3")]
+    [InlineData("1.2.3", "v1.2.3")]
+    public void The_same_release_is_never_blocked_twice(string first, string second)
+    {
+        // Tags reach this list from several places, some with the leading v and some without,
+        // so sameness has to be judged by version rather than by string.
+        string dir = NewProfile();
+
+        UpdateBlocklist.Add(dir, first);
+        UpdateBlocklist.Add(dir, second);
+
+        Assert.Equal(new[] { first }, UpdateBlocklist.Read(dir));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void A_blank_version_is_ignored(string? version)
+    {
+        string dir = NewProfile();
+
+        Assert.Empty(UpdateBlocklist.Add(dir, version!));
+        Assert.Empty(UpdateBlocklist.Read(dir));
+        Assert.False(File.Exists(UpdateBlocklist.PathFor(dir)));
+    }
+
+    [Fact]
+    public void The_blocklist_keeps_the_most_recent_entries_and_no_more()
+    {
+        string dir = NewProfile();
+
+        for (int i = 1; i <= 25; i++)
+        {
+            UpdateBlocklist.Add(dir, "1.0." + i);
+        }
+
+        IReadOnlyList<string> blocked = UpdateBlocklist.Read(dir);
+
+        Assert.Equal(20, blocked.Count);
+        Assert.Equal("1.0.6", blocked[0]);
+        Assert.Equal("1.0.25", blocked[^1]);
+        Assert.DoesNotContain("1.0.5", blocked);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("[ not json")]
+    [InlineData("{}")]
+    public void A_damaged_blocklist_blocks_nothing(string contents)
+    {
+        string dir = NewProfile();
+        File.WriteAllText(UpdateBlocklist.PathFor(dir), contents);
+
+        Assert.Empty(UpdateBlocklist.Read(dir));
+    }
+}

--- a/MagicChatbox.Tests/Core/Updates/UpdateStateStoreTests.cs
+++ b/MagicChatbox.Tests/Core/Updates/UpdateStateStoreTests.cs
@@ -53,7 +53,7 @@ public class UpdateStateStoreTests : IDisposable
 
         Assert.True(PendingUpdate.Write(dir, written));
 
-        PendingUpdateInfo read = PendingUpdate.Read(dir);
+        PendingUpdateInfo? read = PendingUpdate.Read(dir);
 
         Assert.NotNull(read);
         Assert.Equal(written.Version, read.Version);
@@ -74,7 +74,7 @@ public class UpdateStateStoreTests : IDisposable
             dir,
             new PendingUpdateInfo("0.9.231", UpdateChannel.Stable, "staged.zip", "abc", StagedAt));
 
-        PendingUpdateInfo read = PendingUpdate.Read(dir);
+        PendingUpdateInfo? read = PendingUpdate.Read(dir);
 
         Assert.NotNull(read);
         Assert.Equal(StagedAt, read.StagedAtUtc);
@@ -135,7 +135,7 @@ public class UpdateStateStoreTests : IDisposable
             PendingUpdate.PathFor(dir),
             "{ \"version\": \"0.9.231\", \"channel\": " + encoded + ", \"stagedPath\": \"staged.zip\", \"sha256\": \"abc\" }");
 
-        PendingUpdateInfo read = PendingUpdate.Read(dir);
+        PendingUpdateInfo? read = PendingUpdate.Read(dir);
 
         Assert.NotNull(read);
         Assert.Equal(UpdateChannel.Stable, read.Channel);

--- a/MagicChatbox.Tests/Services/CredentialPreservationResetTests.cs
+++ b/MagicChatbox.Tests/Services/CredentialPreservationResetTests.cs
@@ -1,0 +1,119 @@
+using System;
+using vrcosc_magicchatbox.Classes.Modules;
+using vrcosc_magicchatbox.Core.Configuration;
+using vrcosc_magicchatbox.Services;
+using Xunit;
+
+namespace MagicChatbox.Tests.Services;
+
+// Every credential here is stored as a plaintext/encrypted pair whose setters write through to each
+// other, so resetting one half is enough to destroy the half being protected. These cover each
+// settings class that holds a token the user cannot recover from inside the app.
+public class CredentialPreservationResetTests
+{
+    [Fact]
+    public void Resetting_openai_keeps_the_key_and_the_organisation()
+    {
+        var settings = new OpenAISettings
+        {
+            AccessToken = "sk-live-key",
+            OrganizationID = "org-live",
+        };
+
+        new SettingsResetService().ResetAll(new StubSettingsProvider<OpenAISettings>(settings));
+
+        Assert.Equal("sk-live-key", settings.AccessToken);
+        Assert.Equal("org-live", settings.OrganizationID);
+        Assert.NotEmpty(settings.AccessTokenEncrypted);
+    }
+
+    [Fact]
+    public void Resetting_twitch_keeps_both_halves_of_each_pair()
+    {
+        var settings = new TwitchSettings
+        {
+            ClientId = "twitch-client",
+            AccessToken = "twitch-token",
+        };
+        var encryptedClientId = settings.ClientIdEncrypted;
+        var encryptedToken = settings.AccessTokenEncrypted;
+
+        new SettingsResetService().ResetAll(new StubSettingsProvider<TwitchSettings>(settings));
+
+        Assert.Equal("twitch-client", settings.ClientId);
+        Assert.Equal("twitch-token", settings.AccessToken);
+        Assert.Equal(encryptedClientId, settings.ClientIdEncrypted);
+        Assert.Equal(encryptedToken, settings.AccessTokenEncrypted);
+    }
+
+    [Fact]
+    public void Resetting_spotify_keeps_the_refresh_token()
+    {
+        // The refresh token is the one that matters: losing it forces the whole OAuth flow again.
+        var settings = new SpotifySettings
+        {
+            AccessToken = "spotify-access",
+            RefreshToken = "spotify-refresh",
+        };
+
+        new SettingsResetService().ResetAll(new StubSettingsProvider<SpotifySettings>(settings));
+
+        Assert.Equal("spotify-access", settings.AccessToken);
+        Assert.Equal("spotify-refresh", settings.RefreshToken);
+    }
+
+    [Fact]
+    public void Resetting_discord_keeps_the_tokens_and_the_voice_client_id()
+    {
+        var settings = new DiscordSettings
+        {
+            AccessToken = "discord-access",
+            RefreshToken = "discord-refresh",
+            VoiceClientId = "123456789",
+        };
+
+        new SettingsResetService().ResetAll(new StubSettingsProvider<DiscordSettings>(settings));
+
+        Assert.Equal("discord-access", settings.AccessToken);
+        Assert.Equal("discord-refresh", settings.RefreshToken);
+        Assert.Equal("123456789", settings.VoiceClientId);
+    }
+
+    [Fact]
+    public void Resetting_pulsoid_keeps_the_oauth_token()
+    {
+        var settings = new PulsoidModuleSettings { AccessTokenOAuth = "pulsoid-oauth" };
+
+        new SettingsResetService().ResetAll(new StubSettingsProvider<PulsoidModuleSettings>(settings));
+
+        Assert.Equal("pulsoid-oauth", settings.AccessTokenOAuth);
+    }
+
+    [Fact]
+    public void Asking_for_a_full_wipe_clears_the_credentials_too()
+    {
+        var settings = new TwitchSettings
+        {
+            ClientId = "twitch-client",
+            AccessToken = "twitch-token",
+        };
+
+        new SettingsResetService().ResetAll(
+            new StubSettingsProvider<TwitchSettings>(settings),
+            preserveCredentials: false);
+
+        Assert.Empty(settings.ClientId);
+        Assert.Empty(settings.AccessToken);
+        Assert.Empty(settings.ClientIdEncrypted);
+        Assert.Empty(settings.AccessTokenEncrypted);
+    }
+
+    private sealed class StubSettingsProvider<T>(T value) : ISettingsProvider<T> where T : class, new()
+    {
+        public T Value { get; } = value;
+        public event EventHandler? SettingsChanged;
+        public void Save() => SettingsChanged?.Invoke(this, EventArgs.Empty);
+        public void FlushPendingSave() { }
+        public void Reload() { }
+    }
+}

--- a/MagicChatbox.Tests/Services/EmojiServiceConcurrencyTests.cs
+++ b/MagicChatbox.Tests/Services/EmojiServiceConcurrencyTests.cs
@@ -21,7 +21,7 @@ namespace MagicChatbox.Tests.Services;
 public class EmojiServiceConcurrencyTests
 {
     [Fact]
-    public void Reading_an_icon_survives_the_collection_being_rewritten_underneath_it()
+    public async Task Reading_an_icon_survives_the_collection_being_rewritten_underneath_it()
     {
         var settings = new AppSettings { EnableEmojiShuffle = true, EnableEmojiShuffleInChats = true };
         settings.EmojiCollection.Add("a");
@@ -64,7 +64,7 @@ public class EmojiServiceConcurrencyTests
             });
         }
 
-        Task.WaitAll([writer, .. readers]);
+        await Task.WhenAll([writer, .. readers]);
 
         Assert.True(failures.Count == 0, "concurrent access threw: " + string.Join(" | ", failures));
     }

--- a/MagicChatbox.Tests/Services/HardwareMonitorSingleFlightSourceTests.cs
+++ b/MagicChatbox.Tests/Services/HardwareMonitorSingleFlightSourceTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MagicChatbox.Tests.Services;
+
+public sealed class HardwareMonitorSingleFlightSourceTests
+{
+    [Fact]
+    public void Nvidia_sampling_is_serialized_around_the_cache_recheck_and_process_query()
+    {
+        string source = File.ReadAllText(Path.Combine(
+            FindRepoRoot(),
+            "vrcosc-magicchatbox",
+            "Services",
+            "HardwareMonitorService.cs"));
+        Match method = Regex.Match(
+            source,
+            @"private IReadOnlyList<NvidiaSmiSample> GetNvidiaSmiSamples\(\)\s*\{(?<body>.*?)\n    \}",
+            RegexOptions.Singleline);
+
+        Assert.True(method.Success, "GetNvidiaSmiSamples was not found");
+        string body = method.Groups["body"].Value;
+        int gate = body.IndexOf("lock (_nvidiaSmiQueryLock)", StringComparison.Ordinal);
+        int cacheCheck = body.IndexOf("_nvidiaSmiCache != null", StringComparison.Ordinal);
+        int query = body.IndexOf("QueryNvidiaSmiAsync().GetAwaiter().GetResult()", StringComparison.Ordinal);
+
+        Assert.True(gate >= 0);
+        Assert.True(cacheCheck > gate);
+        Assert.True(query > cacheCheck);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null &&
+               !Directory.Exists(Path.Combine(directory.FullName, "vrcosc-magicchatbox", "Core")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName
+            ?? throw new DirectoryNotFoundException("repo root not found from " + AppContext.BaseDirectory);
+    }
+}

--- a/MagicChatbox.Tests/Services/OscSenderExplicitTextTests.cs
+++ b/MagicChatbox.Tests/Services/OscSenderExplicitTextTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel;
 using System.Net;
 using System.Net.Sockets;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using vrcosc_magicchatbox.Classes.Modules;
@@ -15,6 +16,15 @@ namespace MagicChatbox.Tests.Services;
 
 public class OscSenderExplicitTextTests : IDisposable
 {
+    private sealed class ManualTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _utcNow = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        public void Advance(TimeSpan duration) => _utcNow = _utcNow.Add(duration);
+    }
+
     private sealed class StubSettingsProvider<T> : ISettingsProvider<T> where T : class, new()
     {
         public T Value { get; } = new T();
@@ -128,5 +138,39 @@ public class OscSenderExplicitTextTests : IDisposable
 
         Assert.True(await _sender.SendOSCMessage(false, force: true));
         await ReceiveTextAsync();
+    }
+
+    [Fact]
+    public async Task Failed_hostnames_are_retried_after_the_cooldown()
+    {
+        var clock = new ManualTimeProvider();
+        var oscSettings = new StubSettingsProvider<OscSettings>();
+        oscSettings.Value.OscIP = "does-not-exist.invalid";
+        oscSettings.Value.OscPortOut = 9000;
+        var ttsSettings = new StubSettingsProvider<TtsSettings>();
+        using var sender = new OscSenderService(
+            oscSettings,
+            new StubSettingsProvider<AppSettings>(),
+            ttsSettings,
+            new FakeAppState(),
+            new ChatStatusDisplayState(),
+            new OscDisplayState(),
+            new TtsAudioDisplayState(ttsSettings),
+            clock);
+        FieldInfo? retryAfterField = typeof(OscSenderService).GetField(
+            "_lastFailedEndpointRetryAfterUtc",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(retryAfterField);
+        Assert.False(await sender.SendOSCMessage(false, force: true, explicitText: "first"));
+        var firstRetryAfter = (DateTimeOffset)retryAfterField!.GetValue(sender)!;
+
+        Assert.False(await sender.SendOSCMessage(false, force: true, explicitText: "blocked"));
+        Assert.Equal(firstRetryAfter, retryAfterField.GetValue(sender));
+
+        clock.Advance(TimeSpan.FromSeconds(31));
+        Assert.False(await sender.SendOSCMessage(false, force: true, explicitText: "retried"));
+
+        Assert.True((DateTimeOffset)retryAfterField.GetValue(sender)! > firstRetryAfter);
     }
 }

--- a/MagicChatbox.Tests/Services/SeekbarStylePersistenceTests.cs
+++ b/MagicChatbox.Tests/Services/SeekbarStylePersistenceTests.cs
@@ -38,7 +38,8 @@ public class SeekbarStylePersistenceTests : IDisposable
 
         service.AddNewSeekbarStyle();
 
-        MediaLinkStyle added = state.SelectedMediaLinkSeekbarStyle;
+        MediaLinkStyle? added = state.SelectedMediaLinkSeekbarStyle;
+        Assert.NotNull(added);
         Assert.False(added.SystemDefault);
         Assert.True(added.ID >= 100);
 
@@ -53,7 +54,8 @@ public class SeekbarStylePersistenceTests : IDisposable
         using var service = Service(state);
 
         service.AddNewSeekbarStyle();
-        MediaLinkStyle mine = state.SelectedMediaLinkSeekbarStyle;
+        MediaLinkStyle? mine = state.SelectedMediaLinkSeekbarStyle;
+        Assert.NotNull(mine);
 
         mine.FilledCharacter = "#";
         mine.NonFilledCharacter = "-";

--- a/MagicChatbox.Tests/Services/SoundpadPipeClientTests.cs
+++ b/MagicChatbox.Tests/Services/SoundpadPipeClientTests.cs
@@ -119,8 +119,8 @@ public sealed class SoundpadPipeClientTests
         var serverTask = Task.Run(async () =>
         {
             await server.WaitForConnectionAsync();
-            var buffer = new byte[1024];
-            await server.ReadAsync(buffer);
+            var buffer = new byte[Encoding.UTF8.GetByteCount("GetPlayStatus()")];
+            await server.ReadExactlyAsync(buffer);
             await server.DisposeAsync();
         });
 
@@ -141,8 +141,8 @@ public sealed class SoundpadPipeClientTests
         var serverTask = Task.Run(async () =>
         {
             await server.WaitForConnectionAsync();
-            var buffer = new byte[1024];
-            await server.ReadAsync(buffer);
+            var buffer = new byte[Encoding.UTF8.GetByteCount("GetPlayStatus()")];
+            await server.ReadExactlyAsync(buffer);
         });
 
         var reply = await client.SendRequestAsync("GetPlayStatus()", timeoutMs: 500);

--- a/MagicChatbox.Tests/Services/Vr/SteamVrAutoStartServiceTests.cs
+++ b/MagicChatbox.Tests/Services/Vr/SteamVrAutoStartServiceTests.cs
@@ -1,0 +1,462 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using vrcosc_magicchatbox.Classes.Modules;
+using vrcosc_magicchatbox.Core.Configuration;
+using vrcosc_magicchatbox.Core.State;
+using vrcosc_magicchatbox.Services;
+using vrcosc_magicchatbox.Services.Vr;
+using vrcosc_magicchatbox.ViewModels.State;
+using Xunit;
+
+namespace MagicChatbox.Tests.Services.Vr;
+
+public class SteamVrAutoStartServiceTests : IDisposable
+{
+    private const string SteamVrProcessName = "vrmonitor";
+
+    /// <summary>Long enough that a loaded build agent still gets there.</summary>
+    private static readonly TimeSpan Generous = TimeSpan.FromSeconds(5);
+
+    /// <summary>Only ever used to prove that nothing arrives.</summary>
+    private static readonly TimeSpan Brief = TimeSpan.FromMilliseconds(500);
+
+    private readonly string _root;
+
+    public SteamVrAutoStartServiceTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "mcb-steamvr-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    private Harness NewHarness() => new(_root);
+
+    [Fact]
+    public void Starting_with_the_setting_off_takes_the_registration_away()
+    {
+        using var h = NewHarness();
+        h.Settings.StartWithSteamVr = false;
+
+        h.Service.Start();
+        h.WaitForReconcile();
+
+        Assert.Empty(h.Applications.Registers);
+        Assert.Single(h.Applications.Unregisters);
+    }
+
+    [Fact]
+    public void Starting_with_the_setting_on_writes_the_manifest_and_registers_it()
+    {
+        using var h = NewHarness();
+        h.Settings.StartWithSteamVr = true;
+
+        h.Service.Start();
+        h.WaitForReconcile();
+
+        Call call = Assert.Single(h.Applications.Registers);
+        Assert.Equal(h.ManifestPath, call.ManifestPath);
+        Assert.Equal("boihanny.magicchatbox", call.AppKey);
+        Assert.StartsWith(h.LocalAppData, call.ManifestPath, StringComparison.OrdinalIgnoreCase);
+        Assert.True(File.Exists(h.ManifestPath));
+        Assert.Empty(h.Applications.Unregisters);
+    }
+
+    [Fact]
+    public void A_registration_that_worked_is_written_down_for_next_time()
+    {
+        using var h = NewHarness();
+        h.Settings.StartWithSteamVr = true;
+
+        h.Service.Start();
+        h.WaitForReconcile();
+
+        Assert.Equal(h.ManifestPath, h.Settings.SteamVrManifestPath);
+    }
+
+    [Fact]
+    public void Unregistering_clears_the_written_down_path_and_removes_the_manifest()
+    {
+        using var h = NewHarness();
+        h.Settings.StartWithSteamVr = true;
+        h.Service.Start();
+        h.WaitForReconcile();
+        Assert.True(File.Exists(h.ManifestPath));
+
+        h.Settings.StartWithSteamVr = false;
+        h.WaitForReconcile();
+
+        Assert.Equal(string.Empty, h.Settings.SteamVrManifestPath);
+        Assert.False(File.Exists(h.ManifestPath));
+    }
+
+    [Fact]
+    public void Flipping_the_setting_reconciles_again_without_a_restart()
+    {
+        using var h = NewHarness();
+        h.Service.Start();
+        h.WaitForReconcile();
+        Assert.Single(h.Applications.Unregisters);
+
+        h.Settings.StartWithSteamVr = true;
+        h.WaitForReconcile();
+        Assert.Single(h.Applications.Registers);
+
+        h.Settings.StartWithSteamVr = false;
+        h.WaitForReconcile();
+        Assert.Equal(2, h.Applications.Unregisters.Count);
+    }
+
+    [Fact]
+    public void Unregistering_follows_the_path_SteamVR_was_actually_given()
+    {
+        // SteamVR keys removal on the absolute path it was registered with. A copy that has moved
+        // since then computes a different path, so handing back the recorded one is the only thing
+        // that stops the old entry outliving the setting.
+        using var h = NewHarness();
+        string stale = Path.Combine(h.LocalAppData, "moved", SteamVrManifest.FileName);
+        Directory.CreateDirectory(Path.GetDirectoryName(stale)!);
+        File.WriteAllText(stale, "{}");
+
+        h.Settings.StartWithSteamVr = false;
+        h.Settings.SteamVrManifestPath = stale;
+
+        h.Service.Start();
+        h.WaitForReconcile();
+
+        Call call = Assert.Single(h.Applications.Unregisters);
+        Assert.Equal(stale, call.ManifestPath);
+        Assert.NotEqual(h.ManifestPath, call.ManifestPath);
+        Assert.False(File.Exists(stale));
+    }
+
+    [Fact]
+    public void SteamVR_not_being_up_defers_the_change_rather_than_undoing_it()
+    {
+        // Nothing failed, so the recorded path has to stand: clearing it here would lose the only
+        // handle on an entry SteamVR is still holding.
+        using var h = NewHarness();
+        h.Settings.StartWithSteamVr = false;
+        h.Settings.SteamVrManifestPath = h.ManifestPath;
+        h.Applications.NextResult = SteamVrResult.Unavailable("no session");
+
+        h.Service.Start();
+        h.WaitForReconcile();
+
+        Assert.Single(h.Applications.Unregisters);
+        Assert.Equal(h.ManifestPath, h.Settings.SteamVrManifestPath);
+    }
+
+    [Fact]
+    public void A_deferred_registration_is_retried_when_SteamVR_turns_up()
+    {
+        using var h = NewHarness();
+        h.Settings.StartWithSteamVr = true;
+        h.Applications.NextResult = SteamVrResult.Unavailable("no session");
+
+        h.Service.Start();
+        h.WaitForReconcile();
+        Assert.Single(h.Applications.Registers);
+        Assert.Equal(string.Empty, h.Settings.SteamVrManifestPath);
+
+        h.Applications.NextResult = SteamVrResult.Done();
+        h.Processes.SetRunning(SteamVrProcessName, true);
+        h.AppState.IsVRRunning = true;
+        h.WaitForReconcile();
+
+        Assert.Equal(2, h.Applications.Registers.Count);
+        Assert.Equal(h.ManifestPath, h.Settings.SteamVrManifestPath);
+    }
+
+    [Fact]
+    public void Closing_SteamVR_closes_the_app_once()
+    {
+        using var h = NewHarness();
+        h.Settings.StartWithSteamVr = true;
+        h.Settings.QuitWithSteamVr = true;
+        h.Processes.SetRunning(SteamVrProcessName, true);
+
+        h.Service.Start();
+        h.WaitForReconcile();
+
+        h.AppState.IsVRRunning = true;
+        h.Processes.SetRunning(SteamVrProcessName, false);
+        h.AppState.IsVRRunning = false;
+
+        Assert.Equal(1, h.ShutdownRequests);
+
+        // A later session that never gets as far as SteamVR must not ask again.
+        h.AppState.IsVRRunning = true;
+        h.AppState.IsVRRunning = false;
+
+        Assert.Equal(1, h.ShutdownRequests);
+    }
+
+    [Fact]
+    public void The_app_stays_open_when_quitting_with_SteamVR_is_off()
+    {
+        using var h = NewHarness();
+        h.Settings.StartWithSteamVr = true;
+        h.Settings.QuitWithSteamVr = false;
+        h.Processes.SetRunning(SteamVrProcessName, true);
+
+        h.Service.Start();
+        h.WaitForReconcile();
+
+        h.AppState.IsVRRunning = true;
+        h.Processes.SetRunning(SteamVrProcessName, false);
+        h.AppState.IsVRRunning = false;
+
+        Assert.Equal(0, h.ShutdownRequests);
+    }
+
+    [Fact]
+    public void The_app_stays_open_when_only_the_headset_stopped()
+    {
+        // IsVRRunning also covers the Oculus runtime. SteamVR itself is still up, so closing here
+        // would take the app down while the user is still in VR.
+        using var h = NewHarness();
+        h.Settings.StartWithSteamVr = true;
+        h.Settings.QuitWithSteamVr = true;
+        h.Processes.SetRunning(SteamVrProcessName, true);
+
+        h.Service.Start();
+        h.WaitForReconcile();
+
+        h.AppState.IsVRRunning = true;
+        h.AppState.IsVRRunning = false;
+
+        Assert.Equal(0, h.ShutdownRequests);
+    }
+
+    [Fact]
+    public void Stopping_the_service_stops_it_listening()
+    {
+        using var h = NewHarness();
+        h.Service.Start();
+        h.WaitForReconcile();
+
+        h.Service.Stop();
+        h.Settings.StartWithSteamVr = true;
+
+        Assert.False(h.Applications.WaitForCall(Brief));
+        Assert.Empty(h.Applications.Registers);
+    }
+
+    [Fact]
+    public void Disposing_the_service_stops_it_listening()
+    {
+        using var h = NewHarness();
+        h.Settings.StartWithSteamVr = true;
+        h.Settings.QuitWithSteamVr = true;
+        h.Processes.SetRunning(SteamVrProcessName, true);
+        h.Service.Start();
+        h.WaitForReconcile();
+
+        h.AppState.IsVRRunning = true;
+        h.Service.Dispose();
+
+        h.Settings.StartWithSteamVr = false;
+        h.Processes.SetRunning(SteamVrProcessName, false);
+        h.AppState.IsVRRunning = false;
+
+        Assert.False(h.Applications.WaitForCall(Brief));
+        Assert.Single(h.Applications.Registers);
+        Assert.Equal(0, h.ShutdownRequests);
+    }
+
+    #region Harness
+
+    private sealed record Call(string ManifestPath, string AppKey);
+
+    private sealed class Harness : IDisposable
+    {
+        /// <summary>
+        /// The re-entrancy guard the service uses to drop overlapping reconciles. It is cleared
+        /// after the fake has already been called, so a flip made before it clears is swallowed.
+        /// </summary>
+        private static readonly FieldInfo ReconcileFlag =
+            typeof(SteamVrAutoStartService).GetField("_reconcileInProgress", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        private int _shutdownRequests;
+
+        public Harness(string root)
+        {
+            LocalAppData = Path.Combine(root, Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(LocalAppData);
+
+            ExecutablePath = Path.Combine(LocalAppData, "MagicChatbox.exe");
+            File.WriteAllText(ExecutablePath, "exe");
+
+            ManifestPath = SteamVrManifest.PathFor(LocalAppData);
+
+            Service = new SteamVrAutoStartService(
+                Applications,
+                new FakeSettingsProvider(Settings),
+                AppState,
+                Processes,
+                () => Interlocked.Increment(ref _shutdownRequests),
+                LocalAppData,
+                () => ExecutablePath);
+        }
+
+        public string LocalAppData { get; }
+
+        public string ExecutablePath { get; }
+
+        public string ManifestPath { get; }
+
+        public FakeSteamVrApplications Applications { get; } = new();
+
+        public AppSettings Settings { get; } = new();
+
+        public FakeAppState AppState { get; } = new();
+
+        public FakeProcessPresence Processes { get; } = new();
+
+        public SteamVrAutoStartService Service { get; }
+
+        public int ShutdownRequests => Volatile.Read(ref _shutdownRequests);
+
+        /// <summary>
+        /// Waits for the reconcile that is running on a background task to reach SteamVR, and then
+        /// for it to finish tidying up afterwards.
+        /// </summary>
+        public void WaitForReconcile()
+        {
+            Assert.True(Applications.WaitForCall(Generous), "SteamVR was never asked to reconcile.");
+
+            // The fake is signalled from inside the reconcile, which still has to record the
+            // manifest path, delete files and release its guard. Everything after the call is
+            // in-memory work, so this settles immediately in practice.
+            Assert.True(
+                SpinWait.SpinUntil(() => (int)ReconcileFlag.GetValue(Service)! == 0, Generous),
+                "The reconcile never finished.");
+        }
+
+        public void Dispose() => Service.Dispose();
+    }
+
+    private sealed class FakeSteamVrApplications : ISteamVrApplications
+    {
+        private readonly SemaphoreSlim _calls = new(0);
+        private readonly object _gate = new();
+        private readonly List<Call> _registers = new();
+        private readonly List<Call> _unregisters = new();
+
+        public SteamVrResult NextResult { get; set; } = SteamVrResult.Done();
+
+        public IReadOnlyList<Call> Registers
+        {
+            get { lock (_gate) return _registers.ToList(); }
+        }
+
+        public IReadOnlyList<Call> Unregisters
+        {
+            get { lock (_gate) return _unregisters.ToList(); }
+        }
+
+        public SteamVrResult Register(string manifestPath, string appKey)
+        {
+            lock (_gate)
+            {
+                _registers.Add(new Call(manifestPath, appKey));
+            }
+
+            _calls.Release();
+            return NextResult;
+        }
+
+        public SteamVrResult Unregister(string manifestPath, string appKey)
+        {
+            lock (_gate)
+            {
+                _unregisters.Add(new Call(manifestPath, appKey));
+            }
+
+            _calls.Release();
+            return NextResult;
+        }
+
+        public bool IsAutoLaunchEnabled(string appKey) => true;
+
+        public bool WaitForCall(TimeSpan timeout) => _calls.Wait(timeout);
+    }
+
+    private sealed class FakeProcessPresence : IProcessPresenceService
+    {
+        private readonly Dictionary<string, bool> _running = new(StringComparer.OrdinalIgnoreCase);
+
+        public bool IsRunning(string processName)
+            => _running.TryGetValue(processName, out bool running) && running;
+
+        public void SetRunning(string processName, bool running) => _running[processName] = running;
+
+        public void Invalidate(string processName) { }
+
+        public void InvalidateAll() { }
+    }
+
+    private sealed class FakeSettingsProvider : ISettingsProvider<AppSettings>
+    {
+        public FakeSettingsProvider(AppSettings value) => Value = value;
+
+        public AppSettings Value { get; }
+
+        public void Save() { }
+
+        public void FlushPendingSave() { }
+
+        public void Reload() { }
+
+        public event EventHandler SettingsChanged { add { } remove { } }
+    }
+
+    private sealed class FakeAppState : IAppState
+    {
+        private bool _isVRRunning;
+
+        public bool MasterSwitch { get; set; } = true;
+
+        public bool BussyBoysMode { get; set; }
+
+        public bool Egg_Dev { get; set; }
+
+        public bool PulsoidAuthConnected { get; set; }
+
+        public PulsoidAuthState PulsoidAuthState { get; set; }
+
+        public int MainWindowBlurEffect { get; set; }
+
+        public bool IsVRRunning
+        {
+            get => _isVRRunning;
+            set
+            {
+                if (_isVRRunning == value)
+                    return;
+
+                _isVRRunning = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsVRRunning)));
+            }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+    }
+
+    #endregion
+}

--- a/MagicChatbox.Tests/Services/Vr/SteamVrManifestTests.cs
+++ b/MagicChatbox.Tests/Services/Vr/SteamVrManifestTests.cs
@@ -1,0 +1,209 @@
+using Newtonsoft.Json.Linq;
+using System;
+using System.IO;
+using System.Linq;
+using vrcosc_magicchatbox.Services.Vr;
+using Xunit;
+
+namespace MagicChatbox.Tests.Services.Vr;
+
+public class SteamVrManifestTests : IDisposable
+{
+    private const string Executable = @"C:\Portable\MagicChatbox\MagicChatbox.exe";
+    private const string LaunchArgument = "--startedbysteamvr";
+
+    private readonly string _root;
+
+    public SteamVrManifestTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "mcb-steamvr-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    private static JObject Application(string manifest)
+    {
+        var root = JObject.Parse(manifest);
+        var applications = root["applications"] as JArray;
+
+        Assert.NotNull(applications);
+        return Assert.IsType<JObject>(Assert.Single(applications!));
+    }
+
+    [Fact]
+    public void Build_produces_json_that_parses()
+    {
+        var root = JObject.Parse(SteamVrManifest.Build(Executable, LaunchArgument));
+
+        Assert.Equal("builtin", (string?)root["source"]);
+        Assert.Single((JArray)root["applications"]!);
+    }
+
+    [Fact]
+    public void The_entry_describes_the_executable_steamvr_should_launch()
+    {
+        JObject application = Application(SteamVrManifest.Build(Executable, LaunchArgument));
+
+        Assert.Equal("boihanny.magicchatbox", (string?)application["app_key"]);
+        Assert.Equal(SteamVrManifest.AppKey, (string?)application["app_key"]);
+        Assert.Equal("binary", (string?)application["launch_type"]);
+        Assert.Equal(Executable, (string?)application["binary_path_windows"]);
+        Assert.Equal(LaunchArgument, (string?)application["arguments"]);
+    }
+
+    [Fact]
+    public void The_entry_carries_a_display_name()
+    {
+        JObject application = Application(SteamVrManifest.Build(Executable, LaunchArgument));
+
+        Assert.Equal("MagicChatbox", (string?)application["strings"]?["en_us"]?["name"]);
+        Assert.False(string.IsNullOrWhiteSpace((string?)application["strings"]?["en_us"]?["description"]));
+    }
+
+    [Fact]
+    public void The_entry_is_a_dashboard_overlay()
+    {
+        // SteamVR only offers auto-launch to overlay applications. Without the flag the manifest
+        // still registers and the startup entry silently never runs, so this is load-bearing.
+        JObject application = Application(SteamVrManifest.Build(Executable, LaunchArgument));
+
+        Assert.Equal(JTokenType.Boolean, application["is_dashboard_overlay"]!.Type);
+        Assert.True((bool?)application["is_dashboard_overlay"]);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("", null)]
+    [InlineData(null, "")]
+    [InlineData("", "")]
+    public void A_missing_path_or_argument_becomes_an_empty_string_not_a_json_null(string? executable, string? argument)
+    {
+        JObject application = Application(SteamVrManifest.Build(executable!, argument!));
+
+        Assert.Equal(JTokenType.String, application["binary_path_windows"]!.Type);
+        Assert.Equal(JTokenType.String, application["arguments"]!.Type);
+        Assert.Equal(string.Empty, (string?)application["binary_path_windows"]);
+        Assert.Equal(string.Empty, (string?)application["arguments"]);
+    }
+
+    [Fact]
+    public void The_manifest_lives_in_its_own_folder_under_local_app_data()
+    {
+        string localAppData = Path.Combine(_root, "LocalAppData");
+
+        Assert.Equal(
+            Path.Combine(localAppData, "Vrcosc-MagicChatbox", "steamvr"),
+            SteamVrManifest.DirectoryFor(localAppData));
+
+        Assert.Equal(
+            Path.Combine(localAppData, "Vrcosc-MagicChatbox", "steamvr", "magicchatbox.vrmanifest"),
+            SteamVrManifest.PathFor(localAppData));
+
+        Assert.Equal(SteamVrManifest.DirectoryFor(localAppData), Path.GetDirectoryName(SteamVrManifest.PathFor(localAppData)));
+        Assert.EndsWith("magicchatbox.vrmanifest", SteamVrManifest.PathFor(localAppData), StringComparison.Ordinal);
+        Assert.Equal("magicchatbox.vrmanifest", SteamVrManifest.FileName);
+    }
+
+    [Fact]
+    public void TryWrite_creates_the_folder_and_writes_the_manifest()
+    {
+        string localAppData = Path.Combine(_root, "LocalAppData");
+        string path = SteamVrManifest.PathFor(localAppData);
+
+        Assert.False(Directory.Exists(SteamVrManifest.DirectoryFor(localAppData)));
+
+        Assert.True(SteamVrManifest.TryWrite(path, Executable, LaunchArgument));
+
+        Assert.True(File.Exists(path));
+        Assert.Equal(SteamVrManifest.Build(Executable, LaunchArgument), File.ReadAllText(path));
+    }
+
+    [Fact]
+    public void Writing_the_same_manifest_again_leaves_the_file_alone()
+    {
+        string path = SteamVrManifest.PathFor(Path.Combine(_root, "LocalAppData"));
+        Assert.True(SteamVrManifest.TryWrite(path, Executable, LaunchArgument));
+
+        byte[] before = File.ReadAllBytes(path);
+        var stamp = new DateTime(2020, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+        File.SetLastWriteTimeUtc(path, stamp);
+
+        Assert.True(SteamVrManifest.TryWrite(path, Executable, LaunchArgument));
+
+        Assert.Equal(before, File.ReadAllBytes(path));
+        Assert.Equal(stamp, File.GetLastWriteTimeUtc(path));
+    }
+
+    [Fact]
+    public void Writing_a_different_manifest_replaces_the_old_one()
+    {
+        // A portable copy that moved, or an update that replaced the installation, has to leave
+        // SteamVR pointing at the executable that exists now.
+        string path = SteamVrManifest.PathFor(Path.Combine(_root, "LocalAppData"));
+        Assert.True(SteamVrManifest.TryWrite(path, Executable, LaunchArgument));
+
+        const string moved = @"D:\Elsewhere\MagicChatbox\MagicChatbox.exe";
+        Assert.True(SteamVrManifest.TryWrite(path, moved, "--other"));
+
+        string contents = File.ReadAllText(path);
+        Assert.Equal(SteamVrManifest.Build(moved, "--other"), contents);
+
+        JObject application = Application(contents);
+        Assert.Equal(moved, (string?)application["binary_path_windows"]);
+        Assert.Equal("--other", (string?)application["arguments"]);
+        Assert.DoesNotContain(Executable, contents, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Writing_never_leaves_a_temp_file_behind()
+    {
+        string localAppData = Path.Combine(_root, "LocalAppData");
+        string path = SteamVrManifest.PathFor(localAppData);
+
+        Assert.True(SteamVrManifest.TryWrite(path, Executable, LaunchArgument));
+        Assert.True(SteamVrManifest.TryWrite(path, Executable, LaunchArgument));
+        Assert.True(SteamVrManifest.TryWrite(path, @"D:\Moved\MagicChatbox.exe", LaunchArgument));
+
+        Assert.False(File.Exists(path + ".tmp"));
+        Assert.Empty(Directory.GetFiles(SteamVrManifest.DirectoryFor(localAppData), "*.tmp"));
+        Assert.Equal(new[] { SteamVrManifest.FileName }, Directory
+            .GetFiles(SteamVrManifest.DirectoryFor(localAppData))
+            .Select(Path.GetFileName));
+    }
+
+    [Fact]
+    public void Delete_removes_the_manifest()
+    {
+        string path = SteamVrManifest.PathFor(Path.Combine(_root, "LocalAppData"));
+        Assert.True(SteamVrManifest.TryWrite(path, Executable, LaunchArgument));
+
+        SteamVrManifest.Delete(path);
+
+        Assert.False(File.Exists(path));
+    }
+
+    [Fact]
+    public void Delete_is_quiet_when_there_is_nothing_to_remove()
+    {
+        string path = SteamVrManifest.PathFor(Path.Combine(_root, "NeverWritten"));
+
+        SteamVrManifest.Delete(path);
+        SteamVrManifest.Delete(path);
+        SteamVrManifest.Delete(Path.Combine(_root, "no-such-folder", "no-such-file.vrmanifest"));
+        SteamVrManifest.Delete(null!);
+        SteamVrManifest.Delete(string.Empty);
+        SteamVrManifest.Delete("   ");
+
+        Assert.False(Directory.Exists(Path.Combine(_root, "NeverWritten")));
+    }
+}

--- a/MagicChatbox.Tests/UI/AutoUpdateModeConverterTests.cs
+++ b/MagicChatbox.Tests/UI/AutoUpdateModeConverterTests.cs
@@ -1,0 +1,42 @@
+using System.Globalization;
+using vrcosc_magicchatbox.Classes;
+using vrcosc_magicchatbox.Core.Updates;
+using Xunit;
+
+namespace MagicChatbox.Tests.UI;
+
+/// <summary>
+/// The update card's tick is a two-state view of a three-state channel. What matters is where unticking
+/// lands: on Notify, so someone turning off automatic installing still hears about new versions. The
+/// obvious reuse - EnumEqualsConverter - returns Binding.DoNothing when unticked, which is right for a
+/// radio group and would leave this checkbox stuck on.
+/// </summary>
+public class AutoUpdateModeConverterTests
+{
+    private static readonly AutoUpdateModeConverter Converter = new();
+
+    [Theory]
+    [InlineData(UpdateChannelMode.Auto, true)]
+    [InlineData(UpdateChannelMode.Notify, false)]
+    [InlineData(UpdateChannelMode.Off, false)]
+    public void Only_Auto_shows_as_ticked(UpdateChannelMode mode, bool expected)
+        => Assert.Equal(expected, Converter.Convert(mode, typeof(bool), null!, CultureInfo.InvariantCulture));
+
+    [Fact]
+    public void Ticking_it_asks_for_automatic_installs()
+        => Assert.Equal(
+            UpdateChannelMode.Auto,
+            Converter.ConvertBack(true, typeof(UpdateChannelMode), null!, CultureInfo.InvariantCulture));
+
+    [Fact]
+    public void Unticking_it_falls_back_to_being_told_not_to_silence()
+        => Assert.Equal(
+            UpdateChannelMode.Notify,
+            Converter.ConvertBack(false, typeof(UpdateChannelMode), null!, CultureInfo.InvariantCulture));
+
+    [Fact]
+    public void A_null_tick_is_treated_as_off_rather_than_throwing()
+        => Assert.Equal(
+            UpdateChannelMode.Notify,
+            Converter.ConvertBack(null!, typeof(UpdateChannelMode), null!, CultureInfo.InvariantCulture));
+}

--- a/MagicChatbox.Tests/UI/BackgroundStartupTests.cs
+++ b/MagicChatbox.Tests/UI/BackgroundStartupTests.cs
@@ -45,7 +45,9 @@ public class BackgroundStartupTests
         string startup = AppStartupSource();
 
         int trayInit = startup.IndexOf("ITrayIconService>().Initialize(mainWindow)", StringComparison.Ordinal);
-        int hiddenBranch = startup.IndexOf("if (vm.AppSettingsInstance.StartInBackground)", StringComparison.Ordinal);
+        int hiddenBranch = Regex.Match(startup, HiddenBranchPattern) is { Success: true } branch
+            ? branch.Index
+            : -1;
 
         Assert.True(trayInit >= 0, "the tray icon is no longer initialized during startup");
         Assert.True(hiddenBranch >= 0, "the start-hidden branch was not found");
@@ -54,6 +56,12 @@ public class BackgroundStartupTests
             "the tray icon is created after the window is hidden, leaving no way back into the app if a later step fails");
     }
 
+    /// <summary>
+    /// Matches the start-hidden branch while tolerating extra reasons to take it, so that adding
+    /// another way in does not read as the branch having disappeared.
+    /// </summary>
+    private const string HiddenBranchPattern = @"if \(vm\.AppSettingsInstance\.StartInBackground[^)]*\)";
+
     /// <summary>Source of the <c>StartInBackground</c> branch, up to its <c>else</c>.</summary>
     private static string BackgroundBranch()
     {
@@ -61,7 +69,7 @@ public class BackgroundStartupTests
 
         var match = Regex.Match(
             startup,
-            @"if \(vm\.AppSettingsInstance\.StartInBackground\)\s*\{(?<body>.*?)\}\s*else",
+            HiddenBranchPattern + @"\s*\{(?<body>.*?)\}\s*else",
             RegexOptions.Singleline);
 
         Assert.True(match.Success, "the start-hidden branch was not found in App.xaml.cs");

--- a/MagicChatbox.Tests/UI/OptionsPageSectionRealizationTests.cs
+++ b/MagicChatbox.Tests/UI/OptionsPageSectionRealizationTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
+using vrcosc_magicchatbox.UI.Controls;
 using vrcosc_magicchatbox.UI.Pages;
 using vrcosc_magicchatbox.UI.Pages.Options;
 using Xunit;
@@ -10,9 +11,9 @@ using Xunit;
 namespace MagicChatbox.Tests.UI;
 
 /// <summary>
-/// The options page shows every section's title immediately, with a "Loading…" placeholder standing
-/// in for the eighteen sections it builds in background chunks, so opening it does not hitch. This
-/// checks the placeholders get replaced and the deep link map is fully populated once they do.
+/// The options page shows every section's title immediately and leaves a "Loading…" placeholder in
+/// each section it has not built yet, realizing them as they approach the viewport. This checks that
+/// forcing full realization does replace every placeholder and fully populates the deep link map.
 /// </summary>
 /// <remarks>
 /// The only thing that reads the realized section references is the deep link from the tray menu -
@@ -77,12 +78,12 @@ public class OptionsPageSectionRealizationTests
                 Assert.NotNull(realize);
                 realize!.Invoke(page, null);
 
-                var pending = typeof(OptionsPage).GetField(
-                    "_pendingChunkKeys", BindingFlags.Instance | BindingFlags.NonPublic);
-                Assert.NotNull(pending);
-                var queue = (Queue<string>?)pending!.GetValue(page);
-                Assert.NotNull(queue);
-                Assert.Empty(queue!);
+                var realizerField = typeof(OptionsPage).GetField(
+                    "_realizer", BindingFlags.Instance | BindingFlags.NonPublic);
+                Assert.NotNull(realizerField);
+                var realizer = (SectionRealizer?)realizerField!.GetValue(page);
+                Assert.NotNull(realizer);
+                Assert.Equal(realizer!.TotalCount, realizer.RealizedCount);
 
                 spotifyContentAfter = spotifyWrapper.Content.GetType();
                 eggDevContentAfter = eggDevWrapper.Content.GetType();

--- a/MagicChatbox.Tests/UI/ReducedVisualsTests.cs
+++ b/MagicChatbox.Tests/UI/ReducedVisualsTests.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Media.Effects;
+using vrcosc_magicchatbox.UI.Controls;
+using Xunit;
+
+namespace MagicChatbox.Tests.UI;
+
+/// <summary>
+/// Reduced visuals works by coercion, not by sweeping the tree. A sweep would be silently wrong: most
+/// of these values come from style and template triggers, so hovering a button or selecting a tab puts
+/// the shadow straight back and only a screenshot at the wrong moment would show it. These check the
+/// values that a trigger writes afterwards, not just the ones present at the start.
+/// </summary>
+public class ReducedVisualsTests
+{
+    [Fact]
+    public void Turning_it_on_clears_effects_and_flattens_dimming()
+    {
+        bool effectCleared = false;
+        double dimmedOpacity = 0;
+
+        Exception? failure = Run((root, parts) =>
+        {
+            ReducedVisuals.IsEnabled = true;
+            ReducedVisuals.Refresh(root);
+
+            effectCleared = parts.Shadowed.Effect == null;
+            dimmedOpacity = parts.Dimmed.Opacity;
+        });
+
+        Assert.True(failure == null, "the host did not build: " + failure);
+        Assert.True(effectCleared, "the effect was left in place");
+        Assert.Equal(1.0, dimmedOpacity);
+    }
+
+    [Fact]
+    public void An_effect_applied_after_the_mode_is_on_is_still_refused()
+    {
+        bool stayedClear = false;
+
+        Exception? failure = Run((root, parts) =>
+        {
+            ReducedVisuals.IsEnabled = true;
+            ReducedVisuals.Refresh(root);
+
+            // What a trigger does on hover or selection.
+            parts.Dimmed.Effect = new DropShadowEffect { BlurRadius = 12 };
+
+            stayedClear = parts.Dimmed.Effect == null;
+        });
+
+        Assert.True(failure == null, "the host did not build: " + failure);
+        Assert.True(stayedClear, "an effect set while the mode was on came through");
+    }
+
+    [Fact]
+    public void Turning_it_off_puts_the_originals_back()
+    {
+        bool effectRestored = false;
+        double dimmedOpacity = 0;
+
+        Exception? failure = Run((root, parts) =>
+        {
+            ReducedVisuals.IsEnabled = true;
+            ReducedVisuals.Refresh(root);
+
+            ReducedVisuals.IsEnabled = false;
+            ReducedVisuals.Refresh(root);
+
+            effectRestored = parts.Shadowed.Effect != null;
+            dimmedOpacity = parts.Dimmed.Opacity;
+        });
+
+        Assert.True(failure == null, "the host did not build: " + failure);
+        Assert.True(effectRestored, "the effect never came back");
+        Assert.Equal(0.5, dimmedOpacity, 3);
+    }
+
+    [Fact]
+    public void A_blurred_glow_is_hidden_rather_than_left_hard_edged()
+    {
+        double glowOpacity = -1;
+
+        Exception? failure = Run((root, parts) =>
+        {
+            // A glow starts invisible and is animated up by a trigger; that is when it would show.
+            parts.Glow.Opacity = 0.8;
+
+            ReducedVisuals.IsEnabled = true;
+            ReducedVisuals.Refresh(root);
+
+            glowOpacity = parts.Glow.Opacity;
+        });
+
+        Assert.True(failure == null, "the host did not build: " + failure);
+        Assert.Equal(0.0, glowOpacity);
+    }
+
+    [Fact]
+    public void A_deliberately_invisible_element_is_left_alone()
+    {
+        double invisibleOpacity = -1;
+
+        Exception? failure = Run((root, parts) =>
+        {
+            ReducedVisuals.IsEnabled = true;
+            ReducedVisuals.Refresh(root);
+
+            invisibleOpacity = parts.Invisible.Opacity;
+        });
+
+        Assert.True(failure == null, "the host did not build: " + failure);
+        Assert.Equal(0.0, invisibleOpacity);
+    }
+
+    /// <summary>
+    /// Everything runs on the host's own thread - the elements have dispatcher affinity - and the mode
+    /// is a process-wide switch that must not be left on for whatever test runs next.
+    /// </summary>
+    private static Exception? Run(Action<FrameworkElement, Parts> body)
+        => WpfHost.RunInWindow(Build, element =>
+        {
+            var panel = (StackPanel)((ContentControl)element).Content;
+            var parts = new Parts(
+                (Border)panel.Children[0],
+                (Border)panel.Children[1],
+                (Border)panel.Children[2],
+                (Border)panel.Children[3]);
+
+            ReducedVisuals.Install();
+
+            try
+            {
+                body(element, parts);
+            }
+            finally
+            {
+                ReducedVisuals.IsEnabled = false;
+                ReducedVisuals.Refresh(element);
+            }
+        });
+
+    private static FrameworkElement Build()
+    {
+        var panel = new StackPanel();
+
+        panel.Children.Add(new Border
+        {
+            Height = 20,
+            Effect = new DropShadowEffect { BlurRadius = 10, Color = Colors.Black },
+        });
+
+        panel.Children.Add(new Border { Height = 20, Opacity = 0.5 });
+        panel.Children.Add(new Border { Height = 20, Opacity = 0.0 });
+
+        panel.Children.Add(new Border
+        {
+            Height = 20,
+            Opacity = 0.0,
+            Effect = new BlurEffect { KernelType = KernelType.Gaussian, Radius = 26 },
+        });
+
+        return new ContentControl { Content = panel, Width = 300, Height = 200 };
+    }
+
+    private readonly record struct Parts(Border Shadowed, Border Dimmed, Border Invisible, Border Glow);
+}

--- a/MagicChatbox.Tests/UI/SectionRealizerTests.cs
+++ b/MagicChatbox.Tests/UI/SectionRealizerTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+using vrcosc_magicchatbox.UI.Controls;
+using Xunit;
+
+namespace MagicChatbox.Tests.UI;
+
+/// <summary>
+/// The options page owes its cheap navigation to only building the sections near the viewport. If the
+/// realizer ever built everything up front the page would still look and behave correctly, and only a
+/// stopwatch would notice - so the deferral itself is what these pin down.
+/// </summary>
+public class SectionRealizerTests
+{
+    private const int SectionCount = 20;
+
+    private const double SectionHeight = 400;
+
+    [Fact]
+    public void A_section_far_below_the_viewport_is_not_built()
+    {
+        int built = 0;
+        int total = 0;
+
+        Exception? failure = WpfHost.RunInWindow(BuildHost, element =>
+        {
+            var scroll = (ScrollViewer)element;
+            SectionRealizer realizer = Attach(scroll, new Dictionary<string, double>());
+
+            realizer.Start();
+            Pump();
+
+            built = realizer.RealizedCount;
+            total = realizer.TotalCount;
+        });
+
+        Assert.True(failure == null, "the realizer host did not build: " + failure);
+        Assert.Equal(SectionCount, total);
+        Assert.True(built > 0, "nothing was realized, so the page would show placeholders forever");
+        Assert.True(built < total, $"all {total} sections were built up front; the deferral is not working");
+    }
+
+    [Fact]
+    public void RealizeAll_builds_every_section()
+    {
+        int built = 0;
+        int total = 0;
+
+        Exception? failure = WpfHost.RunInWindow(BuildHost, element =>
+        {
+            SectionRealizer realizer = Attach((ScrollViewer)element, new Dictionary<string, double>());
+
+            realizer.RealizeAll();
+
+            built = realizer.RealizedCount;
+            total = realizer.TotalCount;
+        });
+
+        Assert.True(failure == null, "the realizer host did not build: " + failure);
+        Assert.Equal(total, built);
+    }
+
+    [Fact]
+    public void An_unbuilt_section_reserves_its_remembered_height()
+    {
+        double reserved = 0;
+        double unknown = 0;
+
+        var heights = new Dictionary<string, double> { ["section0"] = 1234 };
+
+        Exception? failure = WpfHost.RunInWindow(BuildHost, element =>
+        {
+            var scroll = (ScrollViewer)element;
+            var panel = (StackPanel)scroll.Content;
+
+            Attach(scroll, heights);
+
+            reserved = ((ContentControl)panel.Children[0]).MinHeight;
+            unknown = ((ContentControl)panel.Children[1]).MinHeight;
+        });
+
+        Assert.True(failure == null, "the realizer host did not build: " + failure);
+        Assert.Equal(1234, reserved);
+        Assert.Equal(SectionRealizer.DefaultSectionHeight, unknown);
+    }
+
+    [Fact]
+    public void A_realized_section_records_its_height_for_next_time()
+    {
+        var heights = new Dictionary<string, double>();
+
+        Exception? failure = WpfHost.RunInWindow(BuildHost, element =>
+        {
+            var scroll = (ScrollViewer)element;
+            Attach(scroll, heights).RealizeAll();
+
+            scroll.UpdateLayout();
+            Pump();
+        });
+
+        Assert.True(failure == null, "the realizer host did not build: " + failure);
+        Assert.True(heights.Count > 0, "no section height was recorded, so placeholders can never reserve properly");
+        Assert.All(heights.Values, h => Assert.True(h > 0, "recorded a non-positive height"));
+    }
+
+    private static SectionRealizer Attach(ScrollViewer scroll, Dictionary<string, double> heights)
+    {
+        var realizer = new SectionRealizer(scroll, heights)
+        {
+            LookaheadViewports = 0.5,
+            MaxPerPass = 64,
+        };
+
+        var panel = (StackPanel)scroll.Content;
+        for (int i = 0; i < panel.Children.Count; i++)
+        {
+            string key = $"section{i}";
+            realizer.Add(key, (ContentControl)panel.Children[i], () => new Border { Height = SectionHeight }, ".");
+        }
+
+        return realizer;
+    }
+
+    private static FrameworkElement BuildHost()
+    {
+        var panel = new StackPanel();
+
+        for (int i = 0; i < SectionCount; i++)
+            panel.Children.Add(new ContentControl { Content = new TextBlock { Text = "Loading…" } });
+
+        return new ScrollViewer { Content = panel };
+    }
+
+    /// <summary>Drains the dispatcher queue: the realizer schedules its passes at Background priority.</summary>
+    private static void Pump()
+        => Dispatcher.CurrentDispatcher.Invoke(() => { }, DispatcherPriority.SystemIdle);
+}

--- a/MagicChatbox.Tests/UI/VoicemodPanelDeferralTests.cs
+++ b/MagicChatbox.Tests/UI/VoicemodPanelDeferralTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using vrcosc_magicchatbox.UI.Controls.Voicemod;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MagicChatbox.Tests.UI;
+
+/// <summary>
+/// The Voicemod panel on the Integrations page is behind a template so a switched-off integration does
+/// not pay for it. Collapsing a control does not stop WPF building it, so this checks the panel is
+/// genuinely absent rather than merely invisible.
+/// </summary>
+public class VoicemodPanelDeferralTests
+{
+    private readonly ITestOutputHelper _out;
+
+    public VoicemodPanelDeferralTests(ITestOutputHelper output) => _out = output;
+
+    [Fact]
+    public void A_collapsed_host_does_not_build_its_templated_content()
+    {
+        bool builtWhenCollapsed = false;
+        bool builtWhenVisible = false;
+
+        Exception? failure = WpfHost.RunInWindow(
+            () => new ContentControl
+            {
+                Width = 600,
+                Height = 400,
+                Content = new Border
+                {
+                    Visibility = Visibility.Collapsed,
+                    Child = new ContentControl
+                    {
+                        Content = new object(),
+                        ContentTemplate = PanelTemplate(),
+                    },
+                },
+            },
+            element =>
+            {
+                element.UpdateLayout();
+                builtWhenCollapsed = Contains<VoicemodControlPanel>(element);
+
+                var border = (Border)((ContentControl)element).Content;
+                border.Visibility = Visibility.Visible;
+                element.UpdateLayout();
+                builtWhenVisible = Contains<VoicemodControlPanel>(element);
+            });
+
+        Assert.True(failure == null, "the host did not build: " + failure);
+        _out.WriteLine($"panel present while collapsed: {builtWhenCollapsed}, while visible: {builtWhenVisible}");
+
+        Assert.True(builtWhenVisible, "the panel never appeared, so this measures nothing");
+        Assert.False(builtWhenCollapsed, "the panel is built even while its host is collapsed");
+    }
+
+    private static DataTemplate PanelTemplate()
+    {
+        var template = new DataTemplate { VisualTree = new FrameworkElementFactory(typeof(VoicemodControlPanel)) };
+        template.Seal();
+        return template;
+    }
+
+    private static bool Contains<T>(DependencyObject root) where T : DependencyObject
+    {
+        if (root is T)
+            return true;
+
+        int children = VisualTreeHelper.GetChildrenCount(root);
+        for (int i = 0; i < children; i++)
+        {
+            if (Contains<T>(VisualTreeHelper.GetChild(root, i)))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/MagicChatbox.Tests/ViewModels/ChatEditStateTests.cs
+++ b/MagicChatbox.Tests/ViewModels/ChatEditStateTests.cs
@@ -218,7 +218,12 @@ public class ChatEditStateTests
         ChatStateManager.FadeOlderMessages(messages);
 
         var values = messages
-            .Select(m => double.Parse(m.Opacity, CultureInfo.InvariantCulture))
+            .Select(m =>
+            {
+                string? opacity = m.Opacity;
+                Assert.NotNull(opacity);
+                return double.Parse(opacity, CultureInfo.InvariantCulture);
+            })
             .ToList();
 
         Assert.Equal(1.0, values[^1]);
@@ -233,7 +238,9 @@ public class ChatEditStateTests
 
         ChatStateManager.FadeOlderMessages(only);
 
-        Assert.Equal(1.0, double.Parse(only[0].Opacity, CultureInfo.InvariantCulture));
+        string? opacity = only[0].Opacity;
+        Assert.NotNull(opacity);
+        Assert.Equal(1.0, double.Parse(opacity, CultureInfo.InvariantCulture));
     }
 
     [Fact]

--- a/MagicChatbox.Tests/ViewModels/Models/VersionFormatTests.cs
+++ b/MagicChatbox.Tests/ViewModels/Models/VersionFormatTests.cs
@@ -1,0 +1,116 @@
+using System;
+using Xunit;
+using AppVersion = vrcosc_magicchatbox.ViewModels.Models.Version;
+
+namespace MagicChatbox.Tests.ViewModels.Models;
+
+public class VersionFormatTests
+{
+    [Theory]
+    [InlineData("0.9.223", "0.9.223")]
+    [InlineData("0.9.7", "0.9.007")]
+    [InlineData("0.9.07", "0.9.007")]
+    [InlineData("0.10.99", "0.10.099")]
+    public void A_three_segment_version_keeps_its_shape_with_the_build_padded(string input, string expected)
+    {
+        Assert.Equal(expected, new AppVersion(input).VersionNumber);
+    }
+
+    [Theory]
+    [InlineData("1.9.223")]
+    [InlineData("9.9.223")]
+    [InlineData("0.9.223")]
+    public void The_leading_segment_is_always_forced_to_zero(string input)
+    {
+        Assert.Equal("0.9.223", new AppVersion(input).VersionNumber);
+    }
+
+    [Theory]
+    [InlineData("0.9.223.4", "0.9.223")]
+    [InlineData("1.9.223.4.5.6", "0.9.223")]
+    public void Anything_past_the_third_segment_is_dropped(string input, string expected)
+    {
+        Assert.Equal(expected, new AppVersion(input).VersionNumber);
+    }
+
+    [Fact]
+    public void A_two_segment_version_no_longer_takes_the_update_check_down()
+    {
+        // A tag is not obliged to carry three segments. The missing one used to reach int.Parse
+        // as a null and throw; it now reads as the zero it means.
+        var exception = Record.Exception(() => new AppVersion("1.0"));
+
+        Assert.Null(exception);
+        Assert.Equal("0.0.000", new AppVersion("1.0").VersionNumber);
+    }
+
+    [Theory]
+    [InlineData("1", "0.0.000")]
+    [InlineData("2", "0.0.000")]
+    [InlineData("", "0.0.000")]
+    public void A_one_segment_version_and_an_empty_string_survive_too(string input, string expected)
+    {
+        var exception = Record.Exception(() => new AppVersion(input));
+
+        Assert.Null(exception);
+        Assert.Equal(expected, new AppVersion(input).VersionNumber);
+    }
+
+    [Fact]
+    public void A_null_version_is_read_as_all_zeroes()
+    {
+        var exception = Record.Exception(() => new AppVersion(null!));
+
+        Assert.Null(exception);
+        Assert.Equal("0.0.000", new AppVersion(null!).VersionNumber);
+    }
+
+    [Theory]
+    [InlineData("0.beta.223", "0.0.223")]
+    [InlineData("0.9.beta", "0.9.000")]
+    [InlineData("v0.9.223", "0.9.223")]
+    [InlineData("0.9.223-rc1", "0.9.000")]
+    public void A_segment_that_is_not_a_number_reads_as_zero(string input, string expected)
+    {
+        // The leading segment is overwritten wholesale, so "v0" never has to parse - but a
+        // suffix on the build number is not salvaged, it collapses to zero.
+        Assert.Equal(expected, new AppVersion(input).VersionNumber);
+    }
+
+    [Fact]
+    public void A_build_number_wider_than_three_digits_is_left_alone()
+    {
+        // PadLeft only ever adds, so a four-digit build is not truncated to three.
+        Assert.Equal("0.9.1234", new AppVersion("0.9.1234").VersionNumber);
+    }
+
+    [Fact]
+    public void Setting_the_property_normalises_exactly_like_the_constructor()
+    {
+        var version = new AppVersion("0.9.223");
+
+        version.VersionNumber = "1.9.7";
+
+        Assert.Equal("0.9.007", version.VersionNumber);
+    }
+
+    [Fact]
+    public void Setting_the_property_to_a_short_version_does_not_throw_either()
+    {
+        var version = new AppVersion("0.9.223");
+
+        var exception = Record.Exception(() => version.VersionNumber = "1.0");
+
+        Assert.Null(exception);
+        Assert.Equal("0.0.000", version.VersionNumber);
+    }
+
+    [Fact]
+    public void The_release_details_start_empty_rather_than_null()
+    {
+        var version = new AppVersion("0.9.223");
+
+        Assert.Equal(string.Empty, version.ReleaseDate);
+        Assert.Equal(string.Empty, version.ReleaseNotes);
+    }
+}

--- a/MagicChatbox.Tests/ViewModels/StatusGroupEditingTests.cs
+++ b/MagicChatbox.Tests/ViewModels/StatusGroupEditingTests.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using MagicChatbox.Tests.UI;
+using vrcosc_magicchatbox.Classes.Modules;
+using vrcosc_magicchatbox.Core.Configuration;
+using vrcosc_magicchatbox.Core.Services;
+using vrcosc_magicchatbox.Core.State;
+using vrcosc_magicchatbox.Core.Toast;
+using vrcosc_magicchatbox.Services;
+using vrcosc_magicchatbox.ViewModels;
+using vrcosc_magicchatbox.ViewModels.Models;
+using vrcosc_magicchatbox.ViewModels.State;
+using Xunit;
+
+namespace MagicChatbox.Tests.ViewModels;
+
+public sealed class StatusGroupEditingTests
+{
+    private sealed class StubSettingsProvider<T>(T value) : ISettingsProvider<T> where T : class, new()
+    {
+        public T Value { get; } = value;
+        public void Save() { }
+        public void FlushPendingSave() { }
+        public void Reload() { }
+        public event EventHandler SettingsChanged { add { } remove { } }
+    }
+
+    private sealed class FakeAppState : IAppState
+    {
+        public bool MasterSwitch { get; set; } = true;
+        public bool IsVRRunning { get; set; }
+        public bool BussyBoysMode { get; set; }
+        public bool Egg_Dev { get; set; }
+        public bool PulsoidAuthConnected { get; set; }
+        public PulsoidAuthState PulsoidAuthState { get; set; }
+        public int MainWindowBlurEffect { get; set; }
+        public event PropertyChangedEventHandler? PropertyChanged { add { } remove { } }
+    }
+
+    private sealed class ImmediateDispatcher : IUiDispatcher
+    {
+        public void Invoke(Action action) => action();
+        public T Invoke<T>(Func<T> func) => func();
+        public Task InvokeAsync(Action action) { action(); return Task.CompletedTask; }
+        public Task<T> InvokeAsync<T>(Func<T> func) => Task.FromResult(func());
+        public bool CheckAccess() => true;
+        public void BeginInvoke(Action action) => action();
+        public void Shutdown() { }
+    }
+
+    private sealed class NoOpNavigation : IMenuNavigationService
+    {
+        public void ActivateSetting(string settingName) { }
+        public void NavigateToPage(int pageIndex) { }
+        public void NavigateBack() { }
+        public void NavigateForward() { }
+        public void NavigateToPrivacy() { }
+    }
+
+    private sealed class RecordingStatusListService : IStatusListService
+    {
+        public List<string> AddedGroups { get; } = new();
+        public List<(string GroupId, string Name)> RenamedGroups { get; } = new();
+
+        public void LoadStatusList() { }
+        public void SaveStatusList() { }
+        public void RequestSave() { }
+        public void AddGroup(string name) => AddedGroups.Add(name);
+        public void RenameGroup(string groupId, string newName)
+            => RenamedGroups.Add((groupId, newName));
+        public void DeleteGroup(string groupId) { }
+        public string ExportGroupToJson(string groupId) => string.Empty;
+        public string ExportItemsToJson(IEnumerable<StatusItem> items) => string.Empty;
+        public int ImportFromJson(string json) => 0;
+    }
+
+    private sealed class RecordingToast : IToastService
+    {
+        public List<string> Messages { get; } = new();
+        public ObservableCollection<ToastItemViewModel> Toasts { get; } = new();
+
+        public void Show(
+            string title,
+            string message,
+            ToastType type = ToastType.Info,
+            ToastAction? action = null,
+            int durationMs = 5000,
+            string? key = null)
+            => Messages.Add(message);
+
+        public void Dismiss(ToastItemViewModel item) { }
+    }
+
+    [Fact]
+    public void Invalid_group_names_explain_why_nothing_was_saved()
+    {
+        Exception? failure = WpfHost.Run(() =>
+        {
+            var service = new RecordingStatusListService();
+            var toast = new RecordingToast();
+            StatusPageViewModel viewModel = CreateViewModel(service, toast);
+
+            viewModel.NewGroupName = " ";
+            viewModel.ConfirmAddGroupCommand.Execute(null);
+            viewModel.NewGroupName = new string('x', 51);
+            viewModel.ConfirmAddGroupCommand.Execute(null);
+
+            var group = new StatusGroup
+            {
+                GroupId = "group-1",
+                Name = "Friends",
+                RenameBuffer = " ",
+                IsRenaming = true,
+            };
+            viewModel.ConfirmRenameGroupCommand.Execute(group);
+
+            Assert.Empty(service.AddedGroups);
+            Assert.Empty(service.RenamedGroups);
+            Assert.Contains(toast.Messages, message => message.Contains("Enter", StringComparison.Ordinal));
+            Assert.Contains(toast.Messages, message => message.Contains("50", StringComparison.Ordinal));
+            Assert.True(group.IsRenaming);
+        });
+
+        Assert.Null(failure);
+    }
+
+    [Fact]
+    public void Valid_group_names_are_trimmed_before_they_are_saved()
+    {
+        Exception? failure = WpfHost.Run(() =>
+        {
+            var service = new RecordingStatusListService();
+            StatusPageViewModel viewModel = CreateViewModel(service, new RecordingToast());
+
+            viewModel.NewGroupName = "  Friends  ";
+            viewModel.ConfirmAddGroupCommand.Execute(null);
+
+            var group = new StatusGroup
+            {
+                GroupId = "group-1",
+                Name = "Friends",
+                RenameBuffer = "  Close friends  ",
+                IsRenaming = true,
+            };
+            viewModel.ConfirmRenameGroupCommand.Execute(group);
+
+            Assert.Equal(new[] { "Friends" }, service.AddedGroups);
+            Assert.Equal(("group-1", "Close friends"), Assert.Single(service.RenamedGroups));
+            Assert.False(group.IsRenaming);
+        });
+
+        Assert.Null(failure);
+    }
+
+    [Fact]
+    public void Rename_mode_moves_focus_into_the_bounded_editor()
+    {
+        string root = FindRepoRoot();
+        string codeBehind = File.ReadAllText(Path.Combine(
+            root,
+            "vrcosc-magicchatbox",
+            "UI",
+            "Pages",
+            "StatusPage.xaml.cs"));
+        string xaml = File.ReadAllText(Path.Combine(
+            root,
+            "vrcosc-magicchatbox",
+            "UI",
+            "Pages",
+            "StatusPage.xaml"));
+
+        Assert.Contains("FocusRenameTextBox(group)", codeBehind, StringComparison.Ordinal);
+        Assert.Contains("Keyboard.Focus(textBox)", codeBehind, StringComparison.Ordinal);
+        Assert.Contains("textBox.SelectAll()", codeBehind, StringComparison.Ordinal);
+        Assert.True(Regex.Matches(xaml, "MaxLength=\"50\"").Count >= 2);
+    }
+
+    private static StatusPageViewModel CreateViewModel(
+        IStatusListService statusListService,
+        IToastService toast)
+        => new(
+            new ChatStatusDisplayState(),
+            new FakeAppState(),
+            statusListService,
+            new NoOpNavigation(),
+            new StubSettingsProvider<AppSettings>(new AppSettings()),
+            new ImmediateDispatcher(),
+            toast);
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null &&
+               !Directory.Exists(Path.Combine(directory.FullName, "vrcosc-magicchatbox", "Core")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName
+            ?? throw new DirectoryNotFoundException("repo root not found from " + AppContext.BaseDirectory);
+    }
+}

--- a/MagicChatboxAPI/Enums/VRChatUserCheckResult.cs
+++ b/MagicChatboxAPI/Enums/VRChatUserCheckResult.cs
@@ -8,6 +8,6 @@ namespace MagicChatboxAPI.Enums
 
         public bool AnyUserAllowed { get; set; }
 
-        public string ErrorMessage { get; set; }
+        public string ErrorMessage { get; set; } = string.Empty;
     }
 }

--- a/MagicChatboxAPI/Services/AllowedForUsingService.cs
+++ b/MagicChatboxAPI/Services/AllowedForUsingService.cs
@@ -14,7 +14,7 @@ namespace MagicChatboxAPI.Services
     {
         void StartUserMonitoring(TimeSpan interval);
         void StopUserMonitoring();
-        event EventHandler<BanDetectedEventArgs> BanDetected;
+        event EventHandler<BanDetectedEventArgs>? BanDetected;
     }
 
     public class AllowedForUsingService : IAllowedForUsingService
@@ -26,18 +26,18 @@ namespace MagicChatboxAPI.Services
         private static readonly TimeSpan InitialCheckDelay = TimeSpan.FromSeconds(5);
 
         private readonly HttpClient _httpClient;
-        private Timer _timer;
+        private Timer? _timer;
         private bool _isMonitoring;
         private readonly object _monitorLock = new();
 
-        private List<string> _allUserIds;
+        private List<string>? _allUserIds;
         private readonly Dictionary<string, bool> _userAllowedCache = new();
 
         #endregion
 
         #region Events
 
-        public event EventHandler<BanDetectedEventArgs> BanDetected;
+        public event EventHandler<BanDetectedEventArgs>? BanDetected;
 
         #endregion
 
@@ -249,7 +249,7 @@ namespace MagicChatboxAPI.Services
         private class ApiResponse
         {
             public bool isBanned { get; set; }
-            public string reason { get; set; }
+            public string reason { get; set; } = string.Empty;
         }
 
         #endregion

--- a/vrcosc-magicchatbox/App.xaml
+++ b/vrcosc-magicchatbox/App.xaml
@@ -17,6 +17,7 @@
 
             <DropShadowEffect
                 x:Key="TextBlockShadowEffect"
+                po:Freeze="True"
                 BlurRadius="10"
                 Opacity="1"
                 RenderingBias="Performance"

--- a/vrcosc-magicchatbox/App.xaml
+++ b/vrcosc-magicchatbox/App.xaml
@@ -1732,15 +1732,22 @@
                                     Content="{TemplateBinding Content}"
                                     ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                     ContentTemplate="{TemplateBinding ContentTemplate}" />
-                                <Button
-                                    Margin="0,4,8,0"
+                                <!--  Spans the section header exactly - every section starts with a
+                                      5px top margin and a 30px header toggle - so the button can
+                                      centre against the title rather than hang from the top edge.  -->
+                                <Grid
+                                    Height="30"
+                                    Margin="0,5,8,0"
                                     HorizontalAlignment="Right"
                                     VerticalAlignment="Top"
-                                    Panel.ZIndex="1"
-                                    Command="{Binding DataContext.ResetSectionCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                    CommandParameter="{Binding Tag, RelativeSource={RelativeSource TemplatedParent}}"
-                                    Content="Reset"
-                                    Style="{StaticResource SectionResetButtonStyle}" />
+                                    Panel.ZIndex="1">
+                                    <Button
+                                        VerticalAlignment="Center"
+                                        Command="{Binding DataContext.ResetSectionCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                        CommandParameter="{Binding Tag, RelativeSource={RelativeSource TemplatedParent}}"
+                                        Content="Reset"
+                                        Style="{StaticResource SectionResetButtonStyle}" />
+                                </Grid>
                             </Grid>
                         </ControlTemplate>
                     </Setter.Value>

--- a/vrcosc-magicchatbox/App.xaml.cs
+++ b/vrcosc-magicchatbox/App.xaml.cs
@@ -162,7 +162,7 @@ namespace vrcosc_magicchatbox
                     Core.Diagnostics.PerfProbe.ReportDirectory =
                         Services.GetRequiredService<IEnvironmentService>().LogPath;
                     Core.Diagnostics.BindingErrorProbe.Start();
-                    Logging.WriteInfo("[Perf] Instrumentation enabled (-perf). Ctrl+Shift+F12 dumps a snapshot.");
+                    Logging.WriteInfo("[Perf] Instrumentation enabled (--perf). Ctrl+Shift+F12 dumps a snapshot.");
                 }
 
                 Logging.Initialize(
@@ -225,6 +225,11 @@ namespace vrcosc_magicchatbox
                         {
                             continue;
                         }
+
+                        if (Core.Diagnostics.PerfProbe.IsEnableArgument(arg))
+                        {
+                            continue;
+                        }
                         else
                         {
                             switch (arg)
@@ -266,8 +271,6 @@ namespace vrcosc_magicchatbox
                                     await Task.Run(() => updater.ClearBackUp());
                                     break;
                                 case SteamVrLaunchArgument:
-                                    break;
-                                case Core.Diagnostics.PerfProbe.EnableArgument:
                                     break;
                                 default:
                                     loadingWindow.CloseFromAnyThread();

--- a/vrcosc-magicchatbox/App.xaml.cs
+++ b/vrcosc-magicchatbox/App.xaml.cs
@@ -62,6 +62,8 @@ namespace vrcosc_magicchatbox
         private const int MaxHandledDispatcherExceptionsInWindow = 3;
         private readonly System.Collections.Generic.Queue<DateTime> _handledDispatcherExceptionTimes = new();
 
+        public const string SteamVrLaunchArgument = "-steamvr";
+
         public static MainWindow mainWindow;
 
         protected override async void OnStartup(StartupEventArgs e)
@@ -69,6 +71,8 @@ namespace vrcosc_magicchatbox
             base.OnStartup(e);
             _startupStopwatch.Start();
             LogStartupPhase($"Process started. PID={Environment.ProcessId}, Args='{string.Join(" ", e.Args ?? Array.Empty<string>())}'.");
+
+            bool launchedBySteamVr = WasLaunchedBySteamVr(e.Args);
 
             if (!TryGetProfileNumberFromArgs(e.Args, out int startupProfileNumber, out string? invalidProfileNumber))
             {
@@ -83,6 +87,16 @@ namespace vrcosc_magicchatbox
 
             if (!ShouldSkipSingleInstanceGuard(e.Args) && !TryAcquireSingleInstance(startupProfileNumber))
             {
+                // SteamVR launches its startup apps without checking whether they are already
+                // there. Pulling a window to the front while someone is putting a headset on is
+                // the last thing they want, so this launch simply stands down.
+                if (launchedBySteamVr)
+                {
+                    LogStartupPhase("SteamVR started a copy that was already running. Leaving the running one alone.");
+                    Shutdown();
+                    return;
+                }
+
                 // Launching it again is how someone asks for the window back, not a mistake to be
                 // told off for. Wake the copy that already exists and leave quietly.
                 LogStartupPhase($"Second instance detected for profile {startupProfileNumber}. Waking the running one and exiting.");
@@ -238,6 +252,8 @@ namespace vrcosc_magicchatbox
                                     loadingWindow.UpdateProgress("Rolling back and clearing the slate. Fresh start!", 50);
                                     await Task.Run(() => updater.ClearBackUp());
                                     break;
+                                case SteamVrLaunchArgument:
+                                    break;
                                 default:
                                     loadingWindow.CloseFromAnyThread();
                                     LogStartupPhase($"Invalid command line argument '{arg}'.");
@@ -332,7 +348,9 @@ namespace vrcosc_magicchatbox
 
                 Services.GetRequiredService<ITrayIconService>().Initialize(mainWindow);
 
-                if (vm.AppSettingsInstance.StartInBackground)
+                // Being started by SteamVR means a headset is going on, not that someone wants a
+                // window. This never writes the preference back; it only applies to this launch.
+                if (vm.AppSettingsInstance.StartInBackground || launchedBySteamVr)
                 {
                     mainWindow.AbandonHiddenStart();
                     mainWindow.HideStartupOverlay(animate: false);
@@ -396,6 +414,8 @@ namespace vrcosc_magicchatbox
                 Logging.WriteInfo("[Startup] Starting background scan loop...");
                 mainWindow.StartBackgroundProcessing();
                 Logging.WriteInfo("[Startup] Background processing started.");
+
+                Services.GetRequiredService<Services.Vr.ISteamVrAutoStartService>().Start();
 
                 if (vm.AppSettingsInstance.CheckUpdateOnStartup && consentSvc.IsApproved(PrivacyHook.InternetAccess))
                 {
@@ -794,6 +814,30 @@ namespace vrcosc_magicchatbox
                 return true;
             }
         }
+
+        public void ShutdownFromSteamVr()
+        {
+            try
+            {
+                // Takes the same route as Exit in the tray menu, so "keep running when you close
+                // the window" cannot quietly turn this into a hide.
+                if (mainWindow is not null)
+                {
+                    mainWindow._isTrayClosing = true;
+                    mainWindow.Close();
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logging.WriteException(ex, MSGBox: false);
+            }
+
+            Shutdown();
+        }
+
+        private static bool WasLaunchedBySteamVr(string[]? args)
+            => args != null && args.Any(arg => arg.Equals(SteamVrLaunchArgument, StringComparison.OrdinalIgnoreCase));
 
         private static bool ShouldSkipSingleInstanceGuard(string[]? args)
         {

--- a/vrcosc-magicchatbox/App.xaml.cs
+++ b/vrcosc-magicchatbox/App.xaml.cs
@@ -44,7 +44,8 @@ namespace vrcosc_magicchatbox
             Services.GetRequiredService<ISettingsProvider<WeatherSettings>>().Value);
         private static WeatherSettings _weatherSettings => _lazyWeatherSettings.Value;
 
-        public static IMediaLinkService ApplicationMediaController { get; private set; }
+        // Assigned during InitializeComponentsWithProgress, before any consumer can run.
+        public static IMediaLinkService ApplicationMediaController { get; private set; } = null!;
 
         private readonly Stopwatch _startupStopwatch = new();
         private static readonly TimeSpan StartupWatchdogTimeout = TimeSpan.FromSeconds(120);
@@ -64,7 +65,7 @@ namespace vrcosc_magicchatbox
 
         public const string SteamVrLaunchArgument = "-steamvr";
 
-        public static MainWindow mainWindow;
+        public static MainWindow? mainWindow;
 
         protected override async void OnStartup(StartupEventArgs e)
         {
@@ -324,7 +325,7 @@ namespace vrcosc_magicchatbox
                 loadingWindow.UpdateProgress("Building the main window shell... Hammer, nails, UI!", 98.5, "Rolling out the red carpet... Here comes the UI!");
                 Logging.WriteInfo("Creating MainWindow instance.");
 
-                mainWindow = new MainWindow(
+                MainWindow mainWindow = new MainWindow(
                     Services.GetRequiredService<ScanLoopService>(),
                     Services.GetRequiredService<ModuleBootstrapper>(),
                     Services.GetRequiredService<Core.Services.IModuleHost>(),
@@ -332,6 +333,7 @@ namespace vrcosc_magicchatbox
                     Services.GetRequiredService<ITrayIconService>(),
                     Services.GetRequiredService<HotkeyManagement>(),
                     Services.GetRequiredService<Core.Configuration.ISettingsProvider<Classes.Modules.AppSettings>>());
+                App.mainWindow = mainWindow;
                 Logging.WriteInfo("MainWindow instance created.");
 
                 loadingWindow.UpdateProgress("Rolling out the red carpet... Here comes the UI!", 99, "Wiring up the final UI bits... Almost there!");
@@ -654,7 +656,7 @@ namespace vrcosc_magicchatbox
             string nlogConfigPath = Path.Combine(AppContext.BaseDirectory, "NLog.config");
             if (File.Exists(nlogConfigPath))
             {
-                LogManager.LoadConfiguration(nlogConfigPath);
+                LogManager.Setup().LoadConfigurationFromFile(nlogConfigPath);
             }
 
             try

--- a/vrcosc-magicchatbox/App.xaml.cs
+++ b/vrcosc-magicchatbox/App.xaml.cs
@@ -152,6 +152,7 @@ namespace vrcosc_magicchatbox
                 _loggingReady = true;
                 LogStartupPhase("Logging configured.");
 
+
                 Logging.Initialize(
                     Services.GetRequiredService<AppUpdateState>(),
                     Services.GetRequiredService<IEnvironmentService>(),
@@ -1144,11 +1145,16 @@ namespace vrcosc_magicchatbox
                     Services.GetRequiredService<IModuleHost>().RegisterModule(netStats);
                     LogStep("NetworkStats");
                 }, cancellationToken),
-                RunOptionalStartupTaskAsync("OpenAI", async () =>
+                RunOptionalStartupTaskAsync("OpenAI", () =>
                 {
                     var openAIModule = Services.GetRequiredService<OpenAIModule>();
                     var openAISettings = Services.GetRequiredService<ISettingsProvider<OpenAISettings>>().Value;
-                    await openAIModule.InitializeClient(openAISettings.AccessToken, openAISettings.OrganizationID);
+
+                    // The client is usable the moment it is constructed. Confirming the credentials costs a
+                    // round-trip to the OpenAI API, which held the window back for about two seconds.
+                    if (openAIModule.CreateClient(openAISettings.AccessToken, openAISettings.OrganizationID))
+                        _ = openAIModule.VerifyConnectionAsync();
+
                     LogStep("OpenAI");
                 }, cancellationToken),
                 RunOptionalStartupTaskAsync("IntelliChat", () =>

--- a/vrcosc-magicchatbox/App.xaml.cs
+++ b/vrcosc-magicchatbox/App.xaml.cs
@@ -69,6 +69,10 @@ namespace vrcosc_magicchatbox
         protected override async void OnStartup(StartupEventArgs e)
         {
             base.OnStartup(e);
+
+            // Before any element exists: property metadata cannot be overridden once a type is in use.
+            UI.Controls.ReducedVisuals.Install();
+
             _startupStopwatch.Start();
             LogStartupPhase($"Process started. PID={Environment.ProcessId}, Args='{string.Join(" ", e.Args ?? Array.Empty<string>())}'.");
 

--- a/vrcosc-magicchatbox/App.xaml.cs
+++ b/vrcosc-magicchatbox/App.xaml.cs
@@ -152,6 +152,13 @@ namespace vrcosc_magicchatbox
                 _loggingReady = true;
                 LogStartupPhase("Logging configured.");
 
+                if (Core.Diagnostics.PerfProbe.IsEnabled)
+                {
+                    Core.Diagnostics.PerfProbe.ReportDirectory =
+                        Services.GetRequiredService<IEnvironmentService>().LogPath;
+                    Core.Diagnostics.BindingErrorProbe.Start();
+                    Logging.WriteInfo("[Perf] Instrumentation enabled (-perf). Ctrl+Shift+F12 dumps a snapshot.");
+                }
 
                 Logging.Initialize(
                     Services.GetRequiredService<AppUpdateState>(),
@@ -254,6 +261,8 @@ namespace vrcosc_magicchatbox
                                     await Task.Run(() => updater.ClearBackUp());
                                     break;
                                 case SteamVrLaunchArgument:
+                                    break;
+                                case Core.Diagnostics.PerfProbe.EnableArgument:
                                     break;
                                 default:
                                     loadingWindow.CloseFromAnyThread();

--- a/vrcosc-magicchatbox/App.xaml.cs
+++ b/vrcosc-magicchatbox/App.xaml.cs
@@ -264,6 +264,14 @@ namespace vrcosc_magicchatbox
                     }
                 }
 
+                if (Services.GetRequiredService<IAutoUpdateService>()
+                        .PrepareForStartup(launchedBySteamVr) == StartupUpdateOutcome.HandingOff)
+                {
+                    LogStartupPhase("Handing off to the updater; this process is on its way out.");
+                    loadingWindow.CloseFromAnyThread();
+                    return;
+                }
+
                 bool tosJustAccepted = false;
                 _interactiveStartupPhase = true;
                 {
@@ -414,6 +422,9 @@ namespace vrcosc_magicchatbox
                 Logging.WriteInfo("[Startup] Starting background scan loop...");
                 mainWindow.StartBackgroundProcessing();
                 Logging.WriteInfo("[Startup] Background processing started.");
+
+                Services.GetRequiredService<IAutoUpdateService>().ReportStartupHealthy();
+                LogStartupPhase("Startup reached a working state.");
 
                 Services.GetRequiredService<Services.Vr.ISteamVrAutoStartService>().Start();
 

--- a/vrcosc-magicchatbox/Classes/DataAndSecurity/ChatStateManager.cs
+++ b/vrcosc-magicchatbox/Classes/DataAndSecurity/ChatStateManager.cs
@@ -35,7 +35,7 @@ public class ChatStateManager
         _dispatcher = dispatcher;
     }
 
-    public void ClearChat(ChatItem lastSendChat = null)
+    public void ClearChat(ChatItem? lastSendChat = null)
     {
         _chatStatus.ScanPause = false;
         _oscDisplay.OscToSent = string.Empty;

--- a/vrcosc-magicchatbox/Classes/DataAndSecurity/EncryptionMethods.cs
+++ b/vrcosc-magicchatbox/Classes/DataAndSecurity/EncryptionMethods.cs
@@ -65,17 +65,21 @@ internal static class EncryptionMethods
         {
             if (string.IsNullOrEmpty(source))
             {
-                destination = null;
+                destination = string.Empty;
                 return true;
             }
 
-            destination = isEncryption ? EncryptString(source) : DecryptString(source);
-            return destination != null;
+            string? result = isEncryption ? EncryptString(source) : DecryptString(source);
+            destination = result ?? string.Empty;
+
+            // Success is decided by the result, not by the coalesced destination:
+            // a value that legitimately round-trips to an empty string still succeeded.
+            return result != null;
         }
         catch (Exception ex)
         {
             Logging.WriteException(ex, MSGBox: false);
-            destination = null;
+            destination = string.Empty;
             return false;
         }
     }

--- a/vrcosc-magicchatbox/Classes/DataAndSecurity/EncryptionMethods.cs
+++ b/vrcosc-magicchatbox/Classes/DataAndSecurity/EncryptionMethods.cs
@@ -6,7 +6,7 @@ namespace vrcosc_magicchatbox.Classes.DataAndSecurity;
 
 internal static class EncryptionMethods
 {
-    public static string DecryptString(string cipherText)
+    public static string? DecryptString(string cipherText)
     {
         try
         {
@@ -35,7 +35,7 @@ internal static class EncryptionMethods
         }
     }
 
-    public static string EncryptString(string plainText)
+    public static string? EncryptString(string plainText)
     {
         try
         {

--- a/vrcosc-magicchatbox/Classes/DataAndSecurity/HotkeyManagement.cs
+++ b/vrcosc-magicchatbox/Classes/DataAndSecurity/HotkeyManagement.cs
@@ -24,7 +24,7 @@ public class HotkeyManagement
     private readonly Lazy<ITrayIconService> _trayIconService;
 
     private Dictionary<string, HotkeyInfo> _hotkeyActions;
-    private Window _mainWindow;
+    private Window? _mainWindow;
     private readonly string HotkeyConfigFile;
     private bool _isInitialized;
 
@@ -68,7 +68,7 @@ public class HotkeyManagement
 
 
 
-    private Action GetActionForHotkey(string hotkeyName)
+    private Action? GetActionForHotkey(string hotkeyName)
     {
         return hotkeyName switch
         {
@@ -141,11 +141,11 @@ public class HotkeyManagement
         }
     }
 
-    private void OnGlobalHotkeyPressed(object sender, HotkeyEventArgs e)
+    private void OnGlobalHotkeyPressed(object? sender, HotkeyEventArgs e)
     {
         try
         {
-            if (_hotkeyActions.TryGetValue(e.Name, out HotkeyInfo hotkeyInfo))
+            if (_hotkeyActions.TryGetValue(e.Name, out HotkeyInfo? hotkeyInfo))
             {
                 _dispatcher.BeginInvoke(hotkeyInfo.Action);
             }
@@ -178,7 +178,7 @@ public class HotkeyManagement
 
     private void UpdateTrayHotkeyRegistration()
     {
-        if (!_hotkeyActions.TryGetValue("OpenTrayMenuGlobal", out HotkeyInfo hotkeyInfo))
+        if (!_hotkeyActions.TryGetValue("OpenTrayMenuGlobal", out HotkeyInfo? hotkeyInfo))
             return;
 
         if (_appSettings.OpenTrayWithAltX)
@@ -315,7 +315,7 @@ public class HotkeyManagement
     private class HotkeyInfo
     {
 
-        public HotkeyInfo(Key key, ModifierKeys modifiers, Action action = null)
+        public HotkeyInfo(Key key, ModifierKeys modifiers, Action action)
         {
             Key = key;
             Modifiers = modifiers;

--- a/vrcosc-magicchatbox/Classes/DataAndSecurity/Logging.cs
+++ b/vrcosc-magicchatbox/Classes/DataAndSecurity/Logging.cs
@@ -80,7 +80,7 @@ internal static class Logging
             if (ex != null)
                 msgboxtext = ex.Message;
             new ApplicationError(
-                ex, autoClose, msgboxtimeout, _appUpdateState!,
+                ex ?? new Exception(msgboxtext), autoClose, msgboxtimeout, _appUpdateState!,
                 _env!, _httpClientFactory!, _dispatcher!, _versionService!, _nav!).ShowDialog();
         }
         catch (Exception e)

--- a/vrcosc-magicchatbox/Classes/DataAndSecurity/OSCController.cs
+++ b/vrcosc-magicchatbox/Classes/DataAndSecurity/OSCController.cs
@@ -21,7 +21,7 @@ public sealed class OSCController
         _oscPresenter = oscPresenter;
     }
 
-    internal void ClearChat(ChatItem lastsendchat = null) => _chatMgr.ClearChat(lastsendchat);
+    internal void ClearChat(ChatItem? lastsendchat = null) => _chatMgr.ClearChat(lastsendchat);
 
     public bool CreateChat(bool createItem, string? messageText = null) => _chatMgr.CreateChat(createItem, messageText);
 

--- a/vrcosc-magicchatbox/Classes/DataAndSecurity/UpdateApp.cs
+++ b/vrcosc-magicchatbox/Classes/DataAndSecurity/UpdateApp.cs
@@ -318,7 +318,7 @@ public class UpdateApp
         }
     }
 
-    private DigestVerificationResult VerifyDownloadedPackage(string zipPath)
+    private DigestVerificationResult VerifyDownloadedPackage(string zipPath, bool requireDigest)
     {
         SetStep(UpdateStepKind.Verify, UpdateStepStatus.Running, "Hashing the download");
         ReportIndeterminate("Checking the download against the checksum GitHub published");
@@ -350,6 +350,18 @@ public class UpdateApp
 
             case DigestVerificationStatus.NotPublished:
                 Logging.WriteInfo("No SHA-256 was published for this release asset, so the package could not be verified.");
+
+                // Nobody is watching an unattended install land, so an unverifiable package is
+                // refused outright rather than downgraded to a warning the user never reads.
+                if (requireDigest)
+                {
+                    TryDeleteFile(zipPath);
+                    SetStep(UpdateStepKind.Verify, UpdateStepStatus.Failed, "No checksum published for this release");
+                    throw new InvalidOperationException(
+                        "This release did not publish a checksum, so it cannot be installed without supervision. " +
+                        "Install it from the update button instead.");
+                }
+
                 SetStep(
                     UpdateStepKind.Verify,
                     UpdateStepStatus.Warning,
@@ -385,7 +397,7 @@ public class UpdateApp
         }
     }
 
-    private async Task DownloadAndExtractUpdate(string zipPath)
+    private async Task<DigestVerificationResult> DownloadAndExtractUpdate(string zipPath, bool requireDigest)
     {
         string updateUrl = _updateState.UpdateURL;
         if (string.IsNullOrWhiteSpace(updateUrl) ||
@@ -454,7 +466,7 @@ public class UpdateApp
         SetStep(UpdateStepKind.Download, UpdateStepStatus.Done, UpdateProgressState.DescribeBytes(received));
 
         UpdateStatus("Verifying download");
-        DigestVerificationResult verification = VerifyDownloadedPackage(zipPath);
+        DigestVerificationResult verification = VerifyDownloadedPackage(zipPath, requireDigest);
 
         UpdateStatus("Unpacking update");
         SetStep(UpdateStepKind.Unpack, UpdateStepStatus.Running);
@@ -503,10 +515,150 @@ public class UpdateApp
         TryDeleteFile(zipPath);
 
         UpdateHandoff.Write(dataPath, new UpdateHandoffInfo(
-            _updateState.LatestReleaseVersion?.VersionNumber ?? string.Empty,
+            TargetVersion(),
             verification.Status,
             verification.Actual ?? string.Empty,
             IsRollback: false));
+
+        return verification;
+    }
+
+    /// <summary>
+    /// Hands a package that was staged earlier to the maintenance runner. Applying an update
+    /// always replaces the running installation, so this only ever happens at a cold start,
+    /// before the window is up and before anything is connected.
+    /// </summary>
+    public bool TryStartStagedInstall()
+    {
+        PendingUpdateInfo pending = PendingUpdate.Read(dataPath);
+        if (pending == null)
+            return false;
+
+        try
+        {
+            if (string.IsNullOrWhiteSpace(pending.StagedPath) ||
+                !File.Exists(Path.Combine(pending.StagedPath, ExecutableName)))
+            {
+                Logging.WriteInfo("The staged update is missing its files; discarding it.");
+                PendingUpdate.Clear(dataPath);
+                return false;
+            }
+
+            if (Version.TryParse(_updateState.AppVersion?.VersionNumber, out Version running) &&
+                Version.TryParse(pending.Version, out Version staged) &&
+                staged <= running)
+            {
+                Logging.WriteInfo($"The staged update ({pending.Version}) is not newer than {running}; discarding it.");
+                PendingUpdate.Clear(dataPath);
+                return false;
+            }
+
+            magicChatboxExePath = Path.Combine(pending.StagedPath, ExecutableName);
+            SaveUpdateLocation(backupPath);
+
+            // Cleared before the handoff rather than after it: a package that fails to apply
+            // must not be retried on every launch from here on.
+            PendingUpdate.Clear(dataPath);
+
+            Logging.WriteInfo($"Installing the update staged for {pending.Version}.");
+            StartMaintenanceRunner("-update");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Logging.WriteException(ex, MSGBox: false);
+            PendingUpdate.Clear(dataPath);
+            return false;
+        }
+    }
+
+    public void DiscardStagedUpdate()
+    {
+        PendingUpdate.Clear(dataPath);
+
+        try
+        {
+            if (Directory.Exists(unzipPath))
+            {
+                ClearDirectoryContents(unzipPath);
+                Directory.Delete(unzipPath, true);
+            }
+        }
+        catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+        {
+            Logging.WriteInfo($"Could not clean up the staged update: {ex.Message}");
+        }
+    }
+
+    private string TargetVersionOrDefault()
+    {
+        string version = TargetVersion();
+        return string.IsNullOrWhiteSpace(version) ? "the latest release" : version;
+    }
+
+    private void EnsureRoomForUpdate()
+    {
+        long installSize = MeasureDirectory(currentAppPath);
+        if (installSize <= 0)
+            return;
+
+        // The download, the unpacked copy and the maintenance runner all live in the workspace
+        // at once, and the backup is a full second copy of the installation.
+        RequireFreeSpace(tempPath, installSize * 3);
+        RequireFreeSpace(backupPath, installSize);
+    }
+
+    private static long MeasureDirectory(string path)
+    {
+        try
+        {
+            if (!Directory.Exists(path))
+                return 0;
+
+            return new DirectoryInfo(path)
+                .EnumerateFiles("*", System.IO.SearchOption.AllDirectories)
+                .Sum(file => file.Length);
+        }
+        catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+        {
+            return 0;
+        }
+    }
+
+    private static void RequireFreeSpace(string path, long requiredBytes)
+    {
+        long available;
+
+        try
+        {
+            string root = Path.GetPathRoot(Path.GetFullPath(path));
+            if (string.IsNullOrWhiteSpace(root))
+                return;
+
+            available = new DriveInfo(root).AvailableFreeSpace;
+        }
+        catch (Exception ex) when (ex is ArgumentException || ex is IOException || ex is UnauthorizedAccessException)
+        {
+            return;
+        }
+
+        if (available >= requiredBytes)
+            return;
+
+        throw new IOException(
+            $"Not enough free space on {Path.GetPathRoot(Path.GetFullPath(path))} to install the update. " +
+            $"{UpdateProgressState.DescribeBytes(requiredBytes)} is needed and " +
+            $"{UpdateProgressState.DescribeBytes(available)} is free.");
+    }
+
+    private string TargetVersion()
+    {
+        if (!string.IsNullOrWhiteSpace(_updateState.UpdateVersion))
+            return _updateState.UpdateVersion;
+
+        return _updateState.PendingUpdateChannel == UpdateChannel.PreRelease
+            ? _updateState.PreReleaseVersion?.VersionNumber ?? string.Empty
+            : _updateState.LatestReleaseVersion?.VersionNumber ?? string.Empty;
     }
 
 
@@ -823,7 +975,7 @@ public class UpdateApp
         return null;
     }
 
-    public async Task PrepareUpdate(string customZipPath = null)
+    public async Task PrepareUpdate(string customZipPath = null, bool unattended = false)
     {
         bool gateAcquired = false;
         try
@@ -840,9 +992,11 @@ public class UpdateApp
 
             string targetVersion = useCustomZip
                 ? "a hand-picked package"
-                : _updateState.LatestReleaseVersion?.VersionNumber ?? "the latest release";
+                : TargetVersionOrDefault();
 
             BeginProgress(useCustomZip ? "Installing a custom package" : $"Updating to {targetVersion}");
+
+            EnsureRoomForUpdate();
 
             UpdateStatus("Preparing backup directory");
             ReportIndeterminate("Backing up the current version so you can go back");
@@ -860,11 +1014,13 @@ public class UpdateApp
             UpdateStatus("Preparing update workspace");
             ResetExtractionWorkspace();
 
+            DigestVerificationResult verification = default;
+
             if (!useCustomZip)
             {
                 UpdateStatus("Requesting update");
                 string zipPath = Path.Combine(tempPath, "update.zip");
-                await DownloadAndExtractUpdate(zipPath);
+                verification = await DownloadAndExtractUpdate(zipPath, requireDigest: unattended);
             }
             else
             {
@@ -881,12 +1037,27 @@ public class UpdateApp
                     IsRollback: false));
             }
 
-            SetStep(UpdateStepKind.Install, UpdateStepStatus.Running, "Restarting to swap the files");
-            ReportIndeterminate("Restarting to finish the install");
-
             string launchDirectory = ResolveApplicationDirectory(unzipPath);
             magicChatboxExePath = Path.Combine(launchDirectory, ExecutableName);
             SaveUpdateLocation(backupPath);
+
+            if (unattended)
+            {
+                PendingUpdate.Write(dataPath, new PendingUpdateInfo(
+                    TargetVersion(),
+                    _updateState.PendingUpdateChannel ?? UpdateChannel.Stable,
+                    launchDirectory,
+                    verification.Actual ?? string.Empty,
+                    DateTimeOffset.UtcNow));
+
+                SetStep(UpdateStepKind.Install, UpdateStepStatus.Pending, "Waiting for the next restart");
+                ReportIndeterminate("Ready to install the next time MagicChatbox starts");
+                Logging.WriteInfo($"Staged {TargetVersion()} for install on the next start.");
+                return;
+            }
+
+            SetStep(UpdateStepKind.Install, UpdateStepStatus.Running, "Restarting to swap the files");
+            ReportIndeterminate("Restarting to finish the install");
             StartMaintenanceRunner("-update");
         }
         catch (Exception ex)

--- a/vrcosc-magicchatbox/Classes/DataAndSecurity/UpdateApp.cs
+++ b/vrcosc-magicchatbox/Classes/DataAndSecurity/UpdateApp.cs
@@ -274,6 +274,8 @@ public class UpdateApp
 
     private void FailProgress(string detail) => OnUi(() => Progress.Fail(detail));
 
+    private void CompleteProgress(string detail) => OnUi(() => Progress.Complete(detail));
+
     private static string GetWorkspaceRoot() =>
         Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
@@ -1051,7 +1053,12 @@ public class UpdateApp
                     DateTimeOffset.UtcNow));
 
                 SetStep(UpdateStepKind.Install, UpdateStepStatus.Pending, "Waiting for the next restart");
-                ReportIndeterminate("Ready to install the next time MagicChatbox starts");
+
+                // Complete, not just a progress report: the card can only be dismissed once it has
+                // finished or failed, and staging in the background is finished as far as this session
+                // goes. Reporting progress and returning left the card on screen with a dead close
+                // button for the rest of the session.
+                CompleteProgress("Ready to install the next time MagicChatbox starts");
                 Logging.WriteInfo($"Staged {TargetVersion()} for install on the next start.");
                 return;
             }
@@ -1068,7 +1075,11 @@ public class UpdateApp
             {
                 _updateState.CanUpdate = true;
                 _updateState.CanUpdateLabel = true;
-                Logging.WriteException(ex, MSGBox: true);
+
+                // An update nobody asked for must not interrupt with a modal error. The progress card
+                // already shows the failure, and the caller toasts. A hand-started update keeps the
+                // dialog, because someone is waiting on the answer.
+                Logging.WriteException(ex, MSGBox: !unattended);
             });
         }
         finally

--- a/vrcosc-magicchatbox/Classes/DataAndSecurity/UpdateApp.cs
+++ b/vrcosc-magicchatbox/Classes/DataAndSecurity/UpdateApp.cs
@@ -22,13 +22,13 @@ public class UpdateApp
     private static int _legacyWorkspacesChecked;
     private const string ExecutableName = "MagicChatbox.exe";
     private const int UpdateLocationMetadataVersion = 2;
-    private string backupPath;
-    private string currentAppPath;
+    private string backupPath = string.Empty;
+    private string currentAppPath = string.Empty;
     private readonly string dataPath;
-    private string maintenanceRunnerPath;
-    private string magicChatboxExePath;
-    private string tempPath;
-    private string unzipPath;
+    private string maintenanceRunnerPath = string.Empty;
+    private string magicChatboxExePath = string.Empty;
+    private string tempPath = string.Empty;
+    private string unzipPath = string.Empty;
     private readonly AppUpdateState _updateState;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IUiDispatcher _dispatcher;
@@ -497,7 +497,7 @@ public class UpdateApp
                 }
                 else
                 {
-                    string directory = Path.GetDirectoryName(destinationPath);
+                    string? directory = Path.GetDirectoryName(destinationPath);
                     if (!string.IsNullOrEmpty(directory))
                         Directory.CreateDirectory(directory);
                     entry.ExtractToFile(destinationPath, true);
@@ -532,7 +532,7 @@ public class UpdateApp
     /// </summary>
     public bool TryStartStagedInstall()
     {
-        PendingUpdateInfo pending = PendingUpdate.Read(dataPath);
+        PendingUpdateInfo? pending = PendingUpdate.Read(dataPath);
         if (pending == null)
             return false;
 
@@ -546,8 +546,8 @@ public class UpdateApp
                 return false;
             }
 
-            if (Version.TryParse(_updateState.AppVersion?.VersionNumber, out Version running) &&
-                Version.TryParse(pending.Version, out Version staged) &&
+            if (Version.TryParse(_updateState.AppVersion?.VersionNumber, out Version? running) &&
+                Version.TryParse(pending.Version, out Version? staged) &&
                 staged <= running)
             {
                 Logging.WriteInfo($"The staged update ({pending.Version}) is not newer than {running}; discarding it.");
@@ -633,7 +633,7 @@ public class UpdateApp
 
         try
         {
-            string root = Path.GetPathRoot(Path.GetFullPath(path));
+            string? root = Path.GetPathRoot(Path.GetFullPath(path));
             if (string.IsNullOrWhiteSpace(root))
                 return;
 
@@ -685,7 +685,7 @@ public class UpdateApp
                 }
                 else
                 {
-                    string directory = Path.GetDirectoryName(destinationPath);
+                    string? directory = Path.GetDirectoryName(destinationPath);
                     if (!string.IsNullOrEmpty(directory))
                         Directory.CreateDirectory(directory);
                     entry.ExtractToFile(destinationPath, true);
@@ -819,7 +819,7 @@ public class UpdateApp
     }
 
 
-    private void SaveUpdateLocation(string backupPath = null)
+    private void SaveUpdateLocation(string? backupPath = null)
     {
         Directory.CreateDirectory(dataPath);
 
@@ -926,7 +926,7 @@ public class UpdateApp
             return false;
         }
 
-        Version backupVersion = GetApplicationVersion(Path.Combine(backupPath, ExecutableName));
+        Version? backupVersion = GetApplicationVersion(Path.Combine(backupPath, ExecutableName));
         if (backupVersion != null)
         {
             _updateState.RollBackVersion = backupVersion;
@@ -954,7 +954,7 @@ public class UpdateApp
         }
     }
 
-    public Version GetApplicationVersion(string exePath)
+    public Version? GetApplicationVersion(string exePath)
     {
         try
         {
@@ -964,7 +964,7 @@ public class UpdateApp
             }
 
             FileVersionInfo fileInfo = FileVersionInfo.GetVersionInfo(exePath);
-            if (Version.TryParse(fileInfo.FileVersion, out Version version))
+            if (Version.TryParse(fileInfo.FileVersion, out Version? version))
             {
                 return version;
             }
@@ -977,7 +977,7 @@ public class UpdateApp
         return null;
     }
 
-    public async Task PrepareUpdate(string customZipPath = null, bool unattended = false)
+    public async Task PrepareUpdate(string? customZipPath = null, bool unattended = false)
     {
         bool gateAcquired = false;
         try
@@ -1018,7 +1018,7 @@ public class UpdateApp
 
             DigestVerificationResult verification = default;
 
-            if (!useCustomZip)
+            if (string.IsNullOrEmpty(customZipPath))
             {
                 UpdateStatus("Requesting update");
                 string zipPath = Path.Combine(tempPath, "update.zip");
@@ -1123,7 +1123,7 @@ public class UpdateApp
                 return;
             }
 
-            string currentVersion = GetApplicationVersion(Path.Combine(currentAppPath, ExecutableName))?.ToString()
+            string? currentVersion = GetApplicationVersion(Path.Combine(currentAppPath, ExecutableName))?.ToString()
                 ?? _updateState.AppVersion?.VersionNumber;
 
             string rollbackRecoveryPath = Path.Combine(dataPath, "rollback_recovery");
@@ -1249,11 +1249,9 @@ public class UpdateApp
         Logging.WriteException(new Exception("No rollback backup was found."), MSGBox: true);
     }
 
-    public void UpdateApplication(bool admin = false, string customZipPath = null)
+    public void UpdateApplication(bool admin = false, string? customZipPath = null)
     {
-        bool useCustomZip = !string.IsNullOrEmpty(customZipPath);
-
-        if (useCustomZip)
+        if (!string.IsNullOrEmpty(customZipPath))
         {
             unzipPath = Path.Combine(GetWorkspaceRoot(), "custom_unzip");
             magicChatboxExePath = Path.Combine(unzipPath, ExecutableName);
@@ -1356,7 +1354,7 @@ public class UpdateApp
         return $"Update failed: {reason}";
     }
 
-    public void UpdateStatus(string message, StartUp startUp = null, double proc = 50)
+    public void UpdateStatus(string message, StartUp? startUp = null, double proc = 50)
     {
         _dispatcher.BeginInvoke(() =>
         {

--- a/vrcosc-magicchatbox/Classes/Modules/AfkModule.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/AfkModule.cs
@@ -18,7 +18,7 @@ namespace vrcosc_magicchatbox.Classes.Modules;
 
 public partial class AfkModuleSettings : ObservableObject
 {
-    public event EventHandler SettingsChanged;
+    public event EventHandler? SettingsChanged;
 
     public AfkModuleSettings()
     {
@@ -48,7 +48,7 @@ public partial class AfkModuleSettings : ObservableObject
     }
 
     private const string SettingsFileName = "AfkModuleSettings.json";
-    internal string _settingsPath;
+    internal string _settingsPath = string.Empty;
 
     [ObservableProperty]
     private int afkTimeout = 120;
@@ -172,7 +172,7 @@ public partial class AfkModule : ObservableObject, IModule
     private TimeSettings TS => _ts;
     private readonly IPrivacyConsentService _consentService;
 
-    private Timer _afkTimer;
+    private Timer? _afkTimer;
     private DateTime lastActionTime;
     private bool overrideAfkStarted = false;
     private bool _disposed;
@@ -183,10 +183,10 @@ public partial class AfkModule : ObservableObject, IModule
     public string FriendlyTimeoutTime => FormatDuration(TimeSpan.FromSeconds(Settings.AfkTimeout), Settings.UseSmallLettersForDuration);
 
     [ObservableProperty]
-    private string remainingTimeUntilAFK;
+    private string? remainingTimeUntilAFK;
 
     [ObservableProperty]
-    private string timeCurrentlyAFK;
+    private string? timeCurrentlyAFK;
 
     [ObservableProperty]
     private bool vRModeLabelActive;
@@ -194,7 +194,7 @@ public partial class AfkModule : ObservableObject, IModule
     [ObservableProperty]
     private bool overrideButtonVisible;
 
-    public event EventHandler<EventArgs> AfkDetected;
+    public event EventHandler<EventArgs>? AfkDetected;
 
     [ObservableProperty]
     private AfkModuleSettings settings;
@@ -228,7 +228,7 @@ public partial class AfkModule : ObservableObject, IModule
         InitializeAfkDetection();
     }
 
-    private void ViewModel_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+    private void ViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
         if (e.PropertyName == "IsVRRunning")
         {
@@ -236,7 +236,7 @@ public partial class AfkModule : ObservableObject, IModule
         }
     }
 
-    private void Settings_SettingsChanged(object sender, EventArgs e)
+    private void Settings_SettingsChanged(object? sender, EventArgs e)
     {
         OnPropertyChanged(nameof(FriendlyTimeoutTime));
         HandleAfkDetectionToggle();

--- a/vrcosc-magicchatbox/Classes/Modules/AppSettings.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/AppSettings.cs
@@ -34,7 +34,7 @@ public partial class AppSettings : VersionedSettings
 
     [ObservableProperty] private bool _countOculusSystemAsVR = true;
     [ObservableProperty] private bool _topmost = false;
-    [ObservableProperty] private UpdateChannelMode _stableUpdateMode = UpdateChannelMode.Notify;
+    [ObservableProperty] private UpdateChannelMode _stableUpdateMode = UpdateChannelMode.Auto;
     [ObservableProperty] private UpdateChannelMode _preReleaseUpdateMode = UpdateChannelMode.Off;
     [ObservableProperty] private bool _checkUpdateOnStartup = true;
 

--- a/vrcosc-magicchatbox/Classes/Modules/AppSettings.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/AppSettings.cs
@@ -1,5 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using vrcosc_magicchatbox.Core.Configuration;
@@ -12,6 +13,7 @@ public partial class AppSettings : VersionedSettings
     public const double OscTickIntervalDefaultSeconds = 1.0;
     public const double OscTickIntervalMinSeconds = 0.7;
     public const double OscTickIntervalMaxSeconds = 10.0;
+    public const int OscTickIntervalDecimals = 1;
 
     [ObservableProperty] private double _scanningInterval = OscTickIntervalDefaultSeconds;
     [ObservableProperty] private int _scanPauseTimeout = 15;
@@ -163,9 +165,23 @@ public partial class AppSettings : VersionedSettings
         }
 
         if (value < OscTickIntervalMinSeconds)
+        {
             ScanningInterval = OscTickIntervalMinSeconds;
-        else if (value > OscTickIntervalMaxSeconds)
+            return;
+        }
+
+        if (value > OscTickIntervalMaxSeconds)
+        {
             ScanningInterval = OscTickIntervalMaxSeconds;
+            return;
+        }
+
+        // The slider snaps to minimum plus a whole number of steps, and computing that in binary
+        // floating point drifts: a tenth of a second is not representable, so the tick a user picks
+        // arrives here as 9.799999999999999 and is stored and displayed that way.
+        double snapped = Math.Round(value, OscTickIntervalDecimals, MidpointRounding.AwayFromZero);
+        if (snapped != value)
+            ScanningInterval = snapped;
     }
 
     partial void OnMinimizeToTrayChanged(bool value)

--- a/vrcosc-magicchatbox/Classes/Modules/AppSettings.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/AppSettings.cs
@@ -56,6 +56,7 @@ public partial class AppSettings : VersionedSettings
     [ObservableProperty] private bool _enableTrayNotifications = true;
     [ObservableProperty] private bool _showTrayRunningReminder = true;
     [ObservableProperty] private bool _openTrayWithAltX = true;
+    [ObservableProperty] private bool _showHiddenIntegrationWarning = true;
 
     [JsonProperty("OpenTrayWithAltQ", NullValueHandling = NullValueHandling.Ignore)]
     public bool? LegacyOpenTrayShortcut

--- a/vrcosc-magicchatbox/Classes/Modules/AppSettings.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/AppSettings.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json;
 using System.Collections.ObjectModel;
 using vrcosc_magicchatbox.Core.Configuration;
+using vrcosc_magicchatbox.Core.Updates;
 
 namespace vrcosc_magicchatbox.Classes.Modules;
 
@@ -32,8 +33,21 @@ public partial class AppSettings : VersionedSettings
 
     [ObservableProperty] private bool _countOculusSystemAsVR = true;
     [ObservableProperty] private bool _topmost = false;
-    [ObservableProperty] private bool _joinedAlphaChannel = false;
+    [ObservableProperty] private UpdateChannelMode _stableUpdateMode = UpdateChannelMode.Notify;
+    [ObservableProperty] private UpdateChannelMode _preReleaseUpdateMode = UpdateChannelMode.Off;
     [ObservableProperty] private bool _checkUpdateOnStartup = true;
+
+    [JsonProperty("JoinedAlphaChannel", NullValueHandling = NullValueHandling.Ignore)]
+    public bool? LegacyJoinedAlphaChannel
+    {
+        get => null;
+        set
+        {
+            if (value == true)
+                PreReleaseUpdateMode = UpdateChannelMode.Notify;
+        }
+    }
+
     [ObservableProperty] private bool _startInBackground = false;
     [ObservableProperty] private bool _minimizeToTray = false;
     [ObservableProperty] private bool _closeToTray = false;

--- a/vrcosc-magicchatbox/Classes/Modules/AppSettings.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/AppSettings.cs
@@ -26,6 +26,10 @@ public partial class AppSettings : VersionedSettings
     [ObservableProperty] private string _oscMessageSuffix = string.Empty;
     [ObservableProperty] private bool _seperateWithENTERS = true;
 
+    [ObservableProperty] private bool _startWithSteamVr = false;
+    [ObservableProperty] private bool _quitWithSteamVr = false;
+    [ObservableProperty] private string _steamVrManifestPath = string.Empty;
+
     [ObservableProperty] private bool _countOculusSystemAsVR = true;
     [ObservableProperty] private bool _topmost = false;
     [ObservableProperty] private bool _joinedAlphaChannel = false;

--- a/vrcosc-magicchatbox/Classes/Modules/AppSettings.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/AppSettings.cs
@@ -1,5 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using Newtonsoft.Json;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using vrcosc_magicchatbox.Core.Configuration;
 using vrcosc_magicchatbox.Core.Updates;
@@ -79,6 +80,24 @@ public partial class AppSettings : VersionedSettings
     [ObservableProperty] private bool _statusRoundCorners = true;
 
     [ObservableProperty] private int _currentMenuItem = 0;
+
+    [ObservableProperty] private Dictionary<string, double> _pageScrollOffsets = new();
+
+    /// <summary>
+    /// Last measured height of each Options section, so an unrealized section's placeholder can reserve
+    /// the right space. Without it the scrollbar and any restored offset are wrong until everything is built.
+    /// </summary>
+    [ObservableProperty] private Dictionary<string, double> _optionsSectionHeights = new();
+
+    /// <summary>
+    /// Arms the auto-save for the two scroll dictionaries. They are mutated in place, which raises no
+    /// PropertyChanged of its own, so without this they would only reach disk on a clean shutdown.
+    /// </summary>
+    public void MarkScrollStateChanged()
+    {
+        OnPropertyChanged(nameof(PageScrollOffsets));
+        OnPropertyChanged(nameof(OptionsSectionHeights));
+    }
 
     [ObservableProperty] private bool _settings_Status = false;
     [ObservableProperty] private bool _settings_OpenAI = false;

--- a/vrcosc-magicchatbox/Classes/Modules/AppSettings.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/AppSettings.cs
@@ -135,6 +135,12 @@ public partial class AppSettings : VersionedSettings
     [ObservableProperty] private double _appOpacity = 0.98;
     [ObservableProperty] private bool _appIsEnabled = true;
 
+    /// <summary>Drops shadows, blurs, partial opacity and page transitions, to give the GPU back.</summary>
+    [ObservableProperty] private bool _reducedVisuals = false;
+
+    /// <summary>Turns the above on by itself while VR is running, which is when the GPU is contended.</summary>
+    [ObservableProperty] private bool _reducedVisualsInVr = true;
+
     [ObservableProperty]
     [property: Newtonsoft.Json.JsonIgnore]
     [property: System.Text.Json.Serialization.JsonIgnore]

--- a/vrcosc-magicchatbox/Classes/Modules/ComponentStatsModule.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/ComponentStatsModule.cs
@@ -64,7 +64,11 @@ public class ComponentStatsModule : IModule
 
     private readonly ISettingsProvider<ComponentStatsSettings> _settingsProvider;
     public ComponentStatsSettings Settings => _settingsProvider.Value;
-    public void SaveSettings() => _settingsProvider.Save();
+    public void SaveSettings()
+    {
+        _settingsProvider.Save();
+        SaveComponentStats();
+    }
 
     public string Name => "ComponentStats";
     public bool IsEnabled { get; set; } = true;

--- a/vrcosc-magicchatbox/Classes/Modules/ComponentStatsModule.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/ComponentStatsModule.cs
@@ -24,7 +24,7 @@ namespace vrcosc_magicchatbox.Classes.Modules;
 
 public class ComponentStatsModule : IModule
 {
-    private string FileName = null;
+    private string? FileName = null;
     private readonly object _statsInitLock = new();
     private bool _statsLoaded;
     private bool _ddrVersionFetchStarted;
@@ -32,8 +32,8 @@ public class ComponentStatsModule : IModule
     private static readonly TimeSpan MinHardwareNameCacheTtl = TimeSpan.FromSeconds(1);
     private DateTime _gpuNameCachedAtUtc = DateTime.MinValue;
     private DateTime _cpuNameCachedAtUtc = DateTime.MinValue;
-    private string _cachedGpuName;
-    private string _cachedCpuName;
+    private string? _cachedGpuName;
+    private string? _cachedCpuName;
 
     private static readonly StatsComponentType[] StatDisplayOrder =
     {
@@ -57,7 +57,7 @@ public class ComponentStatsModule : IModule
     private readonly List<ComponentStatsItem> _componentStats = new List<ComponentStatsItem>();
     private readonly Dictionary<StatsComponentType, ComponentStatsItem> _statsByType = new();
 
-    private volatile IReadOnlyList<StatReading> _lastReadings;
+    private volatile IReadOnlyList<StatReading>? _lastReadings;
 
     private string _ramDDRVersion = "Unknown";
     public bool started = false;
@@ -89,7 +89,8 @@ public class ComponentStatsModule : IModule
 
     private IntegrationDisplayState _integrationDisplay;
 
-    private ComponentStatsViewModel _statsVm;
+    // ServiceRegistration resolves ComponentStatsViewModel (which calls SetStatsViewModel) before StartModule ever runs.
+    private ComponentStatsViewModel _statsVm = null!;
     private ComponentStatsViewModel StatsVm => _statsVm;
 
     public void SetStatsViewModel(ComponentStatsViewModel vm)
@@ -161,7 +162,7 @@ public class ComponentStatsModule : IModule
 
     private void FetchAndStoreDDRVersion()
     {
-        string ddrVersion = GetDDRVersion();
+        string? ddrVersion = GetDDRVersion();
         if (string.IsNullOrWhiteSpace(ddrVersion))
             return;
 
@@ -196,7 +197,7 @@ public class ComponentStatsModule : IModule
     private bool ShouldFetchDdrVersion()
     {
         var ramItem = GetStat(StatsComponentType.RAM);
-        return ramItem?.IsEnabled == true && ramItem.ShowDDRVersion;
+        return ramItem != null && ramItem.IsEnabled && ramItem.ShowDDRVersion;
     }
 
     private void QueueDdrVersionFetchIfNeeded()
@@ -240,7 +241,7 @@ public class ComponentStatsModule : IModule
         try
         {
             float? load = _hwService.GetCpuLoad();
-            string name = GetCachedCpuName();
+            string? name = GetCachedCpuName();
             UpdateHardwareName(current, name);
             if (load == null) return "N/A";
             return current.RemoveNumberTrailing == true ? $"{(int)load}" : $"{load:F1}";
@@ -259,7 +260,7 @@ public class ComponentStatsModule : IModule
 
     private StatExtra? FetchGpuCoreClockStat(ComponentStatsItem item)
     {
-        float? mhz = _hwService.GetGpuCoreClock(GetDedicatedGPUName());
+        float? mhz = _hwService.GetGpuCoreClock(GetDedicatedGPUNameForHardwareCall());
         if (mhz == null) return null;
         string value = item.RemoveNumberTrailing ? $"{(int)mhz.Value}" : $"{mhz.Value:F0}";
         return Extra(item, "🔄", "core clk", value, "MHz");
@@ -267,7 +268,7 @@ public class ComponentStatsModule : IModule
 
     private StatExtra? FetchGpuFanSpeedStat(ComponentStatsItem item)
     {
-        float? fanPercent = _hwService.GetGpuFanSpeed(GetDedicatedGPUName());
+        float? fanPercent = _hwService.GetGpuFanSpeed(GetDedicatedGPUNameForHardwareCall());
         if (fanPercent == null) return null;
         string value = item.RemoveNumberTrailing ? $"{(int)fanPercent.Value}" : $"{fanPercent.Value:F0}";
         return Extra(item, "🌀", "fan", value, PercentUnit);
@@ -275,7 +276,7 @@ public class ComponentStatsModule : IModule
 
     private StatExtra? FetchGpuMemoryClockStat(ComponentStatsItem item)
     {
-        float? mhz = _hwService.GetGpuMemoryClock(GetDedicatedGPUName());
+        float? mhz = _hwService.GetGpuMemoryClock(GetDedicatedGPUNameForHardwareCall());
         if (mhz == null) return null;
         string value = item.RemoveNumberTrailing ? $"{(int)mhz.Value}" : $"{mhz.Value:F0}";
         return Extra(item, "💾", "mem clk", value, "MHz");
@@ -283,7 +284,7 @@ public class ComponentStatsModule : IModule
 
     private StatExtra? FetchGpuMemoryLoadStat(ComponentStatsItem item)
     {
-        float? load = _hwService.GetGpuMemoryLoad(GetDedicatedGPUName());
+        float? load = _hwService.GetGpuMemoryLoad(GetDedicatedGPUNameForHardwareCall());
         if (load == null) return null;
         string value = item.RemoveNumberTrailing ? $"{(int)load.Value}" : $"{load.Value:F1}";
         return Extra(item, "📊", "mem load", value, PercentUnit);
@@ -291,7 +292,7 @@ public class ComponentStatsModule : IModule
 
     private StatExtra? FetchGpuMemoryTemperatureStat(ComponentStatsItem item)
     {
-        float? rawCelsius = _hwService.GetGpuMemoryTemperature(GetDedicatedGPUName());
+        float? rawCelsius = _hwService.GetGpuMemoryTemperature(GetDedicatedGPUNameForHardwareCall());
         if (rawCelsius == null || rawCelsius == 0) return null;
         return Extra(item, "🧊", "mem temp", FormatTemperature(item, rawCelsius.Value, out string unitSymbol), unitSymbol);
     }
@@ -323,10 +324,10 @@ public class ComponentStatsModule : IModule
         if (current == null) return "N/A";
         try
         {
-            string gpuName = GetDedicatedGPUName();
+            string gpuName = GetDedicatedGPUNameForHardwareCall();
             string sensorName = StaticSettings.GPU3DHook ? "D3D 3D" : "GPU Core";
             float? load = _hwService.GetGpuLoad(gpuName, sensorName);
-            string resolvedName = _hwService.GetGpuName(gpuName);
+            string? resolvedName = _hwService.GetGpuName(gpuName);
             UpdateHardwareName(current, resolvedName);
             if (load == null) return "N/A";
             return current.RemoveNumberTrailing == true ? $"{(int)load}" : $"{load:F1}";
@@ -340,7 +341,7 @@ public class ComponentStatsModule : IModule
 
     private StatExtra? FetchHotspotTemperatureStat(ComponentStatsItem item)
     {
-        float? rawCelsius = _hwService.GetGpuHotspotTemperature(GetDedicatedGPUName());
+        float? rawCelsius = _hwService.GetGpuHotspotTemperature(GetDedicatedGPUNameForHardwareCall());
 
         if (rawCelsius == null || rawCelsius == 0)
         {
@@ -354,7 +355,7 @@ public class ComponentStatsModule : IModule
 
     private StatExtra? FetchPowerStat(ComponentStatsItem item)
     {
-        float? rawWatts = _hwService.GetGpuPower(GetDedicatedGPUName());
+        float? rawWatts = _hwService.GetGpuPower(GetDedicatedGPUNameForHardwareCall());
 
         if (rawWatts == null || rawWatts == 0)
         {
@@ -396,7 +397,7 @@ public class ComponentStatsModule : IModule
         return ("N/A", "N/A");
     }
 
-    private void UpdateHardwareName(ComponentStatsItem current, string hardwareName)
+    private void UpdateHardwareName(ComponentStatsItem current, string? hardwareName)
     {
         if (current == null || string.IsNullOrEmpty(hardwareName)) return;
         if (current.HardwareFriendlyName != hardwareName)
@@ -407,13 +408,13 @@ public class ComponentStatsModule : IModule
         }
         if (current.ReplaceWithHardwareName || string.IsNullOrEmpty(current.HardwareFriendlyNameSmall))
         {
-            current.CustomHardwarenameValueSmall = TextUtilities.TransformToSuperscript(current.CustomHardwarenameValue);
+            current.CustomHardwarenameValueSmall = TextUtilities.TransformToSuperscript(current.CustomHardwarenameValue ?? string.Empty);
         }
     }
 
     private StatExtra? FetchTemperatureStat(ComponentStatsItem item)
     {
-        float? rawCelsius = _hwService.GetGpuTemperature(GetDedicatedGPUName());
+        float? rawCelsius = _hwService.GetGpuTemperature(GetDedicatedGPUNameForHardwareCall());
 
         if (rawCelsius == null || rawCelsius == 0)
         {
@@ -431,10 +432,10 @@ public class ComponentStatsModule : IModule
         if (current == null) return "N/A";
         try
         {
-            string gpuName = GetDedicatedGPUName();
+            string gpuName = GetDedicatedGPUNameForHardwareCall();
             string sensorName = StaticSettings.GPU3DVRAMHook ? "D3D Dedicated Memory Total" : "GPU Memory Total";
             float? rawMb = _hwService.GetGpuVramTotal(gpuName, sensorName);
-            string resolvedName = _hwService.GetGpuName(gpuName);
+            string? resolvedName = _hwService.GetGpuName(gpuName);
             UpdateHardwareName(current, resolvedName);
             if (rawMb == null) return "N/A";
             double gb = rawMb.Value / 1024.0;
@@ -453,10 +454,10 @@ public class ComponentStatsModule : IModule
         if (current == null) return "N/A";
         try
         {
-            string gpuName = GetDedicatedGPUName();
+            string gpuName = GetDedicatedGPUNameForHardwareCall();
             string sensorName = StaticSettings.GPU3DVRAMHook ? "D3D Dedicated Memory Used" : "GPU Memory Used";
             float? rawMb = _hwService.GetGpuVramUsed(gpuName, sensorName);
-            string resolvedName = _hwService.GetGpuName(gpuName);
+            string? resolvedName = _hwService.GetGpuName(gpuName);
             UpdateHardwareName(current, resolvedName);
             if (rawMb == null) return "N/A";
             double gb = rawMb.Value / 1024.0;
@@ -478,7 +479,7 @@ public class ComponentStatsModule : IModule
         }
     }
 
-    private string GetCachedCpuName()
+    private string? GetCachedCpuName()
     {
         var now = DateTime.UtcNow;
         if (now - _cpuNameCachedAtUtc < HardwareNameCacheTtl)
@@ -489,7 +490,7 @@ public class ComponentStatsModule : IModule
         return _cachedCpuName;
     }
 
-    private string GetDedicatedGPUName()
+    private string? GetDedicatedGPUName()
     {
         var now = DateTime.UtcNow;
         if (now - _gpuNameCachedAtUtc < HardwareNameCacheTtl)
@@ -500,7 +501,12 @@ public class ComponentStatsModule : IModule
         return _cachedGpuName;
     }
 
-    private string ResolveDedicatedGPUName()
+    private string GetDedicatedGPUNameForHardwareCall() =>
+        // IHardwareMonitorService's per-GPU accessors declare a non-nullable name, but resolve
+        // an absent one to the primary adapter internally, same as GetDedicatedGPUName's own contract.
+        GetDedicatedGPUName()!;
+
+    private string? ResolveDedicatedGPUName()
     {
         try
         {
@@ -508,7 +514,7 @@ public class ComponentStatsModule : IModule
 
             if (string.IsNullOrEmpty(StaticSettings.SelectedGPU) || StaticSettings.AutoSelectGPU)
             {
-                string resolved = _hwService.GetGpuName(null);
+                string? resolved = _hwService.GetGpuName(string.Empty);
                 if (!string.IsNullOrEmpty(resolved) &&
                     !string.Equals(StaticSettings.SelectedGPU, resolved, StringComparison.Ordinal))
                 {
@@ -518,11 +524,11 @@ public class ComponentStatsModule : IModule
             }
             else
             {
-                string resolved = _hwService.GetGpuName(StaticSettings.SelectedGPU);
+                string? resolved = _hwService.GetGpuName(StaticSettings.SelectedGPU);
                 if (!string.IsNullOrEmpty(resolved))
                     return resolved;
 
-                string fallback = _hwService.GetGpuName(null);
+                string? fallback = _hwService.GetGpuName(string.Empty);
                 Logging.WriteInfo(
                     $"Selected GPU '{StaticSettings.SelectedGPU}' no longer matches any adapter; " +
                     $"falling back to '{fallback ?? "none"}'.");
@@ -677,7 +683,7 @@ public class ComponentStatsModule : IModule
         }
     }
 
-    private ComponentStatsItem GetStat(StatsComponentType type)
+    private ComponentStatsItem? GetStat(StatsComponentType type)
         => _statsByType.TryGetValue(type, out var item) ? item : null;
 
     private void RebuildStatsByType()
@@ -899,7 +905,7 @@ public class ComponentStatsModule : IModule
         IReadOnlyList<StatExtra> other)
     {
         bool custom = stat.ReplaceWithHardwareName && !string.IsNullOrWhiteSpace(stat.CustomHardwarenameValue);
-        string name = stat.ShowPrefixHardwareTitle
+        string? name = stat.ShowPrefixHardwareTitle
             ? custom ? stat.CustomHardwarenameValue : stat.HardwareFriendlyName
             : stat.SystemMainName;
 
@@ -929,20 +935,20 @@ public class ComponentStatsModule : IModule
         return _componentStats.AsReadOnly();
     }
 
-    public string GetCustomHardwareName(StatsComponentType type)
+    public string? GetCustomHardwareName(StatsComponentType type)
     {
         var item = GetStat(type);
         return item?.CustomHardwarenameValue;
     }
 
-    public string GetDDRVersion()
+    public string? GetDDRVersion()
     {
         EnsureComponentStatsLoaded();
-        string plain = _hwService.GetDdrVersion();
+        string? plain = _hwService.GetDdrVersion();
         return ToSuperscript(plain);
     }
 
-    private static string ToSuperscript(string text)
+    private static string? ToSuperscript(string? text)
     {
         if (string.IsNullOrEmpty(text)) return text;
         var sb = new System.Text.StringBuilder(text.Length);
@@ -963,7 +969,7 @@ public class ComponentStatsModule : IModule
         return sb.ToString();
     }
 
-    public string GetHardwareName(StatsComponentType type)
+    public string? GetHardwareName(StatsComponentType type)
     {
         var item = GetStat(type);
         return item?.HardwareFriendlyName;
@@ -1024,13 +1030,13 @@ public class ComponentStatsModule : IModule
         return item?.ShowSmallName ?? false;
     }
 
-    public string GetStatMaxValue(StatsComponentType type)
+    public string? GetStatMaxValue(StatsComponentType type)
     {
         var item = GetStat(type);
         return item?.ComponentValueMax;
     }
 
-    public string GetStatValue(StatsComponentType type)
+    public string? GetStatValue(StatsComponentType type)
     {
         var item = GetStat(type);
         return item?.ComponentValue;
@@ -1239,7 +1245,7 @@ public class ComponentStatsModule : IModule
         {
             if (_componentStats == null || _componentStats.Count == 0) return;
             var jsonData = JsonConvert.SerializeObject(_componentStats);
-            if (!AtomicFileWriter.WriteAllText(FileName, jsonData))
+            if (!AtomicFileWriter.WriteAllText(FileName ?? string.Empty, jsonData))
                 Logging.WriteInfo("Failed to save component stats.");
         }
         catch (Exception ex)
@@ -1248,7 +1254,7 @@ public class ComponentStatsModule : IModule
         }
     }
 
-    public void SetCustomHardwareName(StatsComponentType type, string name)
+    public void SetCustomHardwareName(StatsComponentType type, string? name)
     {
         var item = GetStat(type);
         if (item != null)
@@ -1459,13 +1465,13 @@ public class ComponentStatsModule : IModule
 
     public bool UpdateStats()
     {
-        void UpdateComponentStats(StatsComponentType type, Func<string> fetchStat, Func<string> fetchMaxStat = null)
+        void UpdateComponentStats(StatsComponentType type, Func<string> fetchStat, Func<string>? fetchMaxStat = null)
         {
             var statItem = GetStat(type);
             if (statItem == null || !statItem.IsEnabled) return;
 
             string value = fetchStat();
-            string maxValue = fetchMaxStat?.Invoke();
+            string? maxValue = fetchMaxStat?.Invoke();
 
             if (!value.Contains("N/A"))
             {

--- a/vrcosc-magicchatbox/Classes/Modules/DiscordIpcClient.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/DiscordIpcClient.cs
@@ -17,7 +17,6 @@ public sealed class DiscordIpcClient : IDisposable
 
     private NamedPipeClientStream? _pipe;
     private CancellationTokenSource? _readCts;
-    private CancellationTokenSource? _reconnectCts;
     private Task? _readTask;
     private volatile bool _disposed;
     private volatile bool _intentionalDisconnect;
@@ -147,7 +146,6 @@ public sealed class DiscordIpcClient : IDisposable
     public void Disconnect()
     {
         _intentionalDisconnect = true;
-        _reconnectCts?.Cancel();
         _readCts?.Cancel();
         ClosePipe();
     }
@@ -158,7 +156,6 @@ public sealed class DiscordIpcClient : IDisposable
         _disposed = true;
         Disconnect();
         _readCts?.Dispose();
-        _reconnectCts?.Dispose();
     }
 
     private async Task WriteFrameAsync(int opcode, JObject payload)

--- a/vrcosc-magicchatbox/Classes/Modules/DiscordModule.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/DiscordModule.cs
@@ -28,7 +28,6 @@ public partial class DiscordModule : ObservableObject, IModule
     private Timer? _channelRefreshTimer;
     private const int ChannelRefreshIntervalMs = 30_000;
     private CancellationTokenSource? _reconnectCts;
-    private const int MaxAutoReconnectAttempts = 5;
 
     private const int MaxChannelChars = 24;
     private const int MinChannelChars = 12;
@@ -136,15 +135,11 @@ public partial class DiscordModule : ObservableObject, IModule
 
         _ = Task.Run(async () =>
         {
-            for (int attempt = 1; attempt <= MaxAutoReconnectAttempts; attempt++)
+            int attempt = 1;
+            TimeSpan delay = Core.Constants.DiscordReconnectMinDelay;
+            while (!ct.IsCancellationRequested && !_disposed)
             {
-                if (ct.IsCancellationRequested || _disposed) return;
-
-                var delay = TimeSpan.FromSeconds(Math.Min(
-                    Core.Constants.DiscordReconnectMinDelay.TotalSeconds * Math.Pow(2, attempt - 1),
-                    Core.Constants.DiscordReconnectMaxDelay.TotalSeconds));
-
-                Logging.WriteInfo($"Discord IPC reconnect attempt {attempt}/{MaxAutoReconnectAttempts} in {delay.TotalSeconds:0.#}s");
+                Logging.WriteInfo($"Discord IPC reconnect attempt {attempt} in {delay.TotalSeconds:0.#}s");
 
                 try
                 {
@@ -165,9 +160,12 @@ public partial class DiscordModule : ObservableObject, IModule
                 {
                     Logging.WriteInfo($"Discord IPC reconnect failed: {ex.Message}");
                 }
-            }
 
-            Logging.WriteInfo("Discord IPC: Reconnect attempts exhausted. Waiting for the Discord integration to be toggled.");
+                attempt++;
+                delay = TimeSpan.FromSeconds(Math.Min(
+                    delay.TotalSeconds * 2,
+                    Core.Constants.DiscordReconnectMaxDelay.TotalSeconds));
+            }
         }, ct);
     }
 

--- a/vrcosc-magicchatbox/Classes/Modules/IntegrationModeVisibility.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/IntegrationModeVisibility.cs
@@ -12,7 +12,8 @@ public sealed record IntegrationModeGate(
     Action<IntegrationSettings>? EnableInVr,
     Func<IntegrationSettings, bool> IsVisibleOnDesktop,
     Action<IntegrationSettings>? EnableOnDesktop,
-    Func<IntegrationSettings, bool>? HasOutputOutsideTheChatbox = null)
+    Func<IntegrationSettings, bool>? HasOutputOutsideTheChatbox = null,
+    Func<IntegrationSettings, bool, bool>? IsRelevantIn = null)
 {
     public bool IsVisibleIn(IntegrationSettings settings, bool isVR)
         => isVR ? IsVisibleInVr(settings) : IsVisibleOnDesktop(settings);
@@ -24,6 +25,14 @@ public sealed record IntegrationModeGate(
     /// </summary>
     public bool ProducesOutputIn(IntegrationSettings settings, bool isVR)
         => IsVisibleIn(settings, isVR) || HasOutputOutsideTheChatbox?.Invoke(settings) == true;
+
+    /// <summary>
+    /// Whether the mode switch is worth mentioning at all. An integration that renders alongside
+    /// another one produces nothing while that other one is absent, so pointing at its switch would
+    /// send someone to flip something that changes nothing.
+    /// </summary>
+    public bool MattersIn(IntegrationSettings settings, bool isVR)
+        => IsRelevantIn?.Invoke(settings, isVR) != false;
 
     public bool CanEnableIn(bool isVR)
         => (isVR ? EnableInVr : EnableOnDesktop) is not null;
@@ -126,7 +135,10 @@ public static class IntegrationModeVisibility
         new(nameof(IntegrationSettings.IntgrLyrics), "Lyrics",
             s => s.IntgrLyrics,
             s => s.IntgrLyrics_VR, s => s.IntgrLyrics_VR = true,
-            s => s.IntgrLyrics_DESKTOP, s => s.IntgrLyrics_DESKTOP = true),
+            s => s.IntgrLyrics_DESKTOP, s => s.IntgrLyrics_DESKTOP = true,
+            IsRelevantIn: (s, isVR) =>
+                (s.IntgrScanMediaLink && (isVR ? s.IntgrMediaLink_VR : s.IntgrMediaLink_DESKTOP))
+                || (s.IntgrSpotify && (isVR ? s.IntgrSpotify_VR : s.IntgrSpotify_DESKTOP))),
     };
 
     private static readonly Dictionary<string, IntegrationModeGate> GatesByMaster =
@@ -141,7 +153,9 @@ public static class IntegrationModeVisibility
             return Array.Empty<HiddenIntegration>();
 
         return Gates
-            .Where(gate => gate.IsMasterEnabled(settings) && !gate.ProducesOutputIn(settings, isVR))
+            .Where(gate => gate.IsMasterEnabled(settings)
+                && gate.MattersIn(settings, isVR)
+                && !gate.ProducesOutputIn(settings, isVR))
             .Select(gate => new HiddenIntegration(gate.DisplayName, gate.CanEnableIn(isVR)))
             .ToList();
     }
@@ -157,7 +171,9 @@ public static class IntegrationModeVisibility
         if (settings == null || !TryGetGate(masterPropertyName, out var gate))
             return false;
 
-        if (!gate.IsMasterEnabled(settings) || gate.ProducesOutputIn(settings, isVR))
+        if (!gate.IsMasterEnabled(settings)
+            || !gate.MattersIn(settings, isVR)
+            || gate.ProducesOutputIn(settings, isVR))
             return false;
 
         hidden = new HiddenIntegration(gate.DisplayName, gate.CanEnableIn(isVR));

--- a/vrcosc-magicchatbox/Classes/Modules/IntegrationTileCatalog.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/IntegrationTileCatalog.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace vrcosc_magicchatbox.Classes.Modules;
@@ -76,7 +77,7 @@ public static class IntegrationTileCatalog
     private static readonly Dictionary<string, IntegrationTile> ByMasterProperty =
         Tiles.ToDictionary(t => t.MasterProperty, StringComparer.Ordinal);
 
-    public static bool TryGet(string key, out IntegrationTile tile)
+    public static bool TryGet(string? key, [NotNullWhen(true)] out IntegrationTile? tile)
     {
         tile = null;
         return !string.IsNullOrWhiteSpace(key) && ByKey.TryGetValue(key.Trim(), out tile);
@@ -85,7 +86,7 @@ public static class IntegrationTileCatalog
     public static string DisplayNameFor(string key)
         => TryGet(key, out var tile) ? tile.DisplayName : key;
 
-    public static bool TryKeyForMasterProperty(string propertyName, out string key)
+    public static bool TryKeyForMasterProperty(string propertyName, [NotNullWhen(true)] out string? key)
     {
         key = null;
         if (string.IsNullOrEmpty(propertyName)) return false;
@@ -94,7 +95,7 @@ public static class IntegrationTileCatalog
         return true;
     }
 
-    public static HashSet<string> ResolveHidden(IEnumerable<string> stored)
+    public static HashSet<string> ResolveHidden(IEnumerable<string?>? stored)
     {
         var resolved = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         if (stored == null) return resolved;

--- a/vrcosc-magicchatbox/Classes/Modules/IntelliChatModule.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/IntelliChatModule.cs
@@ -403,12 +403,14 @@ public partial class IntelliChatModule : ObservableObject, IModule, IRecipient<I
 
     public void EnsureValidSelections()
     {
-        var selectedStyle = Settings.SelectedWritingStyle != null
-            ? Settings.SupportedWritingStyles.FirstOrDefault(style => style.ID == Settings.SelectedWritingStyle.ID)
+        var currentStyle = Settings.SelectedWritingStyle;
+        var selectedStyle = currentStyle != null
+            ? Settings.SupportedWritingStyles.FirstOrDefault(style => style.ID == currentStyle.ID)
             : null;
 
-        var selectedTranslateLanguage = Settings.SelectedTranslateLanguage != null
-            ? Settings.SupportedLanguages.FirstOrDefault(lang => lang.ID == Settings.SelectedTranslateLanguage.ID)
+        var currentTranslateLanguage = Settings.SelectedTranslateLanguage;
+        var selectedTranslateLanguage = currentTranslateLanguage != null
+            ? Settings.SupportedLanguages.FirstOrDefault(lang => lang.ID == currentTranslateLanguage.ID)
             : null;
         Settings.SelectedWritingStyle = selectedStyle ?? Settings.SupportedWritingStyles.FirstOrDefault(style => style.IsBuiltIn);
         Settings.SelectedTranslateLanguage = selectedTranslateLanguage ?? Settings.SupportedLanguages.Where(lang => lang.Language.Equals("English", StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
@@ -462,7 +464,7 @@ public partial class IntelliChatModule : ObservableObject, IModule, IRecipient<I
             Settings.IntelliChatUILabel = true;
             Settings.IntelliChatUILabelTxt = isNextWordPrediction ? "Predicting next word..." : "Generating completion...";
 
-            var writingStyle = Settings.SelectedWritingStyle;
+            var writingStyle = Settings.SelectedWritingStyle!;
             var promptMessage = isNextWordPrediction ? "Predict the next chat message word." : $"Complete the following chat message, max {Core.Constants.MaxChatMessageLength} characters.";
             var messages = new List<ChatMessage>
     {
@@ -595,7 +597,7 @@ public partial class IntelliChatModule : ObservableObject, IModule, IRecipient<I
             }
         }
 
-        return null;
+        return string.Empty;
     }
 
     public static string GetModelType(IntelliGPTModel model)
@@ -747,7 +749,7 @@ public partial class IntelliChatModule : ObservableObject, IModule, IRecipient<I
         }
     }
 
-    public async Task PerformBeautifySentenceAsync(string text, IntelliChatWritingStyle intelliChatWritingStyle = null)
+    public async Task PerformBeautifySentenceAsync(string text, IntelliChatWritingStyle? intelliChatWritingStyle = null)
     {
         if (!_chatService.IsClientAvailable)
         {
@@ -767,7 +769,7 @@ public partial class IntelliChatModule : ObservableObject, IModule, IRecipient<I
             Settings.IntelliChatUILabel = true;
             Settings.IntelliChatUILabelTxt = "Waiting for OpenAI to respond";
 
-            intelliChatWritingStyle = intelliChatWritingStyle ?? Settings.SelectedWritingStyle;
+            intelliChatWritingStyle = intelliChatWritingStyle ?? Settings.SelectedWritingStyle!;
 
             var messages = new List<ChatMessage>
     {
@@ -807,7 +809,7 @@ public partial class IntelliChatModule : ObservableObject, IModule, IRecipient<I
         }
     }
 
-    public async Task PerformLanguageTranslationAsync(string text, SupportedIntelliChatLanguage supportedIntelliChatLanguage = null)
+    public async Task PerformLanguageTranslationAsync(string text, SupportedIntelliChatLanguage? supportedIntelliChatLanguage = null)
     {
         if (!_chatService.IsClientAvailable)
         {
@@ -823,7 +825,7 @@ public partial class IntelliChatModule : ObservableObject, IModule, IRecipient<I
         {
             if (!await ModerationCheckPassedAsync(text)) return;
 
-            SupportedIntelliChatLanguage intelliChatLanguage = supportedIntelliChatLanguage ?? Settings.SelectedTranslateLanguage;
+            SupportedIntelliChatLanguage intelliChatLanguage = supportedIntelliChatLanguage ?? Settings.SelectedTranslateLanguage!;
 
             var messages = new List<ChatMessage>
     {
@@ -888,7 +890,7 @@ public partial class IntelliChatModule : ObservableObject, IModule, IRecipient<I
             Settings.IntelliChatUILabel = true;
             Settings.IntelliChatUILabelTxt = "Waiting for OpenAI to respond";
 
-            IntelliChatWritingStyle intelliChatWritingStyle = Settings.SelectedWritingStyle;
+            IntelliChatWritingStyle intelliChatWritingStyle = Settings.SelectedWritingStyle!;
 
             var messages = new List<ChatMessage>
     {

--- a/vrcosc-magicchatbox/Classes/Modules/IntelliChatModuleSettings.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/IntelliChatModuleSettings.cs
@@ -61,10 +61,10 @@ public partial class IntelliChatModuleSettings : VersionedSettings
     private List<SupportedIntelliChatLanguage> selectedSupportedLanguages = new List<SupportedIntelliChatLanguage>();
 
     [ObservableProperty]
-    private SupportedIntelliChatLanguage selectedTranslateLanguage;
+    private SupportedIntelliChatLanguage? selectedTranslateLanguage;
 
     [ObservableProperty]
-    private IntelliChatWritingStyle selectedWritingStyle;
+    private IntelliChatWritingStyle? selectedWritingStyle;
 
     [ObservableProperty]
     private List<SupportedIntelliChatLanguage> supportedLanguages = new List<SupportedIntelliChatLanguage>();

--- a/vrcosc-magicchatbox/Classes/Modules/IntelliChatTypes.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/IntelliChatTypes.cs
@@ -108,7 +108,7 @@ public partial class ModelTokenUsage : ObservableObject
     private int completionTokens;
 
     [ObservableProperty]
-    private string modelName;
+    private string modelName = string.Empty;
 
     [ObservableProperty]
     private int promptTokens;
@@ -136,7 +136,7 @@ public partial class DailyTokenUsage : ObservableObject
 
 public class TokenUsageData : ObservableObject
 {
-    private string _lastRequestModelName;
+    private string _lastRequestModelName = string.Empty;
     private int _lastRequestTotalTokens;
 
     public TokenUsageData()
@@ -196,7 +196,7 @@ public partial class SupportedIntelliChatLanguage : ObservableObject
     private bool isFavorite = false;
 
     [ObservableProperty]
-    private string language;
+    private string language = string.Empty;
 }
 
 public partial class IntelliChatWritingStyle : ObservableObject
@@ -211,10 +211,10 @@ public partial class IntelliChatWritingStyle : ObservableObject
     private bool isFavorite = false;
 
     [ObservableProperty]
-    private string styleDescription;
+    private string styleDescription = string.Empty;
 
     [ObservableProperty]
-    private string styleName;
+    private string styleName = string.Empty;
 
     [ObservableProperty]
     private double temperature;

--- a/vrcosc-magicchatbox/Classes/Modules/Lyrics/LrcParser.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/Lyrics/LrcParser.cs
@@ -6,20 +6,20 @@ using System.Text.RegularExpressions;
 
 namespace vrcosc_magicchatbox.Classes.Modules.Lyrics;
 
-public static class LrcParser
+public static partial class LrcParser
 {
-    private static readonly Regex TimestampPattern =
-        new(@"\[(\d{1,3}):(\d{1,2})(?:[.:](\d{1,3}))?\]", RegexOptions.Compiled);
+    [GeneratedRegex(@"\[(\d{1,3}):(\d{1,2})(?:[.:](\d{1,3}))?\]")]
+    private static partial Regex TimestampPattern();
 
-    private static readonly Regex OffsetPattern =
-        new(@"^\s*\[offset:\s*([+-]?\d+)\s*\]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    [GeneratedRegex(@"^\s*\[offset:\s*([+-]?\d+)\s*\]", RegexOptions.IgnoreCase)]
+    private static partial Regex OffsetPattern();
 
-    private static readonly Regex MetadataPattern =
-        new(@"^\s*\[[a-zA-Z#]+:[^\]]*\]\s*$", RegexOptions.Compiled);
+    [GeneratedRegex(@"^\s*\[[a-zA-Z#]+:[^\]]*\]\s*$")]
+    private static partial Regex MetadataPattern();
 
-    private static readonly Regex StageDirectionPattern =
-        new(@"^\s*[\[\(](music|applause|laughter|instrumental|intro|outro|chorus|verse|bridge|hook|silence)[^\]\)]*[\]\)]\s*$",
-            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    [GeneratedRegex(@"^\s*[\[\(](music|applause|laughter|instrumental|intro|outro|chorus|verse|bridge|hook|silence)[^\]\)]*[\]\)]\s*$",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex StageDirectionPattern();
 
     public const double MaxStageDirectionShare = 0.30;
 
@@ -34,7 +34,7 @@ public static class LrcParser
 
         foreach (string raw in content.Replace("\r\n", "\n").Split('\n'))
         {
-            var offsetMatch = OffsetPattern.Match(raw);
+            var offsetMatch = OffsetPattern().Match(raw);
             if (offsetMatch.Success &&
                 int.TryParse(offsetMatch.Groups[1].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int ms))
             {
@@ -42,16 +42,16 @@ public static class LrcParser
                 continue;
             }
 
-            var stamps = TimestampPattern.Matches(raw);
+            var stamps = TimestampPattern().Matches(raw);
             if (stamps.Count == 0)
                 continue;
 
-            string text = TimestampPattern.Replace(raw, string.Empty).Trim();
+            string text = TimestampPattern().Replace(raw, string.Empty).Trim();
 
-            if (MetadataPattern.IsMatch(text) || IsCreditBlock(text))
+            if (MetadataPattern().IsMatch(text) || IsCreditBlock(text))
                 continue;
 
-            if (StageDirectionPattern.IsMatch(text))
+            if (StageDirectionPattern().IsMatch(text))
                 stageDirections++;
 
             foreach (Match stamp in stamps)

--- a/vrcosc-magicchatbox/Classes/Modules/Lyrics/LyricAsides.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/Lyrics/LyricAsides.cs
@@ -5,11 +5,10 @@ using vrcosc_magicchatbox.Classes.Utilities;
 
 namespace vrcosc_magicchatbox.Classes.Modules.Lyrics;
 
-public static class LyricAsides
+public static partial class LyricAsides
 {
-    private static readonly Regex Aside = new(
-        @"\(([^()]+)\)",
-        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    [GeneratedRegex(@"\(([^()]+)\)", RegexOptions.CultureInvariant)]
+    private static partial Regex Aside();
 
     private const double MinimumRaisedShare = 0.7;
 
@@ -22,7 +21,7 @@ public static class LyricAsides
 
         string source = text;
 
-        return Aside.Replace(source, match =>
+        return Aside().Replace(source, match =>
         {
             string inner = match.Groups[1].Value.Trim();
             if (!TryRaise(inner, out string raised))

--- a/vrcosc-magicchatbox/Classes/Modules/Lyrics/TitleQualifier.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/Lyrics/TitleQualifier.cs
@@ -4,15 +4,13 @@ using System.Text.RegularExpressions;
 
 namespace vrcosc_magicchatbox.Classes.Modules.Lyrics;
 
-public static class TitleQualifier
+public static partial class TitleQualifier
 {
-    private static readonly Regex BracketTail = new(
-        @"\s*[\(\[]([^\(\)\[\]]*)[\)\]]\s*$",
-        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    [GeneratedRegex(@"\s*[\(\[]([^\(\)\[\]]*)[\)\]]\s*$", RegexOptions.CultureInvariant)]
+    private static partial Regex BracketTail();
 
-    private static readonly Regex DashTail = new(
-        @"\s+[-–—]\s+(.+)$",
-        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    [GeneratedRegex(@"\s+[-–—]\s+(.+)$", RegexOptions.CultureInvariant)]
+    private static partial Regex DashTail();
 
     public static (string Base, string Qualifier) Split(string? title)
     {
@@ -24,7 +22,7 @@ public static class TitleQualifier
 
         while (true)
         {
-            Match bracket = BracketTail.Match(working);
+            Match bracket = BracketTail().Match(working);
             if (!bracket.Success)
                 break;
 
@@ -37,7 +35,7 @@ public static class TitleQualifier
             working = remainder;
         }
 
-        Match dash = DashTail.Match(working);
+        Match dash = DashTail().Match(working);
         if (dash.Success)
         {
             string remainder = working[..dash.Index].Trim();

--- a/vrcosc-magicchatbox/Classes/Modules/Lyrics/TrackQueryNormalizer.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/Lyrics/TrackQueryNormalizer.cs
@@ -3,28 +3,30 @@ using System.Text.RegularExpressions;
 
 namespace vrcosc_magicchatbox.Classes.Modules.Lyrics;
 
-public static class TrackQueryNormalizer
+public static partial class TrackQueryNormalizer
 {
-    private static readonly Regex NoiseSuffix = new(
+    [GeneratedRegex(
         @"[\(\[\{]\s*(official\s*(music\s*)?(video|audio|visualizer|lyric[s]?\s*video)?|" +
         @"lyric[s]?|audio|video|visualizer|mv|m/v|hd|hq|4k|8k|remaster(ed)?(\s*\d{4})?|" +
         @"full\s*version|full\s*album|color\s*coded|eng\s*sub|sub\s*espa[nñ]ol|" +
         @"free\s*download|out\s*now|explicit|clean|extended|radio\s*edit)\s*[^\)\]\}]*[\)\]\}]",
-        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        RegexOptions.IgnoreCase)]
+    private static partial Regex NoiseSuffix();
 
-    private static readonly Regex TopicSuffix =
-        new(@"\s*-\s*topic\s*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    [GeneratedRegex(@"\s*-\s*topic\s*$", RegexOptions.IgnoreCase)]
+    private static partial Regex TopicSuffix();
 
-    private static readonly Regex FeaturingSuffix =
-        new(@"\s*[\(\[]\s*(feat|ft|featuring)\b[^\)\]]*[\)\]]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    [GeneratedRegex(@"\s*[\(\[]\s*(feat|ft|featuring)\b[^\)\]]*[\)\]]", RegexOptions.IgnoreCase)]
+    private static partial Regex FeaturingSuffix();
 
-    private static readonly Regex TrailingSeparators =
-        new(@"[\s\-–—_|,;:/\\]+$", RegexOptions.Compiled);
+    [GeneratedRegex(@"[\s\-–—_|,;:/\\]+$")]
+    private static partial Regex TrailingSeparators();
 
-    private static readonly Regex LeadingSeparators =
-        new(@"^[\s\-–—_|,;:/\\]+", RegexOptions.Compiled);
+    [GeneratedRegex(@"^[\s\-–—_|,;:/\\]+")]
+    private static partial Regex LeadingSeparators();
 
-    private static readonly Regex MultipleSpaces = new(@"\s{2,}", RegexOptions.Compiled);
+    [GeneratedRegex(@"\s{2,}")]
+    private static partial Regex MultipleSpaces();
 
     public static LyricsQuery Normalize(string? title, string? artist, string? album, TimeSpan duration)
     {
@@ -53,8 +55,8 @@ public static class TrackQueryNormalizer
             return string.Empty;
 
         string working = NormalizeWidth(title);
-        working = NoiseSuffix.Replace(working, " ");
-        working = FeaturingSuffix.Replace(working, " ");
+        working = NoiseSuffix().Replace(working, " ");
+        working = FeaturingSuffix().Replace(working, " ");
 
         return Tidy(working);
     }
@@ -65,8 +67,8 @@ public static class TrackQueryNormalizer
             return string.Empty;
 
         string working = NormalizeWidth(artist);
-        working = TopicSuffix.Replace(working, string.Empty);
-        working = NoiseSuffix.Replace(working, " ");
+        working = TopicSuffix().Replace(working, string.Empty);
+        working = NoiseSuffix().Replace(working, " ");
 
         return Tidy(working);
     }
@@ -95,9 +97,9 @@ public static class TrackQueryNormalizer
 
     private static string Tidy(string text)
     {
-        string working = MultipleSpaces.Replace(text, " ");
-        working = LeadingSeparators.Replace(working, string.Empty);
-        working = TrailingSeparators.Replace(working, string.Empty);
+        string working = MultipleSpaces().Replace(text, " ");
+        working = LeadingSeparators().Replace(working, string.Empty);
+        working = TrailingSeparators().Replace(working, string.Empty);
         return working.Trim();
     }
 }

--- a/vrcosc-magicchatbox/Classes/Modules/Media/ArtistNameShortener.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/Media/ArtistNameShortener.cs
@@ -5,19 +5,20 @@ using System.Text.RegularExpressions;
 
 namespace vrcosc_magicchatbox.Classes.Modules.Media;
 
-public static class ArtistNameShortener
+public static partial class ArtistNameShortener
 {
-    private static readonly Regex TopicSuffix = new(
+    [GeneratedRegex(
         @"\s*-\s*Topic\s*$",
-        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex TopicSuffix();
 
-    private static readonly Regex FeaturedTail = new(
+    [GeneratedRegex(
         @"\s*[\(\[]?\s*\b(?:feat\.?|ft\.?|featuring)\s+.*$",
-        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex FeaturedTail();
 
-    private static readonly Regex AmpersandJoin = new(
-        @"\s+&\s+",
-        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    [GeneratedRegex(@"\s+&\s+", RegexOptions.CultureInvariant)]
+    private static partial Regex AmpersandJoin();
 
     private static readonly char[] CreditSeparators = [',', ';'];
 
@@ -26,7 +27,7 @@ public static class ArtistNameShortener
         if (string.IsNullOrWhiteSpace(artist))
             return string.Empty;
 
-        return TopicSuffix.Replace(artist.Trim(), string.Empty).Trim();
+        return TopicSuffix().Replace(artist.Trim(), string.Empty).Trim();
     }
 
     public static IReadOnlyList<string> SplitCredits(string? artist)
@@ -41,7 +42,7 @@ public static class ArtistNameShortener
 
         if (parts.Count > 1)
         {
-            string[] tail = AmpersandJoin.Split(parts[^1]);
+            string[] tail = AmpersandJoin().Split(parts[^1]);
             if (tail.Length > 1)
             {
                 parts.RemoveAt(parts.Count - 1);
@@ -68,7 +69,7 @@ public static class ArtistNameShortener
 
         Add(cleaned);
 
-        string withoutFeat = FeaturedTail.Replace(cleaned, string.Empty)
+        string withoutFeat = FeaturedTail().Replace(cleaned, string.Empty)
             .Trim()
             .TrimEnd(',', ';', '(', '[')
             .Trim();

--- a/vrcosc-magicchatbox/Classes/Modules/Media/MediaTitleCleaner.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/Media/MediaTitleCleaner.cs
@@ -6,35 +6,39 @@ using vrcosc_magicchatbox.Classes.Modules.Lyrics;
 
 namespace vrcosc_magicchatbox.Classes.Modules.Media;
 
-public static class MediaTitleCleaner
+public static partial class MediaTitleCleaner
 {
     private const string NoiseToken =
         @"(?:official|music|lyric[s]?|video|audio|visualiser|visualizer|m/?v|hd|hq|uhd|full|[48]k|" +
         @"colou?r|coded|eng|sub|espa[nñ]ol|free|download|out|now|\d{4})";
 
-    private static readonly Regex ProductionNoise = new(
+    [GeneratedRegex(
         $@"[\(\[\{{]\s*{NoiseToken}(?:[\s\-–—/&,\.]+{NoiseToken})*\s*[\)\]\}}]",
-        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex ProductionNoise();
 
     private const string FeatureWord = @"\b(?:featuring|feat|ft)\b\.?";
 
-    private static readonly Regex FeaturedTail = new(
+    [GeneratedRegex(
         $@"\s*[\(\[]\s*{FeatureWord}[^\)\]]*[\)\]]",
-        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex FeaturedTail();
 
-    private static readonly Regex BareFeaturedTail = new(
+    [GeneratedRegex(
         $@"\s+{FeatureWord}\s+.*$",
-        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex BareFeaturedTail();
 
-    private static readonly Regex MultipleSpaces = new(@"\s{2,}", RegexOptions.Compiled);
+    [GeneratedRegex(@"\s{2,}")]
+    private static partial Regex MultipleSpaces();
 
-    private static readonly Regex EdgeSeparators = new(
-        @"^[\s\-–—_|,;:/\\]+|[\s\-–—_|,;:/\\]+$",
-        RegexOptions.Compiled);
+    [GeneratedRegex(@"^[\s\-–—_|,;:/\\]+|[\s\-–—_|,;:/\\]+$")]
+    private static partial Regex EdgeSeparators();
 
-    private static readonly Regex ArtistDecoration = new(
+    [GeneratedRegex(
         @"(?:vevo|official|topic|music|channel)$",
-        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex ArtistDecoration();
 
     private static readonly string[] TitleArtistDividers = [" - ", " – ", " — ", " | ", " • ", ": "];
 
@@ -44,7 +48,7 @@ public static class MediaTitleCleaner
             return string.Empty;
 
         string working = TrackQueryNormalizer.NormalizeWidth(title);
-        working = ProductionNoise.Replace(working, " ");
+        working = ProductionNoise().Replace(working, " ");
         working = Tidy(working);
 
         return StripArtistEcho(working, artist);
@@ -55,8 +59,8 @@ public static class MediaTitleCleaner
         if (string.IsNullOrWhiteSpace(title))
             return string.Empty;
 
-        string working = FeaturedTail.Replace(title, " ");
-        working = BareFeaturedTail.Replace(working, string.Empty);
+        string working = FeaturedTail().Replace(title, " ");
+        working = BareFeaturedTail().Replace(working, string.Empty);
         return Tidy(working);
     }
 
@@ -100,12 +104,12 @@ public static class MediaTitleCleaner
     {
         string letters = new(value.Where(char.IsLetterOrDigit).ToArray());
         letters = letters.ToLowerInvariant();
-        return ArtistDecoration.Replace(letters, string.Empty);
+        return ArtistDecoration().Replace(letters, string.Empty);
     }
 
     private static string Tidy(string text)
     {
-        string working = MultipleSpaces.Replace(text, " ");
-        return EdgeSeparators.Replace(working, string.Empty).Trim();
+        string working = MultipleSpaces().Replace(text, " ");
+        return EdgeSeparators().Replace(working, string.Empty).Trim();
     }
 }

--- a/vrcosc-magicchatbox/Classes/Modules/MediaLinkModule.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/MediaLinkModule.cs
@@ -169,8 +169,8 @@ public class MediaLinkModule : vrcosc_magicchatbox.Services.IMediaLinkService
         if (left == null || right == null)
             return false;
 
-        string leftId = left.Session?.Id;
-        string rightId = right.Session?.Id;
+        string? leftId = left.Session?.Id;
+        string? rightId = right.Session?.Id;
 
         return !string.IsNullOrEmpty(leftId) &&
                string.Equals(leftId, rightId, StringComparison.Ordinal);
@@ -546,7 +546,7 @@ public class MediaLinkModule : vrcosc_magicchatbox.Services.IMediaLinkService
         }
     }
 
-    private void ViewModel_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+    private void ViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
         if (e.PropertyName == "IntgrScanMediaLink" ||
             e.PropertyName == "IntgrMediaLink_VR" ||
@@ -827,7 +827,7 @@ public class MediaLinkModule : vrcosc_magicchatbox.Services.IMediaLinkService
     public void SessionRestore(MediaSessionInfo session)
     {
         MediaSessionSettings savedSettings = new MediaSessionSettings();
-        MediaSessionSettings matchingSettings;
+        MediaSessionSettings? matchingSettings;
 
         lock (MediaSessionSettings.SavedSessionsLock)
         {
@@ -895,14 +895,14 @@ public class MediaLinkModule : vrcosc_magicchatbox.Services.IMediaLinkService
         private bool timePreSuffixOnTheInside = true;
         private string timeSuffix = string.Empty;
 
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
 
-        protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
-        protected bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string propertyName = null)
+        protected bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string? propertyName = null)
         {
             if (Equals(storage, value)) return false;
             storage = value;

--- a/vrcosc-magicchatbox/Classes/Modules/NetworkStatisticsModule.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/NetworkStatisticsModule.cs
@@ -22,7 +22,7 @@ public class NetworkStatisticsModule : INotifyPropertyChanged, IModule
 {
     private readonly IAppState _appState;
 
-    private NetworkInterface _activeNetworkInterface;
+    private NetworkInterface? _activeNetworkInterface;
 
     private CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
 
@@ -40,7 +40,7 @@ public class NetworkStatisticsModule : INotifyPropertyChanged, IModule
     private long _previousBytesSent;
     private double _totalDownloadedMB;
     private double _totalUploadedMB;
-    private Timer _updateTimer;
+    private Timer? _updateTimer;
 
     private readonly ISettingsProvider<NetworkStatsSettings> _settingsProvider;
     public NetworkStatsSettings Settings => _settingsProvider.Value;
@@ -107,7 +107,7 @@ public class NetworkStatisticsModule : INotifyPropertyChanged, IModule
         }
     }
 
-    public event PropertyChangedEventHandler PropertyChanged;
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     private string Measure(double amount, string unit)
         => new SegmentWriter()
@@ -142,7 +142,7 @@ public class NetworkStatisticsModule : INotifyPropertyChanged, IModule
         return Measure(speedMbps, "Mbps");
     }
 
-    private Task<NetworkInterface> GetActiveNetworkInterfaceAsync(CancellationToken cancellationToken)
+    private Task<NetworkInterface?> GetActiveNetworkInterfaceAsync(CancellationToken cancellationToken)
     {
         var networkInterfaces = NetworkInterface.GetAllNetworkInterfaces()
             .Where(ni =>
@@ -215,7 +215,7 @@ public class NetworkStatisticsModule : INotifyPropertyChanged, IModule
 
                 if (UseInterfaceMaxSpeed)
                 {
-                    var speedInMbps = _activeNetworkInterface.Speed / 1e6;
+                    var speedInMbps = networkInterface.Speed / 1e6;
                     MaxDownloadSpeedMbps = speedInMbps;
                     MaxUploadSpeedMbps = speedInMbps;
                 }
@@ -225,7 +225,7 @@ public class NetworkStatisticsModule : INotifyPropertyChanged, IModule
                     MaxUploadSpeedMbps = 0;
                 }
 
-                var stats = GetTotalBytes(_activeNetworkInterface);
+                var stats = GetTotalBytes(networkInterface);
                 _previousBytesReceived = stats.BytesReceived;
                 _previousBytesSent = stats.BytesSent;
 
@@ -269,7 +269,7 @@ public class NetworkStatisticsModule : INotifyPropertyChanged, IModule
         }
     }
 
-    private bool IsRelevantPropertyChange(string propertyName)
+    private bool IsRelevantPropertyChange(string? propertyName)
     {
         return propertyName == nameof(_integrationSettings.IntgrNetworkStatistics) ||
                propertyName == nameof(_appState.IsVRRunning) ||
@@ -277,7 +277,7 @@ public class NetworkStatisticsModule : INotifyPropertyChanged, IModule
                propertyName == nameof(_integrationSettings.IntgrNetworkStatistics_DESKTOP);
     }
 
-    private void OnTimedEvent(object state)
+    private void OnTimedEvent(object? state)
     {
         try
         {
@@ -297,6 +297,8 @@ public class NetworkStatisticsModule : INotifyPropertyChanged, IModule
                     return;
             }
 
+            var activeNetworkInterface = _activeNetworkInterface;
+
             if (UseInterfaceMaxSpeed != Settings.UseInterfaceMaxSpeed)
             {
                 UseInterfaceMaxSpeed = Settings.UseInterfaceMaxSpeed;
@@ -304,7 +306,7 @@ public class NetworkStatisticsModule : INotifyPropertyChanged, IModule
                 MaxUploadSpeedMbps = 0;
             }
 
-            var stats = GetTotalBytes(_activeNetworkInterface);
+            var stats = GetTotalBytes(activeNetworkInterface);
 
             var bytesReceivedDiff = stats.BytesReceived - _previousBytesReceived;
             var bytesSentDiff = stats.BytesSent - _previousBytesSent;
@@ -329,11 +331,11 @@ public class NetworkStatisticsModule : INotifyPropertyChanged, IModule
             }
 
             var maxDownloadSpeed = UseInterfaceMaxSpeed
-                ? _activeNetworkInterface.Speed / 1e6
+                ? activeNetworkInterface.Speed / 1e6
                 : MaxDownloadSpeedMbps;
 
             var maxUploadSpeed = UseInterfaceMaxSpeed
-                ? _activeNetworkInterface.Speed / 1e6
+                ? activeNetworkInterface.Speed / 1e6
                 : MaxUploadSpeedMbps;
 
             var utilization = maxDownloadSpeed > 0
@@ -357,7 +359,7 @@ public class NetworkStatisticsModule : INotifyPropertyChanged, IModule
         }
     }
 
-    private void PropertyChangedHandler(object sender, PropertyChangedEventArgs e)
+    private void PropertyChangedHandler(object? sender, PropertyChangedEventArgs e)
     {
         if (IsRelevantPropertyChange(e.PropertyName))
         {
@@ -379,7 +381,7 @@ public class NetworkStatisticsModule : INotifyPropertyChanged, IModule
                 (!_appState.IsVRRunning && _integrationSettings.IntgrNetworkStatistics_DESKTOP));
     }
 
-    protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
+    protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
     {
         if (!_dispatcher.CheckAccess())
         {
@@ -394,7 +396,7 @@ public class NetworkStatisticsModule : INotifyPropertyChanged, IModule
         }
     }
 
-    protected bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string propertyName = null)
+    protected bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string? propertyName = null)
     {
         if (EqualityComparer<T>.Default.Equals(storage, value))
             return false;
@@ -553,7 +555,8 @@ public class NetworkStatisticsModule : INotifyPropertyChanged, IModule
             _interval = value;
             if (_isMonitoring)
             {
-                _updateTimer.Change(TimeSpan.Zero, TimeSpan.FromMilliseconds(_interval));
+                // _updateTimer is always set while _isMonitoring is true (see StartModule/StopModule).
+                _updateTimer!.Change(TimeSpan.Zero, TimeSpan.FromMilliseconds(_interval));
             }
         }
     }

--- a/vrcosc-magicchatbox/Classes/Modules/OpenAIModule.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/OpenAIModule.cs
@@ -117,6 +117,17 @@ public class OpenAIModule : ITranscriptionService
 
     public async Task InitializeClient(string apiKey, string organizationID)
     {
+        if (!CreateClient(apiKey, organizationID))
+            return;
+
+        await VerifyConnectionAsync();
+    }
+
+    /// <summary>
+    /// Builds the client without contacting the API. Returns false when there is nothing to verify.
+    /// </summary>
+    public bool CreateClient(string apiKey, string organizationID)
+    {
         if (!_consent.IsApproved(PrivacyHook.InternetAccess))
         {
             OpenAIClient = null;
@@ -124,21 +135,23 @@ public class OpenAIModule : ITranscriptionService
             _openAI.AccessError = true;
             _openAI.AccessErrorTxt = "Internet Access permission required";
             _toast?.Show("🔒 OpenAI", "Internet Access permission required for OpenAI features.", ToastType.Privacy, key: "openai-privacy-denied");
-            return;
+            return false;
         }
 
-        if (string.IsNullOrEmpty(apiKey))
-        {
-            return;
-        }
-
-        if (string.IsNullOrEmpty(organizationID))
-        {
-            return;
-        }
+        if (string.IsNullOrEmpty(apiKey) || string.IsNullOrEmpty(organizationID))
+            return false;
 
         var options = new OpenAIClientOptions { OrganizationId = organizationID };
         OpenAIClient = new OpenAIClient(new System.ClientModel.ApiKeyCredential(apiKey), options);
+        return true;
+    }
+
+    /// <summary>Round-trips the API to confirm the credentials still work.</summary>
+    public async Task VerifyConnectionAsync()
+    {
+        if (OpenAIClient == null)
+            return;
+
         await TestConnection();
         _openAI.Connected = AuthChecked;
     }

--- a/vrcosc-magicchatbox/Classes/Modules/PulsoidModule.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/PulsoidModule.cs
@@ -19,7 +19,7 @@ namespace vrcosc_magicchatbox.Classes.Modules;
 
 public partial class PulsoidModule : ObservableObject, IModule
 {
-    private CancellationTokenSource _cts;
+    private CancellationTokenSource? _cts;
     private bool _disposed;
     private readonly IAppState _appState;
     private readonly IUiDispatcher _dispatcher;
@@ -84,7 +84,7 @@ public partial class PulsoidModule : ObservableObject, IModule
 
     [ObservableProperty]
     private bool pulsoidDeviceOnline = false;
-    public PulsoidStatisticsResponse PulsoidStatistics;
+    public PulsoidStatisticsResponse? PulsoidStatistics;
 
     private readonly ISettingsProvider<PulsoidModuleSettings> _settingsProvider;
     public PulsoidModuleSettings Settings => _settingsProvider.Value;
@@ -410,17 +410,21 @@ public partial class PulsoidModule : ObservableObject, IModule
         OscSender.SendOscParam("/avatar/parameters/MCB_Heartrate_TrendUp", trendUp);
         OscSender.SendOscParam("/avatar/parameters/MCB_Heartrate_TrendDown", trendDown);
 
+        var stats = PulsoidStatistics;
+        if (stats == null)
+            return;
+
         if (!Settings.SentMCBHeartrateInfoLegacy)
         {
-            OscSender.SendOscParam("/avatar/parameters/MCB_Heartrate_Min", PulsoidStatistics.minimum_beats_per_minute);
-            OscSender.SendOscParam("/avatar/parameters/MCB_Heartrate_Max", PulsoidStatistics.maximum_beats_per_minute);
-            OscSender.SendOscParam("/avatar/parameters/MCB_Heartrate_Avg", PulsoidStatistics.average_beats_per_minute);
+            OscSender.SendOscParam("/avatar/parameters/MCB_Heartrate_Min", stats.minimum_beats_per_minute);
+            OscSender.SendOscParam("/avatar/parameters/MCB_Heartrate_Max", stats.maximum_beats_per_minute);
+            OscSender.SendOscParam("/avatar/parameters/MCB_Heartrate_Avg", stats.average_beats_per_minute);
         }
         else
         {
-            SendHeartRateDigits("/avatar/parameters/MCB_Heartrate_Min", PulsoidStatistics.minimum_beats_per_minute);
-            SendHeartRateDigits("/avatar/parameters/MCB_Heartrate_Max", PulsoidStatistics.maximum_beats_per_minute);
-            SendHeartRateDigits("/avatar/parameters/MCB_Heartrate_Avg", PulsoidStatistics.average_beats_per_minute);
+            SendHeartRateDigits("/avatar/parameters/MCB_Heartrate_Min", stats.minimum_beats_per_minute);
+            SendHeartRateDigits("/avatar/parameters/MCB_Heartrate_Max", stats.maximum_beats_per_minute);
+            SendHeartRateDigits("/avatar/parameters/MCB_Heartrate_Avg", stats.average_beats_per_minute);
         }
     }
 
@@ -678,7 +682,7 @@ public partial class PulsoidModule : ObservableObject, IModule
         PulsoidModuleSettings settings,
         int heartRate,
         bool deviceOnline,
-        PulsoidStatisticsResponse stats)
+        PulsoidStatisticsResponse? stats)
     {
         if (settings.EnableHeartRateOfflineCheck && !deviceOnline)
             return string.Empty;
@@ -814,7 +818,7 @@ public partial class PulsoidModule : ObservableObject, IModule
         return value;
     }
 
-    public bool IsRelevantPropertyChange(string propertyName)
+    public bool IsRelevantPropertyChange(string? propertyName)
     {
         return propertyName == nameof(_integrationSettings.IntgrHeartRate) ||
                propertyName == nameof(_appState.IsVRRunning) ||
@@ -1032,16 +1036,9 @@ public partial class PulsoidModule : ObservableObject, IModule
     };
 
         var selectedSymbol = Settings.SelectedPulsoidTrendSymbol?.CombinedTrendSymbol;
-        var symbolExists = selectedSymbol != null && Settings.PulsoidTrendSymbols.Any(s => s.CombinedTrendSymbol == selectedSymbol);
+        var matchingSymbol = Settings.PulsoidTrendSymbols.FirstOrDefault(s => s.CombinedTrendSymbol == selectedSymbol);
 
-        if (symbolExists)
-        {
-            Settings.SelectedPulsoidTrendSymbol = Settings.PulsoidTrendSymbols.FirstOrDefault(s => s.CombinedTrendSymbol == selectedSymbol);
-        }
-        else
-        {
-            Settings.SelectedPulsoidTrendSymbol = Settings.PulsoidTrendSymbols.FirstOrDefault();
-        }
+        Settings.SelectedPulsoidTrendSymbol = matchingSymbol ?? Settings.PulsoidTrendSymbols[0];
     }
 
     public bool ShouldStartMonitoring()

--- a/vrcosc-magicchatbox/Classes/Modules/PulsoidModuleSettings.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/PulsoidModuleSettings.cs
@@ -296,7 +296,7 @@ public partial class PulsoidModuleSettings : VersionedSettings
     protected virtual bool TryProtectToken(string plaintext, out string ciphertext)
     {
         string source = plaintext;
-        string destination = null;
+        string destination = string.Empty;
         bool ok = EncryptionMethods.TryProcessToken(ref source, ref destination, isEncryption: true);
         ciphertext = destination;
         return ok;
@@ -305,7 +305,7 @@ public partial class PulsoidModuleSettings : VersionedSettings
     protected virtual bool TryUnprotectToken(string ciphertext, out string plaintext)
     {
         string source = ciphertext;
-        string destination = null;
+        string destination = string.Empty;
         bool ok = EncryptionMethods.TryProcessToken(ref source, ref destination, isEncryption: false);
         plaintext = destination;
         return ok;

--- a/vrcosc-magicchatbox/Classes/Modules/PulsoidOAuthHandler.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/PulsoidOAuthHandler.cs
@@ -20,11 +20,11 @@ public class PulsoidOAuthHandler : IDisposable, IPulsoidTokenValidator
 
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly INavigationService _nav;
-    private HttpClient _httpClient;
+    private HttpClient? _httpClient;
     private HttpClient OAuthHttpClient => _httpClient ??= _httpClientFactory.CreateClient("Pulsoid");
-    private HttpListener httpListener;
+    private HttpListener? httpListener;
     private readonly object listenerLock = new object();
-    private HttpListener secondListener;
+    private HttpListener? secondListener;
 
     public PulsoidOAuthHandler(IHttpClientFactory httpClientFactory, INavigationService nav)
     {
@@ -67,11 +67,11 @@ public class PulsoidOAuthHandler : IDisposable, IPulsoidTokenValidator
         }
     }
 
-    public async Task<string> AuthenticateUserAsync(string authorizationEndpoint)
+    public async Task<string?> AuthenticateUserAsync(string authorizationEndpoint)
     {
         try
         {
-            string token = null;
+            string? token = null;
 
             if (httpListener == null || secondListener == null)
                 throw new InvalidOperationException("Listeners are not started");
@@ -124,10 +124,18 @@ public class PulsoidOAuthHandler : IDisposable, IPulsoidTokenValidator
         GC.SuppressFinalize(this);
     }
 
-    public static Dictionary<string, string> ParseQueryString(string queryString)
+    public static Dictionary<string, string?> ParseQueryString(string queryString)
     {
         var nvc = HttpUtility.ParseQueryString(queryString);
-        return nvc.AllKeys.ToDictionary(k => k, k => nvc[k]);
+        var result = new Dictionary<string, string?>();
+        foreach (var key in nvc.AllKeys)
+        {
+            if (key == null)
+                continue;
+
+            result[key] = nvc[key];
+        }
+        return result;
     }
 
     public void StartListeners()
@@ -137,8 +145,8 @@ public class PulsoidOAuthHandler : IDisposable, IPulsoidTokenValidator
             if (httpListener != null && secondListener != null)
                 return;
 
-            HttpListener first = null;
-            HttpListener second = null;
+            HttpListener? first = null;
+            HttpListener? second = null;
             try
             {
                 first = new HttpListener { Prefixes = { Core.Constants.PulsoidOAuthRedirectUri } };
@@ -171,7 +179,7 @@ public class PulsoidOAuthHandler : IDisposable, IPulsoidTokenValidator
         }
     }
 
-    private static void CloseListenerSafely(HttpListener listener)
+    private static void CloseListenerSafely(HttpListener? listener)
     {
         if (listener == null)
             return;
@@ -273,7 +281,7 @@ public class PulsoidOAuthHandler : IDisposable, IPulsoidTokenValidator
     private class TokenInfo
     {
         [JsonProperty("scopes")]
-        public string[] Scopes { get; set; }
+        public string[]? Scopes { get; set; }
 
         [JsonProperty("expires_in")]
         public long ExpiresIn { get; set; }

--- a/vrcosc-magicchatbox/Classes/Modules/PulsoidOAuthHandler.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/PulsoidOAuthHandler.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
 using vrcosc_magicchatbox.Classes.DataAndSecurity;
@@ -16,7 +17,11 @@ namespace vrcosc_magicchatbox.Classes.Modules;
 
 public class PulsoidOAuthHandler : IDisposable, IPulsoidTokenValidator
 {
-    private bool disposed = false;
+    private const int MaxCallbackBodyChars = 16 * 1024;
+    private static readonly TimeSpan OAuthTimeout = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan CallbackReadTimeout = TimeSpan.FromSeconds(5);
+
+    private bool disposed;
 
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly INavigationService _nav;
@@ -41,15 +46,17 @@ public class PulsoidOAuthHandler : IDisposable, IPulsoidTokenValidator
                 var fragment = window.location.hash.substring(1);
                 var xhttp = new XMLHttpRequest();
                 xhttp.open('POST', 'http://localhost:7385/', true);
+                xhttp.onloadend = function() {
+                    window.location.replace('https://pulsoid.net/ui/integrations');
+                };
                 xhttp.send(fragment);
-
-                window.location.replace('https://pulsoid.net/ui/integrations');
             </script>
         </head>
         <body></body>
     </html>";
 
         var buffer = Encoding.UTF8.GetBytes(responseString);
+        response.ContentType = "text/html; charset=utf-8";
         response.ContentLength64 = buffer.Length;
         await response.OutputStream.WriteAsync(buffer, 0, buffer.Length);
         response.OutputStream.Close();
@@ -67,45 +74,59 @@ public class PulsoidOAuthHandler : IDisposable, IPulsoidTokenValidator
         }
     }
 
-    public async Task<string?> AuthenticateUserAsync(string authorizationEndpoint)
+    public async Task<string?> AuthenticateUserAsync(string authorizationEndpoint, string expectedState)
     {
+        if (string.IsNullOrWhiteSpace(expectedState))
+            throw new ArgumentException("An OAuth state value is required.", nameof(expectedState));
+
         try
         {
-            string? token = null;
-
             if (httpListener == null || secondListener == null)
                 throw new InvalidOperationException("Listeners are not started");
 
             _nav.OpenUrl(authorizationEndpoint);
 
             var redirectTask = httpListener.GetContextAsync();
-            var timeoutTask = Task.Delay(TimeSpan.FromMinutes(2));
-            if (await Task.WhenAny(redirectTask, timeoutTask) == timeoutTask)
-            {
-                Logging.WriteInfo("Pulsoid OAuth timed out waiting for browser redirect.");
-                StopListeners();
-                return null;
-            }
-
-            var context1 = await redirectTask;
-            await SendBrowserCloseResponseAsync(context1.Response);
-
             var callbackTask = secondListener.GetContextAsync();
-            var callbackTimeoutTask = Task.Delay(TimeSpan.FromMinutes(2));
-            if (await Task.WhenAny(callbackTask, callbackTimeoutTask) == callbackTimeoutTask)
-            {
-                Logging.WriteInfo("Pulsoid OAuth timed out waiting for token callback.");
-                StopListeners();
-                return null;
-            }
+            var timeoutTask = Task.Delay(OAuthTimeout);
 
-            var context2 = await callbackTask;
-            using (var reader = new StreamReader(context2.Request.InputStream))
+            while (true)
             {
-                token = await reader.ReadToEndAsync();
-            }
+                Task completed = await Task.WhenAny(redirectTask, callbackTask, timeoutTask);
+                if (completed == timeoutTask)
+                {
+                    Logging.WriteInfo("Pulsoid OAuth timed out waiting for the browser callback.");
+                    return null;
+                }
 
-            return token;
+                if (completed == redirectTask)
+                {
+                    HttpListenerContext redirect = await redirectTask;
+                    redirectTask = httpListener.GetContextAsync();
+
+                    if (!string.Equals(redirect.Request.HttpMethod, "GET", StringComparison.OrdinalIgnoreCase))
+                    {
+                        CompleteResponse(redirect.Response, HttpStatusCode.MethodNotAllowed, "GET");
+                        continue;
+                    }
+
+                    try
+                    {
+                        await SendBrowserCloseResponseAsync(redirect.Response);
+                    }
+                    catch (Exception ex) when (ex is IOException or HttpListenerException)
+                    {
+                        Logging.WriteInfo($"Pulsoid OAuth bridge response failed: {ex.Message}");
+                    }
+                    continue;
+                }
+
+                HttpListenerContext callback = await callbackTask;
+                callbackTask = secondListener.GetContextAsync();
+                string? fragment = await ReadValidatedCallbackAsync(callback, expectedState);
+                if (fragment != null)
+                    return fragment;
+            }
         }
         catch (Exception ex)
         {
@@ -116,6 +137,95 @@ public class PulsoidOAuthHandler : IDisposable, IPulsoidTokenValidator
         {
             StopListeners();
         }
+    }
+
+    private static async Task<string?> ReadValidatedCallbackAsync(
+        HttpListenerContext context,
+        string expectedState)
+    {
+        HttpListenerRequest request = context.Request;
+        if (!string.Equals(request.HttpMethod, "POST", StringComparison.OrdinalIgnoreCase))
+        {
+            CompleteResponse(context.Response, HttpStatusCode.MethodNotAllowed, "POST");
+            return null;
+        }
+
+        string? origin = request.Headers["Origin"];
+        string expectedOrigin = new Uri(Core.Constants.PulsoidOAuthRedirectUri)
+            .GetLeftPart(UriPartial.Authority);
+        if (!string.IsNullOrWhiteSpace(origin) &&
+            !string.Equals(origin, expectedOrigin, StringComparison.OrdinalIgnoreCase))
+        {
+            CompleteResponse(context.Response, HttpStatusCode.Forbidden);
+            return null;
+        }
+
+        if (request.ContentLength64 > MaxCallbackBodyChars)
+        {
+            CompleteResponse(context.Response, HttpStatusCode.RequestEntityTooLarge);
+            return null;
+        }
+
+        string? fragment;
+        try
+        {
+            using var reader = new StreamReader(request.InputStream, Encoding.UTF8);
+            using var timeout = new CancellationTokenSource(CallbackReadTimeout);
+            var buffer = new char[MaxCallbackBodyChars + 1];
+            int total = 0;
+            while (total < buffer.Length)
+            {
+                int read = await reader.ReadAsync(
+                    buffer.AsMemory(total, buffer.Length - total),
+                    timeout.Token);
+                if (read == 0)
+                    break;
+
+                total += read;
+            }
+
+            fragment = total > MaxCallbackBodyChars
+                ? null
+                : new string(buffer, 0, total);
+        }
+        catch (OperationCanceledException)
+        {
+            CompleteResponse(context.Response, HttpStatusCode.RequestTimeout);
+            return null;
+        }
+        catch (Exception ex) when (ex is IOException or HttpListenerException)
+        {
+            Logging.WriteInfo($"Pulsoid OAuth callback body could not be read: {ex.Message}");
+            CompleteResponse(context.Response, HttpStatusCode.BadRequest);
+            return null;
+        }
+
+        if (fragment == null)
+        {
+            CompleteResponse(context.Response, HttpStatusCode.RequestEntityTooLarge);
+            return null;
+        }
+
+        if (!HasExpectedState(fragment, expectedState))
+        {
+            CompleteResponse(context.Response, HttpStatusCode.BadRequest);
+            return null;
+        }
+
+        CompleteResponse(context.Response, HttpStatusCode.NoContent);
+        return fragment;
+    }
+
+    private static void CompleteResponse(
+        HttpListenerResponse response,
+        HttpStatusCode statusCode,
+        string? allowedMethod = null)
+    {
+        response.StatusCode = (int)statusCode;
+        if (allowedMethod != null)
+            response.Headers["Allow"] = allowedMethod;
+        response.ContentLength64 = 0;
+        response.Close();
     }
 
     public void Dispose()
@@ -136,6 +246,16 @@ public class PulsoidOAuthHandler : IDisposable, IPulsoidTokenValidator
             result[key] = nvc[key];
         }
         return result;
+    }
+
+    public static bool HasExpectedState(string fragmentString, string expectedState)
+    {
+        if (string.IsNullOrWhiteSpace(fragmentString) || string.IsNullOrWhiteSpace(expectedState))
+            return false;
+
+        Dictionary<string, string?> fragment = ParseQueryString(fragmentString);
+        return fragment.TryGetValue("state", out string? returnedState) &&
+               string.Equals(returnedState, expectedState, StringComparison.Ordinal);
     }
 
     public void StartListeners()

--- a/vrcosc-magicchatbox/Classes/Modules/SoundpadModule.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/SoundpadModule.cs
@@ -415,7 +415,7 @@ public partial class SoundpadModule : ObservableObject, IModule
         }
     }
 
-    public bool IsRelevantPropertyChange(string propertyName)
+    public bool IsRelevantPropertyChange(string? propertyName)
     {
         return propertyName == nameof(_integrationSettings.IntgrSoundpad) ||
                propertyName == nameof(_appState.IsVRRunning) ||
@@ -437,7 +437,7 @@ public partial class SoundpadModule : ObservableObject, IModule
     public void PlaySoundFromCategory(int categoryIndex, int soundIndex)
         => _ = SendCommandAsync($"DoPlaySoundFromCategory({categoryIndex},{soundIndex})");
 
-    public void PropertyChangedHandler(object sender, PropertyChangedEventArgs e)
+    public void PropertyChangedHandler(object? sender, PropertyChangedEventArgs e)
     {
         if (IsRelevantPropertyChange(e.PropertyName))
         {

--- a/vrcosc-magicchatbox/Classes/Modules/Spotify/SpotifyTokenRefreshOutcome.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/Spotify/SpotifyTokenRefreshOutcome.cs
@@ -1,0 +1,41 @@
+using System.Net;
+
+namespace vrcosc_magicchatbox.Classes.Modules.Spotify;
+
+public enum SpotifyTokenRefreshFailureReason
+{
+    None = 0,
+    ReauthenticationRequired,
+    Transient,
+}
+
+public sealed record SpotifyTokenRefreshOutcome
+{
+    public SpotifyTokenResult? Token { get; init; }
+
+    public SpotifyTokenRefreshFailureReason FailureReason { get; init; }
+
+    public HttpStatusCode? StatusCode { get; init; }
+
+    public string? SpotifyError { get; init; }
+
+    public string? Detail { get; init; }
+
+    public bool Succeeded => Token != null;
+
+    public static SpotifyTokenRefreshOutcome Success(SpotifyTokenResult token)
+        => new() { Token = token };
+
+    public static SpotifyTokenRefreshOutcome Failure(
+        SpotifyTokenRefreshFailureReason reason,
+        HttpStatusCode? statusCode = null,
+        string? spotifyError = null,
+        string? detail = null)
+        => new()
+        {
+            FailureReason = reason,
+            StatusCode = statusCode,
+            SpotifyError = spotifyError,
+            Detail = detail,
+        };
+}

--- a/vrcosc-magicchatbox/Classes/Modules/SpotifyModule.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/SpotifyModule.cs
@@ -451,6 +451,11 @@ public sealed partial class SpotifyModule : ObservableObject, IModule
                 return;
             }
 
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                return;
+            }
+
             bool liked = false;
             string? trackId = playback.Value?.Track?.Id;
             if (Settings.ShowLiked && !string.IsNullOrWhiteSpace(trackId))

--- a/vrcosc-magicchatbox/Classes/Modules/SpotifyModule.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/SpotifyModule.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading;
@@ -21,6 +22,14 @@ namespace vrcosc_magicchatbox.Classes.Modules;
 
 public sealed partial class SpotifyModule : ObservableObject, IModule
 {
+    private sealed class SpotifyTokenRefreshTransientException : HttpRequestException
+    {
+        public SpotifyTokenRefreshTransientException(HttpStatusCode? statusCode)
+            : base("Spotify token refresh was temporarily unavailable. Retrying shortly.", null, statusCode)
+        {
+        }
+    }
+
     private static readonly TimeSpan TokenRefreshSkew = TimeSpan.FromMinutes(1);
     private static readonly TimeSpan RefreshTimeout = TimeSpan.FromSeconds(12);
     private static readonly TimeSpan ControlTimeout = TimeSpan.FromSeconds(8);
@@ -515,9 +524,13 @@ public sealed partial class SpotifyModule : ObservableObject, IModule
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException or JsonException or InvalidOperationException)
         {
             Logging.WriteException(ex, MSGBox: false);
-            string message = ex is JsonException or InvalidOperationException
-                ? "Spotify returned an unexpected response. Retrying shortly."
-                : "Spotify refresh timed out.";
+            string message = ex switch
+            {
+                SpotifyTokenRefreshTransientException => ex.Message,
+                JsonException or InvalidOperationException =>
+                    "Spotify returned an unexpected response. Retrying shortly.",
+                _ => "Spotify refresh timed out.",
+            };
             await HandleTransientFailureAsync(message).ConfigureAwait(false);
         }
         finally
@@ -693,9 +706,14 @@ public sealed partial class SpotifyModule : ObservableObject, IModule
                 return null;
             }
 
-            var token = await _oauth.RefreshTokenAsync(Settings.ClientId, Settings.RefreshToken, cancellationToken).ConfigureAwait(false);
-            if (token == null)
+            SpotifyTokenRefreshOutcome refresh = await _oauth
+                .RefreshTokenAsync(Settings.ClientId, Settings.RefreshToken, cancellationToken)
+                .ConfigureAwait(false);
+            if (!refresh.Succeeded)
             {
+                if (refresh.FailureReason == SpotifyTokenRefreshFailureReason.Transient)
+                    throw new SpotifyTokenRefreshTransientException(refresh.StatusCode);
+
                 await _dispatcher.InvokeAsync(() =>
                 {
                     _display.NeedsReconnect = true;
@@ -705,6 +723,7 @@ public sealed partial class SpotifyModule : ObservableObject, IModule
                 return null;
             }
 
+            SpotifyTokenResult token = refresh.Token!;
             Settings.AccessToken = token.AccessToken;
             if (!string.IsNullOrWhiteSpace(token.RefreshToken))
                 Settings.RefreshToken = token.RefreshToken;

--- a/vrcosc-magicchatbox/Classes/Modules/SpotifyOAuthHandler.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/SpotifyOAuthHandler.cs
@@ -153,14 +153,17 @@ public sealed class SpotifyOAuthHandler : IDisposable
         }
     }
 
-    public async Task<SpotifyTokenResult?> RefreshTokenAsync(
+    public async Task<SpotifyTokenRefreshOutcome> RefreshTokenAsync(
         string clientId,
         string refreshToken,
         CancellationToken cancellationToken = default)
     {
         string normalizedClientId = clientId?.Trim() ?? string.Empty;
         if (string.IsNullOrWhiteSpace(normalizedClientId) || string.IsNullOrWhiteSpace(refreshToken))
-            return null;
+        {
+            return SpotifyTokenRefreshOutcome.Failure(
+                SpotifyTokenRefreshFailureReason.ReauthenticationRequired);
+        }
 
         var content = new FormUrlEncodedContent(new Dictionary<string, string>
         {
@@ -178,10 +181,24 @@ public sealed class SpotifyOAuthHandler : IDisposable
             var (error, description) = SpotifyAuthOutcome.ParseErrorBody(body);
             Logging.WriteInfo(
                 $"Spotify token refresh failed ({(int)response.StatusCode} {response.StatusCode}): {error} {description}".TrimEnd());
-            return null;
+            bool transient = response.StatusCode == HttpStatusCode.RequestTimeout ||
+                             response.StatusCode == HttpStatusCode.TooManyRequests ||
+                             (int)response.StatusCode >= 500 ||
+                             string.Equals(error, "temporarily_unavailable", StringComparison.OrdinalIgnoreCase) ||
+                             string.Equals(error, "server_error", StringComparison.OrdinalIgnoreCase);
+            return SpotifyTokenRefreshOutcome.Failure(
+                transient
+                    ? SpotifyTokenRefreshFailureReason.Transient
+                    : SpotifyTokenRefreshFailureReason.ReauthenticationRequired,
+                response.StatusCode,
+                error,
+                description);
         }
 
-        return ParseTokenResponse(body);
+        SpotifyTokenResult? token = ParseTokenResponse(body);
+        return token == null
+            ? SpotifyTokenRefreshOutcome.Failure(SpotifyTokenRefreshFailureReason.Transient)
+            : SpotifyTokenRefreshOutcome.Success(token);
     }
 
     private async Task<SpotifyAuthOutcome> ExchangeCodeAsync(string clientId, string code, string verifier)

--- a/vrcosc-magicchatbox/Classes/Modules/TTSModule.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/TTSModule.cs
@@ -132,7 +132,12 @@ public class TTSModule
 
             using var mp3Stream = new MemoryStream(audioData);
             using var mp3Reader = new Mp3FileReader(mp3Stream);
-            using var wasapiOut = new WasapiOut(device, AudioClientShareMode.Shared, false, 100);
+            using var wasapiOut = new WasapiPlayerBuilder()
+                .WithDevice(device)
+                .WithSharedMode()
+                .WithPollingSync()
+                .WithLatency(100)
+                .Build();
 
             wasapiOut.Init(mp3Reader);
             wasapiOut.Volume = _ttsSettings.TtsVolume;
@@ -142,7 +147,7 @@ public class TTSModule
 
             TimeSpan playbackBudget = mp3Reader.TotalTime + PlaybackGrace;
 
-            _oscSender.ToggleVoice();
+            _ = _oscSender.ToggleVoice();
             try
             {
                 await Task.Delay(175).ConfigureAwait(false);
@@ -164,7 +169,7 @@ public class TTSModule
             }
             finally
             {
-                _oscSender.ToggleVoice();
+                _ = _oscSender.ToggleVoice();
             }
         }
         catch (Exception ex)

--- a/vrcosc-magicchatbox/Classes/Modules/TikTokLiveModule.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/TikTokLiveModule.cs
@@ -30,6 +30,10 @@ public sealed partial class TikTokLiveModule : ObservableObject, IModule
     [GeneratedRegex("\"followerCount\"\\s*:\\s*(?<value>\\d+)", RegexOptions.CultureInvariant)]
     private static partial Regex FollowerCountRegex();
 
+    // TikTok's own status code for "user does not exist", carried in the page it still serves as 200.
+    [GeneratedRegex("\"statusCode\"\\s*:\\s*10221", RegexOptions.CultureInvariant)]
+    private static partial Regex ProfileNotFoundRegex();
+
     [GeneratedRegex("\"nickname\"\\s*:\\s*\"(?<value>(?:\\\\.|[^\"])*)\"", RegexOptions.CultureInvariant)]
     private static partial Regex NicknameRegex();
 
@@ -733,10 +737,26 @@ public sealed partial class TikTokLiveModule : ObservableObject, IModule
         if (!TryParseProfileSnapshot(html, profileUserName, out TikTokProfileSnapshot profile))
         {
             Logging.WriteInfo($"TikTok profile parser could not find followerCount for @{profileUserName}.");
-            throw new InvalidOperationException("Follower count was not available on the public profile page.");
+            throw new InvalidOperationException(DescribeMissingProfile(html, profileUserName));
         }
 
         return profile;
+    }
+
+    /// <summary>
+    /// TikTok answers 200 for a missing account and for a bot check alike, so the page itself is the
+    /// only thing that says which happened - and telling them apart is the difference between "fix
+    /// your spelling" and "wait and try again".
+    /// </summary>
+    private static string DescribeMissingProfile(string html, string profileUserName)
+    {
+        if (ProfileNotFoundRegex().IsMatch(html))
+            return $"No TikTok account called @{profileUserName}. Check the spelling.";
+
+        if (!html.Contains("__UNIVERSAL_DATA_FOR_REHYDRATION__", StringComparison.Ordinal))
+            return "TikTok returned a check page instead of the profile. It is rate-limiting this network; try again in a few minutes.";
+
+        return "TikTok did not include a follower count on this profile.";
     }
 
     private void WireClientEvents(TikTokLiveClient client, int sessionId, TaskCompletionSource<bool> disconnectedTcs)

--- a/vrcosc-magicchatbox/Classes/Modules/TikTokLiveModule.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/TikTokLiveModule.cs
@@ -24,10 +24,17 @@ namespace vrcosc_magicchatbox.Classes.Modules;
 
 public sealed partial class TikTokLiveModule : ObservableObject, IModule
 {
-    private static readonly Regex TikTokUserNameRegex = new("^[A-Za-z0-9._]{2,24}$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
-    private static readonly Regex FollowerCountRegex = new("\"followerCount\"\\s*:\\s*(?<value>\\d+)", RegexOptions.Compiled | RegexOptions.CultureInvariant);
-    private static readonly Regex NicknameRegex = new("\"nickname\"\\s*:\\s*\"(?<value>(?:\\\\.|[^\"])*)\"", RegexOptions.Compiled | RegexOptions.CultureInvariant);
-    private static readonly Regex UniqueIdRegex = new("\"uniqueId\"\\s*:\\s*\"(?<value>(?:\\\\.|[^\"])*)\"", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    [GeneratedRegex("^[A-Za-z0-9._]{2,24}$", RegexOptions.CultureInvariant)]
+    private static partial Regex TikTokUserNameRegex();
+
+    [GeneratedRegex("\"followerCount\"\\s*:\\s*(?<value>\\d+)", RegexOptions.CultureInvariant)]
+    private static partial Regex FollowerCountRegex();
+
+    [GeneratedRegex("\"nickname\"\\s*:\\s*\"(?<value>(?:\\\\.|[^\"])*)\"", RegexOptions.CultureInvariant)]
+    private static partial Regex NicknameRegex();
+
+    [GeneratedRegex("\"uniqueId\"\\s*:\\s*\"(?<value>(?:\\\\.|[^\"])*)\"", RegexOptions.CultureInvariant)]
+    private static partial Regex UniqueIdRegex();
 
     private const int CommentPreviewLength = TikTokLiveOutput.CommentPreviewLength;
     private const int UserPreviewLength = TikTokLiveOutput.UserPreviewLength;
@@ -1354,7 +1361,7 @@ public sealed partial class TikTokLiveModule : ObservableObject, IModule
         if (separatorIndex >= 0)
             text = text[..separatorIndex];
 
-        return TikTokUserNameRegex.IsMatch(text) ? text : string.Empty;
+        return TikTokUserNameRegex().IsMatch(text) ? text : string.Empty;
     }
 
     private static string ExtractUserName(User? user)
@@ -1435,18 +1442,18 @@ public sealed partial class TikTokLiveModule : ObservableObject, IModule
     private static bool TryParseProfileSnapshot(string html, string requestedUserName, out TikTokProfileSnapshot profile)
     {
         profile = default;
-        Match followerMatch = FollowerCountRegex.Match(html);
+        Match followerMatch = FollowerCountRegex().Match(html);
         if (!followerMatch.Success
             || !long.TryParse(followerMatch.Groups["value"].Value, NumberStyles.None, CultureInfo.InvariantCulture, out long followerCount))
         {
             return false;
         }
 
-        string uniqueId = ReadJsonString(UniqueIdRegex.Match(html).Groups["value"].Value);
+        string uniqueId = ReadJsonString(UniqueIdRegex().Match(html).Groups["value"].Value);
         if (string.IsNullOrWhiteSpace(uniqueId))
             uniqueId = requestedUserName;
 
-        string displayName = ReadJsonString(NicknameRegex.Match(html).Groups["value"].Value);
+        string displayName = ReadJsonString(NicknameRegex().Match(html).Groups["value"].Value);
         if (string.IsNullOrWhiteSpace(displayName))
             displayName = uniqueId;
 
@@ -1514,7 +1521,7 @@ public sealed partial class TikTokLiveModule : ObservableObject, IModule
         string OutputPreview);
 }
 
-public static class TikTokLiveOutput
+public static partial class TikTokLiveOutput
 {
     public const int UserPreviewLength = 24;
 
@@ -1522,7 +1529,8 @@ public static class TikTokLiveOutput
 
     public const int GiftNameLength = 24;
 
-    private static readonly Regex MultiSpaceRegex = new("[ \t]{2,}", RegexOptions.Compiled);
+    [GeneratedRegex("[ \t]{2,}")]
+    private static partial Regex MultiSpaceRegex();
 
     public static string Count(long value, bool compact)
     {
@@ -1559,7 +1567,7 @@ public static class TikTokLiveOutput
             rendered = rendered.Replace($"{{{token.Key}}}", token.Value ?? string.Empty, StringComparison.OrdinalIgnoreCase);
 
         rendered = rendered.Replace("\\n", "\n", StringComparison.Ordinal);
-        rendered = MultiSpaceRegex.Replace(rendered, " ");
+        rendered = MultiSpaceRegex().Replace(rendered, " ");
         return rendered.Trim();
     }
 

--- a/vrcosc-magicchatbox/Classes/Modules/TrackerBatteryModule.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/TrackerBatteryModule.cs
@@ -139,7 +139,6 @@ namespace vrcosc_magicchatbox.Classes.Modules
         private readonly IPrivacyConsentService _consentService;
         private readonly IOpenVrSessionService _session;
         private readonly IToastService? _toast;
-        private volatile bool _trackerErrorShown;
 
         public TrackerBatteryModule(
             ISettingsProvider<TrackerBatterySettings> settingsProvider,
@@ -263,7 +262,6 @@ namespace vrcosc_magicchatbox.Classes.Modules
                 return;
             }
 
-            _trackerErrorShown = false;
             var currentSerialNumbers = new HashSet<string>();
             IReadOnlyList<TrackerDevice> knownDevices = DeviceSnapshot;
 
@@ -290,7 +288,7 @@ namespace vrcosc_magicchatbox.Classes.Modules
 
                 currentSerialNumbers.Add(serial);
 
-                TrackerDevice device = knownDevices
+                TrackerDevice? device = knownDevices
                     .FirstOrDefault(d => string.Equals(d.SerialNumber, serial, StringComparison.OrdinalIgnoreCase));
 
                 if (device == null)
@@ -537,7 +535,7 @@ namespace vrcosc_magicchatbox.Classes.Modules
         {
             var error = ETrackedPropertyError.TrackedProp_Success;
             _stringBuilder.Clear();
-            _vrSystem.GetStringTrackedDeviceProperty(
+            _vrSystem?.GetStringTrackedDeviceProperty(
                 deviceIndex,
                 prop,
                 _stringBuilder,
@@ -596,7 +594,7 @@ namespace vrcosc_magicchatbox.Classes.Modules
                 return "Headset";
             }
 
-            var role = _vrSystem.GetControllerRoleForTrackedDeviceIndex(deviceIndex);
+            var role = _vrSystem?.GetControllerRoleForTrackedDeviceIndex(deviceIndex);
             if (role == ETrackedControllerRole.LeftHand)
             {
                 return "Left Hand";
@@ -650,7 +648,7 @@ namespace vrcosc_magicchatbox.Classes.Modules
             }
         }
 
-        private static void NormalizeLegacyIcon(TrackerDevice device, string deviceKind)
+        private static void NormalizeLegacyIcon(TrackerDevice device, string? deviceKind)
         {
             if (device == null)
             {
@@ -676,7 +674,7 @@ namespace vrcosc_magicchatbox.Classes.Modules
             device.CustomIcon = defaultIcon ?? string.Empty;
         }
 
-        private static string GetDefaultIcon(string deviceKind)
+        private static string GetDefaultIcon(string? deviceKind)
         {
             if (DefaultIconsByKind.TryGetValue(deviceKind ?? string.Empty, out var icon))
             {

--- a/vrcosc-magicchatbox/Classes/Modules/Twitch/TwitchApiClient.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/Twitch/TwitchApiClient.cs
@@ -17,7 +17,7 @@ public sealed class TwitchApiClient : ITwitchApiClient
     private readonly TwitchAPI _api = new();
     private readonly IHttpClientFactory _httpClientFactory;
 
-    private HttpClient _helixClient;
+    private HttpClient? _helixClient;
     private HttpClient HelixClient => _helixClient ??= _httpClientFactory.CreateClient("Twitch");
 
     private string _configuredClientId = string.Empty;

--- a/vrcosc-magicchatbox/Classes/Modules/TwitchModule.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/TwitchModule.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using TwitchLib.Api.Core.Exceptions;
 using vrcosc_magicchatbox.Classes.DataAndSecurity;
 using vrcosc_magicchatbox.Classes.Modules.Twitch;
 using vrcosc_magicchatbox.Classes.Utilities;
@@ -823,7 +824,7 @@ public sealed partial class TwitchModule : ObservableObject, IModule
         }
 
         string format = value >= 100 ? "0" : value >= 10 ? "0.#" : "0.##";
-        return $"{value.ToString(format, CultureInfo.CurrentCulture)}{suffix}";
+        return $"{value.ToString(format, CultureInfo.InvariantCulture)}{suffix}";
     }
 
     private static string ToSmallTextPreserveEmoji(string text)
@@ -936,13 +937,22 @@ public sealed partial class TwitchModule : ObservableObject, IModule
 
     private static bool IsUnauthorized(Exception ex)
     {
-        if (ex == null)
+        for (Exception? current = ex; current != null; current = current.InnerException)
         {
-            return false;
+            if (current is TokenExpiredException or BadTokenException)
+            {
+                return true;
+            }
+
+            string message = current.Message ?? string.Empty;
+            if (message.Contains("401", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("unauthorized", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("expired token", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
         }
 
-        string message = ex.Message ?? string.Empty;
-        return message.Contains("401", StringComparison.OrdinalIgnoreCase) ||
-               message.Contains("unauthorized", StringComparison.OrdinalIgnoreCase);
+        return false;
     }
 }

--- a/vrcosc-magicchatbox/Classes/Modules/TwitchModule.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/TwitchModule.cs
@@ -715,7 +715,7 @@ public sealed partial class TwitchModule : ObservableObject, IModule
         string titleLabel = useSmallText ? ToSmallTextPreserveEmoji(titleLabelSource) : titleLabelSource;
         string titleWithLabel = BuildLabeledValue(titleLabel, title);
 
-        string channel = settings.ShowChannelName ? settings.ChannelName?.Trim() : string.Empty;
+        string channel = settings.ShowChannelName ? (settings.ChannelName?.Trim() ?? string.Empty) : string.Empty;
         string channelLabelSource = string.IsNullOrWhiteSpace(settings.ChannelPrefix) ? string.Empty : settings.ChannelPrefix.Trim();
         string channelLabel = useSmallText ? ToSmallTextPreserveEmoji(channelLabelSource) : channelLabelSource;
         string channelWithLabel = BuildLabeledValue(channelLabel, channel);

--- a/vrcosc-magicchatbox/Classes/Modules/VrcLogModule.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/VrcLogModule.cs
@@ -160,7 +160,6 @@ public partial class VrcLogModule : ObservableObject, IModule
     private DateTimeOffset _appStartedAt = DateTimeOffset.UtcNow;
     private double _totalOfflineSeconds;
     private DateTime _lastSessionSave = DateTime.MinValue;
-    private bool _sessionResumed;
 
     private int _downloadSizeMB;
     private double _downloadSpeedMBps;
@@ -448,7 +447,7 @@ public partial class VrcLogModule : ObservableObject, IModule
                     if (!Directory.Exists(VrcLogDir))
                     {
                         CloseLogStream();
-                        await Task.Delay(5000, ct);
+                        await Task.Delay(5000, ct).ConfigureAwait(false);
                         continue;
                     }
 
@@ -460,7 +459,7 @@ public partial class VrcLogModule : ObservableObject, IModule
                         if (latestFile == null)
                         {
                             CloseLogStream();
-                            await Task.Delay(2000, ct);
+                            await Task.Delay(2000, ct).ConfigureAwait(false);
                             continue;
                         }
 
@@ -512,7 +511,7 @@ public partial class VrcLogModule : ObservableObject, IModule
                         _logStream ??= new FileStream(_currentLogFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                     }
 
-                    if (_logStream != null && await ReadNewLogLinesAsync(_logStream, ct))
+                    if (_logStream != null && await ReadNewLogLinesAsync(_logStream, ct).ConfigureAwait(false))
                         _lastLogActivity = DateTime.UtcNow;
 
                     lock (_stateLock)
@@ -526,7 +525,7 @@ public partial class VrcLogModule : ObservableObject, IModule
                                 string stats = Settings.TemplateSessionStats
                                     .Replace("{worlds}", _sessionWorldsVisited.ToString())
                                     .Replace("{players}", _allPlayersSeen.Count.ToString())
-                                    .Replace("{peak_session}", _peakPlayerCountThisSession.ToString());
+                                    .Replace("{peak_session}", PeakPlayerCountThisSession.ToString());
                                 SetTransient(stats, Settings.SessionStatsDuration, TransientPriority.SessionStats);
                             }
                         }
@@ -569,7 +568,7 @@ public partial class VrcLogModule : ObservableObject, IModule
                     Settings.UseWindowDetection && !_vrchatProcessDetected
                         ? IdlePollIntervalMs
                         : ActivePollIntervalMs,
-                    ct);
+                    ct).ConfigureAwait(false);
             }
         }
         finally
@@ -612,7 +611,7 @@ public partial class VrcLogModule : ObservableObject, IModule
         int read = 0;
         while (read < wanted)
         {
-            int got = await fs.ReadAsync(buffer.AsMemory(read, wanted - read), ct);
+            int got = await fs.ReadAsync(buffer.AsMemory(read, wanted - read), ct).ConfigureAwait(false);
             if (got <= 0) break;
             read += got;
         }
@@ -780,7 +779,7 @@ public partial class VrcLogModule : ObservableObject, IModule
             var logTime = ParseLogTimestamp(line);
             _worldJoinedAt = logTime > DateTime.MinValue ? logTime : DateTime.Now;
 
-            _isDownloading = false;
+            IsDownloading = false;
             _downloadSizeMB = 0;
             _downloadSpeedMBps = 0;
 
@@ -1099,12 +1098,12 @@ public partial class VrcLogModule : ObservableObject, IModule
             _pulseSequence[address] = seq;
         }
 
-        Task.Run(async () =>
+        _ = Task.Run(async () =>
         {
             try
             {
                 _oscSender.SendOscParam(address, true);
-                await Task.Delay(150);
+                await Task.Delay(150).ConfigureAwait(false);
 
                 lock (_pulseSequence)
                 {
@@ -1229,8 +1228,8 @@ public partial class VrcLogModule : ObservableObject, IModule
         }
 
         int currentCount = _currentRoomPlayers.Count;
-        if (currentCount > _peakPlayerCountThisSession)
-            _peakPlayerCountThisSession = currentCount;
+        if (currentCount > PeakPlayerCountThisSession)
+            PeakPlayerCountThisSession = currentCount;
     }
 
     private void CloseEncounter(string userId)
@@ -1305,7 +1304,7 @@ public partial class VrcLogModule : ObservableObject, IModule
             _pulseSequence.Clear();
             _pendingOwnerUserId = string.Empty;
             _peakPlayerCount = 0;
-            _peakPlayerCountThisSession = 0;
+            PeakPlayerCountThisSession = 0;
             _worldJoinedAt = DateTime.MinValue;
             _currentInstanceKey = string.Empty;
             _encounterRecords.Clear();
@@ -1382,7 +1381,6 @@ public partial class VrcLogModule : ObservableObject, IModule
             _appStartedAt = saved.AppStartedAt;
             double offlineGap = (DateTimeOffset.UtcNow - saved.LastActiveAt).TotalSeconds;
             _totalOfflineSeconds = saved.TotalOfflineSeconds + Math.Max(0, offlineGap);
-            _sessionResumed = true;
 
             Logging.WriteInfo($"VrcRadar: Resumed session — world joined {saved.WorldJoinedAt:HH:mm}, offline gap {offlineGap:F0}s, total offline {_totalOfflineSeconds:F0}s");
         }

--- a/vrcosc-magicchatbox/Classes/Modules/VrcLogModule.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/VrcLogModule.cs
@@ -64,17 +64,29 @@ public partial class VrcLogModule : ObservableObject, IModule
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "Low",
         "VRChat", "VRChat");
 
-    private static readonly Regex JoiningRegex = new(
-        @"Joining (wrld_[a-f0-9\-]+:\d+(?:~\w+\([^)]*\))*)",
-        RegexOptions.Compiled);
+    [GeneratedRegex(@"Joining (wrld_[a-f0-9\-]+:\d+(?:~\w+\([^)]*\))*)")]
+    private static partial Regex JoiningRegex();
 
-    private static readonly Regex EmptySeparatorRegex = new(@"\s*\|\s*\|\s*", RegexOptions.Compiled);
-    private static readonly Regex TrailingSeparatorRegex = new(@"(\s*\|\s*)+$", RegexOptions.Compiled);
-    private static readonly Regex LeadingSeparatorRegex = new(@"^\s*\|\s*", RegexOptions.Compiled);
-    private static readonly Regex RepeatedSpaceRegex = new(@"\s{2,}", RegexOptions.Compiled);
-    private static readonly Regex DownloadSizeRegex = new(@"@ (\d+) MB", RegexOptions.Compiled);
-    private static readonly Regex DownloadSpeedRegex = new(@"speed: (\d+) bytes per second", RegexOptions.Compiled);
-    private static readonly Regex InstanceRegionRegex = new(@"~region\((\w+)\)", RegexOptions.Compiled);
+    [GeneratedRegex(@"\s*\|\s*\|\s*")]
+    private static partial Regex EmptySeparatorRegex();
+
+    [GeneratedRegex(@"(\s*\|\s*)+$")]
+    private static partial Regex TrailingSeparatorRegex();
+
+    [GeneratedRegex(@"^\s*\|\s*")]
+    private static partial Regex LeadingSeparatorRegex();
+
+    [GeneratedRegex(@"\s{2,}")]
+    private static partial Regex RepeatedSpaceRegex();
+
+    [GeneratedRegex(@"@ (\d+) MB")]
+    private static partial Regex DownloadSizeRegex();
+
+    [GeneratedRegex(@"speed: (\d+) bytes per second")]
+    private static partial Regex DownloadSpeedRegex();
+
+    [GeneratedRegex(@"~region\((\w+)\)")]
+    private static partial Regex InstanceRegionRegex();
 
     private const int ActivePollIntervalMs = 500;
     private const int IdlePollIntervalMs = 5000;
@@ -414,10 +426,10 @@ public partial class VrcLogModule : ObservableObject, IModule
 
         text = text.Replace("{owner}", VrcLogText.Name(InstanceOwnerName));
 
-        text = EmptySeparatorRegex.Replace(text, " | ");
-        text = TrailingSeparatorRegex.Replace(text, "");
-        text = LeadingSeparatorRegex.Replace(text, "");
-        text = RepeatedSpaceRegex.Replace(text, " ");
+        text = EmptySeparatorRegex().Replace(text, " | ");
+        text = TrailingSeparatorRegex().Replace(text, "");
+        text = LeadingSeparatorRegex().Replace(text, "");
+        text = RepeatedSpaceRegex().Replace(text, " ");
         text = text.Trim();
 
         text = text.Replace("\\n", "\n").Replace("/n", "\n");
@@ -910,7 +922,7 @@ public partial class VrcLogModule : ObservableObject, IModule
 
         if (line.Contains("[AssetBundleDownloadManager] Starting download of World"))
         {
-            var sizeMatch = DownloadSizeRegex.Match(line);
+            var sizeMatch = DownloadSizeRegex().Match(line);
             if (sizeMatch.Success)
             {
                 _downloadSizeMB = int.Parse(sizeMatch.Groups[1].Value, CultureInfo.InvariantCulture);
@@ -929,7 +941,7 @@ public partial class VrcLogModule : ObservableObject, IModule
 
         if (line.Contains("[AssetBundleDownloadManager] Average download speed:"))
         {
-            var speedMatch = DownloadSpeedRegex.Match(line);
+            var speedMatch = DownloadSpeedRegex().Match(line);
             if (speedMatch.Success && _downloadSizeMB > 0)
             {
                 _downloadSpeedMBps = Math.Round(
@@ -969,7 +981,7 @@ public partial class VrcLogModule : ObservableObject, IModule
 
     private void ParseJoiningLine(string line)
     {
-        var keyMatch = JoiningRegex.Match(line);
+        var keyMatch = JoiningRegex().Match(line);
         if (keyMatch.Success)
             _currentInstanceKey = keyMatch.Groups[1].Value;
 
@@ -1003,7 +1015,7 @@ public partial class VrcLogModule : ObservableObject, IModule
         }
 
         string region = string.Empty;
-        var regionMatch = InstanceRegionRegex.Match(line);
+        var regionMatch = InstanceRegionRegex().Match(line);
         if (regionMatch.Success)
             region = regionMatch.Groups[1].Value;
 

--- a/vrcosc-magicchatbox/Classes/Modules/WeatherService.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/WeatherService.cs
@@ -35,7 +35,7 @@ public class WeatherService : IWeatherService
 
     private readonly IUiDispatcher _dispatcher;
     private readonly IPrivacyConsentService _consentService;
-    private HttpClient _client;
+    private HttpClient? _client;
     private HttpClient Client => _client ??= _httpClientFactory.CreateClient("Weather");
     private readonly object SyncLock = new object();
 
@@ -53,9 +53,9 @@ public class WeatherService : IWeatherService
     private DateTime _lastFetchUtc = DateTime.MinValue;
     private DateTime _lastSuccessUtc = DateTime.MinValue;
     private DateTime _lastLocationFetchUtc = DateTime.MinValue;
-    private WeatherLocation _location;
-    private WeatherSnapshot _snapshot;
-    private string _locationCacheKey;
+    private WeatherLocation? _location;
+    private WeatherSnapshot? _snapshot;
+    private string? _locationCacheKey;
     private readonly IReadOnlyDictionary<int, string> DefaultConditionMap = new Dictionary<int, string>
     {
         { 0, "Clear" },
@@ -198,7 +198,7 @@ public class WeatherService : IWeatherService
 
         string template = NormalizeTemplate(Settings.WeatherTemplate);
         bool hasTemplate = !string.IsNullOrWhiteSpace(template);
-        WeatherTokens tokens = BuildWeatherTokens(hasTemplate);
+        WeatherTokens? tokens = BuildWeatherTokens(hasTemplate);
         if (tokens == null)
         {
             if (Settings.WeatherFallbackMode != WeatherFallbackMode.ShowNA)
@@ -231,7 +231,7 @@ public class WeatherService : IWeatherService
             return string.Empty;
         }
 
-        WeatherSnapshot snapshot;
+        WeatherSnapshot? snapshot;
         lock (SyncLock)
         {
             snapshot = _snapshot;
@@ -245,11 +245,11 @@ public class WeatherService : IWeatherService
 
     public string BuildSampleWeatherText() => ComposeWeatherOnly(SampleSnapshot);
 
-    private string ComposeWeatherOnly(WeatherSnapshot snapshot)
+    private string ComposeWeatherOnly(WeatherSnapshot? snapshot)
     {
         string template = NormalizeTemplate(Settings.WeatherTemplate);
         bool hasTemplate = !string.IsNullOrWhiteSpace(template);
-        WeatherTokens tokens = BuildWeatherTokens(hasTemplate, snapshot);
+        WeatherTokens? tokens = BuildWeatherTokens(hasTemplate, snapshot);
         if (tokens == null)
         {
             if (Settings.WeatherFallbackMode != WeatherFallbackMode.ShowNA)
@@ -269,9 +269,9 @@ public class WeatherService : IWeatherService
         return tokens.Weather ?? string.Empty;
     }
 
-    private WeatherTokens BuildWeatherTokens(bool ignoreCustomSeparators)
+    private WeatherTokens? BuildWeatherTokens(bool ignoreCustomSeparators)
     {
-        WeatherSnapshot snapshot;
+        WeatherSnapshot? snapshot;
         lock (SyncLock)
         {
             snapshot = _snapshot;
@@ -280,7 +280,7 @@ public class WeatherService : IWeatherService
         return BuildWeatherTokens(ignoreCustomSeparators, snapshot);
     }
 
-    private WeatherTokens BuildWeatherTokens(bool ignoreCustomSeparators, WeatherSnapshot snapshot)
+    private WeatherTokens? BuildWeatherTokens(bool ignoreCustomSeparators, WeatherSnapshot? snapshot)
     {
         if (snapshot == null)
         {
@@ -572,7 +572,7 @@ public class WeatherService : IWeatherService
     {
         try
         {
-            WeatherLocation location = await GetLocationAsync().ConfigureAwait(false);
+            WeatherLocation? location = await GetLocationAsync().ConfigureAwait(false);
             if (location == null)
             {
                 return;
@@ -637,7 +637,7 @@ public class WeatherService : IWeatherService
         }
     }
 
-    private async Task<WeatherLocation> GetLocationAsync()
+    private async Task<WeatherLocation?> GetLocationAsync()
     {
         string cacheKey = BuildLocationCacheKey();
         lock (SyncLock)
@@ -650,7 +650,7 @@ public class WeatherService : IWeatherService
             }
         }
 
-        WeatherLocation location = await ResolveLocationAsync().ConfigureAwait(false);
+        WeatherLocation? location = await ResolveLocationAsync().ConfigureAwait(false);
         if (location == null)
         {
             return null;
@@ -677,7 +677,7 @@ public class WeatherService : IWeatherService
         };
     }
 
-    private async Task<WeatherLocation> ResolveLocationAsync()
+    private async Task<WeatherLocation?> ResolveLocationAsync()
     {
         switch (Settings.WeatherLocationMode)
         {
@@ -700,7 +700,7 @@ public class WeatherService : IWeatherService
         }
     }
 
-    private WeatherLocation BuildLocationFromCoordinates(double latitude, double longitude)
+    private WeatherLocation? BuildLocationFromCoordinates(double latitude, double longitude)
     {
         if (!IsValidCoordinate(latitude, longitude))
         {
@@ -710,7 +710,7 @@ public class WeatherService : IWeatherService
         return new WeatherLocation(latitude, longitude);
     }
 
-    private async Task<WeatherLocation> BuildLocationFromCityAsync(string cityName)
+    private async Task<WeatherLocation?> BuildLocationFromCityAsync(string cityName)
     {
         string city = string.IsNullOrWhiteSpace(cityName) ? DefaultCityName : cityName.Trim();
         if (string.Equals(city, DefaultCityName, StringComparison.OrdinalIgnoreCase))
@@ -736,7 +736,7 @@ public class WeatherService : IWeatherService
         return new WeatherLocation(latitude.Value, longitude.Value);
     }
 
-    private async Task<WeatherLocation> BuildLocationFromIPAsync()
+    private async Task<WeatherLocation?> BuildLocationFromIPAsync()
     {
         string response = await Client.GetStringAsync(Core.Constants.IpGeoLocationUrl).ConfigureAwait(false);
         var json = JObject.Parse(response);
@@ -774,7 +774,7 @@ public class WeatherService : IWeatherService
 
     private string MapWeatherCode(int code)
     {
-        if (!DefaultConditionMap.TryGetValue(code, out string defaultValue))
+        if (!DefaultConditionMap.TryGetValue(code, out string? defaultValue))
         {
             defaultValue = string.Empty;
         }
@@ -880,7 +880,7 @@ public class WeatherService : IWeatherService
 
     private string MapWeatherEmoji(int code)
     {
-        if (!DefaultConditionIconMap.TryGetValue(code, out string defaultIcon))
+        if (!DefaultConditionIconMap.TryGetValue(code, out string? defaultIcon))
         {
             defaultIcon = string.Empty;
         }
@@ -920,13 +920,13 @@ public class WeatherService : IWeatherService
             return new WeatherTokens(weather);
         }
 
-        public string Temp { get; }
-        public string Unit { get; }
-        public string TempWithUnit { get; }
-        public string Condition { get; }
-        public string Humidity { get; }
-        public string Wind { get; }
-        public string FeelsLike { get; }
+        public string? Temp { get; }
+        public string? Unit { get; }
+        public string? TempWithUnit { get; }
+        public string? Condition { get; }
+        public string? Humidity { get; }
+        public string? Wind { get; }
+        public string? FeelsLike { get; }
         public string Weather { get; }
     }
 

--- a/vrcosc-magicchatbox/Classes/Modules/WeatherService.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/WeatherService.cs
@@ -575,6 +575,7 @@ public class WeatherService : IWeatherService
             WeatherLocation? location = await GetLocationAsync().ConfigureAwait(false);
             if (location == null)
             {
+                ShowWeatherError(BuildLocationErrorMessage());
                 return;
             }
 
@@ -616,18 +617,15 @@ public class WeatherService : IWeatherService
         catch (Exception ex)
         {
             Logging.WriteException(ex, MSGBox: false);
-            if (!_weatherErrorShown)
+            string friendlyMsg = ex switch
             {
-                _weatherErrorShown = true;
-                string friendlyMsg = ex switch
-                {
-                    HttpRequestException => "Could not reach the weather service. Check your internet connection.",
-                    TaskCanceledException => "Weather request timed out. Will retry automatically.",
-                    _ => "Weather update failed. Check your city name in settings."
-                };
-                _toast?.Show("⛅ Weather Error", friendlyMsg, ToastType.Error, key: "weather-error");
-            }
+                HttpRequestException => "Could not reach the weather service. Check your internet connection.",
+                TaskCanceledException => "Weather request timed out. Will retry automatically.",
+                _ => "Weather update failed. Check your city name in settings."
+            };
+            ShowWeatherError(friendlyMsg);
         }
+
         finally
         {
             lock (SyncLock)
@@ -635,6 +633,30 @@ public class WeatherService : IWeatherService
                 _fetchInProgress = false;
             }
         }
+    }
+
+    private void ShowWeatherError(string message)
+    {
+        if (_weatherErrorShown)
+            return;
+
+        _weatherErrorShown = true;
+        _toast?.Show("⛅ Weather Error", message, ToastType.Error, key: "weather-error");
+    }
+
+    private string BuildLocationErrorMessage()
+    {
+        if (Settings.WeatherLocationMode == WeatherLocationMode.CustomCoordinates)
+            return "The weather coordinates are invalid. Check latitude and longitude in settings.";
+
+        if (Settings.WeatherLocationMode == WeatherLocationMode.IPBased &&
+            Settings.WeatherAllowIPLocation &&
+            _consentService.IsApproved(PrivacyHook.InternetAccess))
+        {
+            return "The weather service could not determine your location. Try a custom city instead.";
+        }
+
+        return "No weather location matched that city. Check the city name in settings.";
     }
 
     private async Task<WeatherLocation?> GetLocationAsync()

--- a/vrcosc-magicchatbox/Classes/Modules/WhisperModule.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/WhisperModule.cs
@@ -21,8 +21,8 @@ namespace vrcosc_magicchatbox.Classes.Modules
 {
     public partial class SpeechToTextLanguage : ObservableObject
     {
-        public string Code { get; set; }
-        public string Language { get; set; }
+        public string Code { get; set; } = string.Empty;
+        public string Language { get; set; } = string.Empty;
     }
 
     public partial class WhisperModuleSettings : ObservableObject
@@ -51,13 +51,13 @@ namespace vrcosc_magicchatbox.Classes.Modules
         private int selectedDeviceIndex = -1;
 
         [ObservableProperty]
-        private SpeechToTextLanguage selectedSpeechToTextLanguage;
+        private SpeechToTextLanguage? selectedSpeechToTextLanguage;
 
         [ObservableProperty]
         private int silenceAutoTurnOffDuration = 3000;
 
         [ObservableProperty]
-        private List<SpeechToTextLanguage> speechToTextLanguages;
+        private List<SpeechToTextLanguage> speechToTextLanguages = new();
 
         [ObservableProperty]
         private bool translateToCustomLanguage = false;
@@ -289,7 +289,7 @@ namespace vrcosc_magicchatbox.Classes.Modules
         private TimeSpan speakingDuration;
         private DateTime speakingStartedTimestamp;
 
-        private WaveInEvent waveIn;
+        private WaveIn? waveIn;
 
         [ObservableProperty]
         private WhisperModuleSettings settings;
@@ -302,9 +302,9 @@ namespace vrcosc_magicchatbox.Classes.Modules
         public Task StopAsync(CancellationToken ct = default) { Dispose(); return Task.CompletedTask; }
         public void SaveSettings() => Settings?.SaveSettings();
 
-        public event Action<string> TranscriptionReceived;
+        public event Action<string>? TranscriptionReceived;
 
-        public event Action SentChatMessage;
+        public event Action? SentChatMessage;
 
         public WhisperModule(IMenuNavigationService navService, ITranscriptionService transcription, IUiDispatcher dispatcher, IMessenger messenger, IToastService? toast = null)
         {
@@ -384,7 +384,7 @@ namespace vrcosc_magicchatbox.Classes.Modules
                     return;
                 }
 
-                waveIn = new WaveInEvent
+                waveIn = new WaveIn
                 {
                     DeviceNumber = Settings.SelectedDeviceIndex,
                     WaveFormat = new WaveFormat(16000, 16, 1),                    BufferMilliseconds = 350                };
@@ -399,7 +399,7 @@ namespace vrcosc_magicchatbox.Classes.Modules
             }
         }
 
-        private void OnDataAvailable(object sender, WaveInEventArgs e)
+        private void OnDataAvailable(object? sender, WaveInEventArgs e)
         {
             float maxAmplitude = CalculateMaxAmplitude(e.Buffer, e.BytesRecorded);
             bool isLoudEnough = maxAmplitude > Settings.NoiseGateThreshold;
@@ -415,7 +415,7 @@ namespace vrcosc_magicchatbox.Classes.Modules
             }
         }
 
-        private void OnRecordingStopped(object sender, StoppedEventArgs e)
+        private void OnRecordingStopped(object? sender, StoppedEventArgs e)
         {
             if (e.Exception != null)
             {
@@ -451,7 +451,7 @@ namespace vrcosc_magicchatbox.Classes.Modules
                 _transcriptionCancellationTokenSource.Dispose();
                 _transcriptionCancellationTokenSource = new CancellationTokenSource();
 
-                string transcription = await TranscribeAudioAsync(localCopyStream, _transcriptionCancellationTokenSource.Token);
+                string? transcription = await TranscribeAudioAsync(localCopyStream, _transcriptionCancellationTokenSource.Token);
                 if (!string.IsNullOrEmpty(transcription))
                 {
                     TranscriptionReceived?.Invoke(transcription);
@@ -489,7 +489,7 @@ namespace vrcosc_magicchatbox.Classes.Modules
             }
         }
 
-        private void Settings_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void Settings_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == nameof(Settings.SelectedDeviceIndex))
             {
@@ -500,12 +500,13 @@ namespace vrcosc_magicchatbox.Classes.Modules
             }
         }
 
-        private async Task<string> TranscribeAudioAsync(Stream waveFileStream, CancellationToken cancellationToken)
+        private async Task<string?> TranscribeAudioAsync(Stream waveFileStream, CancellationToken cancellationToken)
         {
             try
             {
                 using var wavMemory = new MemoryStream();
-                using (var writer = new WaveFileWriter(wavMemory, waveIn.WaveFormat))
+                // A recording session must be active for audio to have reached here, so waveIn is populated.
+                using (var writer = new WaveFileWriter(wavMemory, waveIn!.WaveFormat))
                 {
                     await waveFileStream.CopyToAsync(writer, 81920, cancellationToken);
                     await writer.FlushAsync(cancellationToken);
@@ -514,7 +515,7 @@ namespace vrcosc_magicchatbox.Classes.Modules
                 byte[] wavBytes = wavMemory.ToArray();
 
                 string modelName = GetModelDescription(Settings.SpeechToTextModel);
-                string languageCode = Settings.TranslateToCustomLanguage
+                string? languageCode = Settings.TranslateToCustomLanguage
                     ? Settings.SelectedSpeechToTextLanguage?.Code
                     : null;
 

--- a/vrcosc-magicchatbox/Classes/Modules/WindowActivityModule.cs
+++ b/vrcosc-magicchatbox/Classes/Modules/WindowActivityModule.cs
@@ -219,7 +219,7 @@ public class WindowActivityModule : vrcosc_magicchatbox.Services.IWindowActivity
         return showTitle1stCheck;
     }
 
-    private string ConstructReturnString(ProcessInfo existingProcessInfo, string processName, string windowTitle)
+    private string ConstructReturnString(ProcessInfo? existingProcessInfo, string processName, string windowTitle)
     {
         try
         {
@@ -610,7 +610,7 @@ public class WindowActivityModule : vrcosc_magicchatbox.Services.IWindowActivity
         {
             const int maxRetries = 3;
             IntPtr hwnd = IntPtr.Zero;
-            Process process = null;
+            Process? process = null;
             bool errorInhwnd = false;
             bool errorInProcess = false;
 
@@ -627,7 +627,7 @@ public class WindowActivityModule : vrcosc_magicchatbox.Services.IWindowActivity
                 GetWindowThreadProcessId(hwnd, out uint pid);
 
                 string processName;
-                string cachedProcessName = null;
+                string? cachedProcessName = null;
 
                 lock (_foregroundStateLock)
                 {
@@ -667,7 +667,7 @@ public class WindowActivityModule : vrcosc_magicchatbox.Services.IWindowActivity
 
                 string windowTitle = "";
 
-                ProcessInfo existingProcessInfo = _scannedAppsLookup.TryGetValue(processName, out ProcessInfo found)
+                ProcessInfo? existingProcessInfo = _scannedAppsLookup.TryGetValue(processName, out ProcessInfo? found)
                     ? found
                     : null;
 

--- a/vrcosc-magicchatbox/Classes/XamlCommunication/AutoUpdateModeConverter.cs
+++ b/vrcosc-magicchatbox/Classes/XamlCommunication/AutoUpdateModeConverter.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using vrcosc_magicchatbox.Core.Updates;
+
+namespace vrcosc_magicchatbox.Classes
+{
+    /// <summary>
+    /// Presents an <see cref="UpdateChannelMode"/> as a plain on/off tick for the update card.
+    /// </summary>
+    /// <remarks>
+    /// The channel has three settings and the tick only has two, so unticking it lands on
+    /// <see cref="UpdateChannelMode.Notify"/> rather than <see cref="UpdateChannelMode.Off"/>: someone
+    /// turning off automatic installing is saying "ask me first", not "stop telling me about updates".
+    /// Turning updates off entirely stays where it already is, on the Options page.
+    ///
+    /// <c>EnumEqualsConverter</c> cannot do this - its ConvertBack returns <c>Binding.DoNothing</c> when
+    /// unchecked, which is right for a radio group and would silently ignore unticking a checkbox.
+    /// </remarks>
+    public class AutoUpdateModeConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+            => value is UpdateChannelMode mode && mode == UpdateChannelMode.Auto;
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            => value is true ? UpdateChannelMode.Auto : UpdateChannelMode.Notify;
+    }
+}

--- a/vrcosc-magicchatbox/Classes/XamlCommunication/EnumDescriptionConverter.cs
+++ b/vrcosc-magicchatbox/Classes/XamlCommunication/EnumDescriptionConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.Globalization;
 using System.Windows.Data;
@@ -7,17 +8,26 @@ namespace vrcosc_magicchatbox.Classes
 {
     public class EnumDescriptionConverter : IValueConverter
     {
+        // A binding re-runs its converter whenever its source changes. Reflecting for the same attribute
+        // every time is pure repeat work, so each enum value is resolved once and remembered.
+        private static readonly ConcurrentDictionary<object, string> Descriptions = new();
+
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             if (value == null) return string.Empty;
 
-            var enumValue = value.GetType().GetField(value.ToString());
-            if (enumValue == null) return value.ToString();
+            return Descriptions.GetOrAdd(value, static v =>
+            {
+                string name = v.ToString() ?? string.Empty;
 
-            var attributes = enumValue.GetCustomAttributes(typeof(DescriptionAttribute), false);
-            return attributes.Length > 0 && attributes[0] is DescriptionAttribute attribute
-                ? attribute.Description
-                : value.ToString();
+                var field = v.GetType().GetField(name);
+                if (field == null) return name;
+
+                var attributes = field.GetCustomAttributes(typeof(DescriptionAttribute), false);
+                return attributes.Length > 0 && attributes[0] is DescriptionAttribute attribute
+                    ? attribute.Description
+                    : name;
+            });
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/vrcosc-magicchatbox/Classes/XamlCommunication/EnumEqualsConverter.cs
+++ b/vrcosc-magicchatbox/Classes/XamlCommunication/EnumEqualsConverter.cs
@@ -23,9 +23,13 @@ namespace vrcosc_magicchatbox.Classes
             if (!enumType.IsEnum)
                 return Binding.DoNothing;
 
+            string? parameterText = parameter.ToString();
+            if (parameterText == null)
+                return Binding.DoNothing;
+
             try
             {
-                return Enum.Parse(enumType, parameter.ToString(), ignoreCase: true);
+                return Enum.Parse(enumType, parameterText, ignoreCase: true);
             }
             catch (ArgumentException)
             {

--- a/vrcosc-magicchatbox/Classes/XamlCommunication/EnumEqualsConverter.cs
+++ b/vrcosc-magicchatbox/Classes/XamlCommunication/EnumEqualsConverter.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace vrcosc_magicchatbox.Classes
+{
+    public class EnumEqualsConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null || parameter == null)
+                return false;
+
+            return string.Equals(value.ToString(), parameter.ToString(), StringComparison.Ordinal);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is not bool isSelected || !isSelected || parameter == null)
+                return Binding.DoNothing;
+
+            Type enumType = Nullable.GetUnderlyingType(targetType) ?? targetType;
+            if (!enumType.IsEnum)
+                return Binding.DoNothing;
+
+            try
+            {
+                return Enum.Parse(enumType, parameter.ToString(), ignoreCase: true);
+            }
+            catch (ArgumentException)
+            {
+                return Binding.DoNothing;
+            }
+        }
+    }
+}

--- a/vrcosc-magicchatbox/Classes/XamlCommunication/TextBoxBehaviour.cs
+++ b/vrcosc-magicchatbox/Classes/XamlCommunication/TextBoxBehaviour.cs
@@ -37,7 +37,7 @@ namespace vrcosc_magicchatbox.Classes
         {
             if (e.Key == Key.Escape || e.Key == Key.Enter)
             {
-                var textBox = sender as TextBox;
+                if (sender is not TextBox textBox) return;
                 var item = textBox.DataContext as StatusItem;
                 if (item == null) return;
 

--- a/vrcosc-magicchatbox/Core/Configuration/JsonSettingsProvider.cs
+++ b/vrcosc-magicchatbox/Core/Configuration/JsonSettingsProvider.cs
@@ -27,7 +27,7 @@ public sealed class JsonSettingsProvider<T> : ISettingsProvider<T>, IDisposable 
     private readonly string _filePath;
     private readonly object _lock = new();
     private readonly object _timerLock = new();
-    private Timer _debounceTimer;
+    private Timer? _debounceTimer;
     private DateTime? _firstDirtyChangeUtc;
     private const int DebounceDelayMs = 2000;
     private const int MaxSaveDelayMs = 30000;
@@ -57,7 +57,7 @@ public sealed class JsonSettingsProvider<T> : ISettingsProvider<T>, IDisposable 
     private bool _loadFailed;
     private bool _saveFailureLogged;
 
-    public event EventHandler SettingsChanged;
+    public event EventHandler? SettingsChanged;
 
     public JsonSettingsProvider(IEnvironmentService environment)
     {
@@ -193,7 +193,7 @@ public sealed class JsonSettingsProvider<T> : ISettingsProvider<T>, IDisposable 
             {
                 try
                 {
-                    object defaultVal = prop.GetValue(defaults);
+                    object? defaultVal = prop.GetValue(defaults);
                     prop.SetValue(_settings, defaultVal);
                     anyReset = true;
                     Logging.WriteInfo(
@@ -306,7 +306,7 @@ public sealed class JsonSettingsProvider<T> : ISettingsProvider<T>, IDisposable 
             npc.PropertyChanged -= OnSettingsPropertyChanged;
     }
 
-    private void OnSettingsPropertyChanged(object sender, PropertyChangedEventArgs e)
+    private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         // A property that is never serialized cannot make the file dirty. Some modules write these at
         // 1 Hz, which otherwise defeats the debounce and forces a byte-identical save every 30 seconds.

--- a/vrcosc-magicchatbox/Core/Configuration/JsonSettingsProvider.cs
+++ b/vrcosc-magicchatbox/Core/Configuration/JsonSettingsProvider.cs
@@ -244,6 +244,10 @@ public sealed class JsonSettingsProvider<T> : ISettingsProvider<T>, IDisposable 
                     MSGBox: false);
                 NotifySaveFailed();
             }
+            else if (saved)
+            {
+                _saveFailureLogged = false;
+            }
         }
     }
 

--- a/vrcosc-magicchatbox/Core/Configuration/JsonSettingsProvider.cs
+++ b/vrcosc-magicchatbox/Core/Configuration/JsonSettingsProvider.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
@@ -30,6 +31,27 @@ public sealed class JsonSettingsProvider<T> : ISettingsProvider<T>, IDisposable 
     private DateTime? _firstDirtyChangeUtc;
     private const int DebounceDelayMs = 2000;
     private const int MaxSaveDelayMs = 30000;
+
+    /// <summary>Properties excluded from serialization, so a change to one is not a reason to save.</summary>
+    private static readonly HashSet<string> NonPersistedProperties =
+        new(
+            typeof(T)
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(p => p.GetCustomAttribute<JsonIgnoreAttribute>() != null)
+                .Select(p => p.Name),
+            StringComparer.Ordinal);
+
+    /// <summary>
+    /// Resolved once per closed generic. Every settings load used to reflect over every public property
+    /// of T looking for an attribute that is applied to almost none of them.
+    /// </summary>
+    private static readonly (PropertyInfo Property, ResetAfterVersionAttribute Attribute)[] ResettableProperties =
+        typeof(T)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.CanRead && p.CanWrite)
+            .Select(p => (Property: p, Attribute: p.GetCustomAttribute<ResetAfterVersionAttribute>()!))
+            .Where(p => p.Attribute != null)
+            .ToArray();
     private volatile bool _loaded;
     private bool _disposed;
     private bool _loadFailed;
@@ -159,16 +181,14 @@ public sealed class JsonSettingsProvider<T> : ISettingsProvider<T>, IDisposable 
             return true;
         }
 
+        if (ResettableProperties.Length == 0)
+            return false;
+
         bool anyReset = false;
         T defaults = new();
 
-        foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        foreach ((PropertyInfo prop, ResetAfterVersionAttribute attr) in ResettableProperties)
         {
-            if (!prop.CanRead || !prop.CanWrite) continue;
-
-            var attr = prop.GetCustomAttribute<ResetAfterVersionAttribute>();
-            if (attr == null) continue;
-
             if (AppVersion.IsOlderThan(loadedAppVersion, attr.MinVersion))
             {
                 try
@@ -288,6 +308,11 @@ public sealed class JsonSettingsProvider<T> : ISettingsProvider<T>, IDisposable 
 
     private void OnSettingsPropertyChanged(object sender, PropertyChangedEventArgs e)
     {
+        // A property that is never serialized cannot make the file dirty. Some modules write these at
+        // 1 Hz, which otherwise defeats the debounce and forces a byte-identical save every 30 seconds.
+        if (!string.IsNullOrEmpty(e.PropertyName) && NonPersistedProperties.Contains(e.PropertyName))
+            return;
+
         lock (_timerLock)
         {
             if (_disposed) return;

--- a/vrcosc-magicchatbox/Core/Configuration/SettingsMigrationService.cs
+++ b/vrcosc-magicchatbox/Core/Configuration/SettingsMigrationService.cs
@@ -46,7 +46,7 @@ public static class SettingsMigrationService
             return;
         }
 
-        XmlNode root = xmlDoc.SelectSingleNode("Settings");
+        XmlNode? root = xmlDoc.SelectSingleNode("Settings");
         if (root == null)
             return;
 
@@ -104,7 +104,7 @@ public static class SettingsMigrationService
 
         foreach (var entry in map)
         {
-            string xmlValue = GetXmlValue(root, entry.XmlCategory, entry.XmlKey);
+            string? xmlValue = GetXmlValue(root, entry.XmlCategory, entry.XmlKey);
             if (xmlValue == null) continue;
 
             try
@@ -112,11 +112,11 @@ public static class SettingsMigrationService
                 var prop = typeof(T).GetProperty(entry.JsonPropertyName);
                 if (prop == null || !prop.CanRead || !prop.CanWrite) continue;
 
-                object current = prop.GetValue(settings);
-                object defaultVal = prop.GetValue(defaults);
+                object? current = prop.GetValue(settings);
+                object? defaultVal = prop.GetValue(defaults);
                 if (!IsDefaultValue(current, defaultVal)) continue;
 
-                object converted = ConvertValue(xmlValue, prop.PropertyType);
+                object? converted = ConvertValue(xmlValue, prop.PropertyType);
                 if (converted == null) continue;
 
                 prop.SetValue(settings, converted);
@@ -195,14 +195,14 @@ public static class SettingsMigrationService
         }
     }
 
-    private static string GetXmlValue(XmlNode root, string category, string key)
+    private static string? GetXmlValue(XmlNode root, string category, string key)
     {
-        XmlNode catNode = root.SelectSingleNode(category);
-        XmlNode valNode = catNode?.SelectSingleNode(key);
+        XmlNode? catNode = root.SelectSingleNode(category);
+        XmlNode? valNode = catNode?.SelectSingleNode(key);
         return valNode?.InnerText;
     }
 
-    private static bool IsDefaultValue(object current, object defaultVal)
+    private static bool IsDefaultValue(object? current, object? defaultVal)
     {
         if (current == null && defaultVal == null) return true;
         if (current == null || defaultVal == null) return false;
@@ -239,28 +239,28 @@ public static class SettingsMigrationService
             _ => JsonConvert.SerializeObject(value, Newtonsoft.Json.Formatting.None)
         };
 
-    private static object ConvertValue(string value, Type targetType)
+    private static object? ConvertValue(string value, Type targetType)
     {
         if (targetType == typeof(string)) return value;
-        if (targetType == typeof(bool)) return bool.TryParse(value, out var b) ? b : (object)null;
-        if (targetType == typeof(int)) return int.TryParse(value, out var i) ? i : (object)null;
-        if (targetType == typeof(long)) return long.TryParse(value, out var l) ? l : (object)null;
-        if (targetType == typeof(uint)) return uint.TryParse(value, out var u) ? u : (object)null;
-        if (targetType == typeof(byte)) return byte.TryParse(value, out var by) ? by : (object)null;
+        if (targetType == typeof(bool)) return bool.TryParse(value, out var b) ? b : (object?)null;
+        if (targetType == typeof(int)) return int.TryParse(value, out var i) ? i : (object?)null;
+        if (targetType == typeof(long)) return long.TryParse(value, out var l) ? l : (object?)null;
+        if (targetType == typeof(uint)) return uint.TryParse(value, out var u) ? u : (object?)null;
+        if (targetType == typeof(byte)) return byte.TryParse(value, out var by) ? by : (object?)null;
         if (targetType == typeof(double))
         {
             if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var dInv))
                 return dInv;
-            return double.TryParse(value, out var dSys) ? dSys : (object)null;
+            return double.TryParse(value, out var dSys) ? dSys : (object?)null;
         }
         if (targetType == typeof(float))
         {
             if (float.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var fInv))
                 return fInv;
-            return float.TryParse(value, out var fSys) ? fSys : (object)null;
+            return float.TryParse(value, out var fSys) ? fSys : (object?)null;
         }
         if (targetType == typeof(DateTime))
-            return DateTime.TryParse(value, out var dt) ? dt : (object)null;
+            return DateTime.TryParse(value, out var dt) ? dt : (object?)null;
         if (targetType.IsEnum)
             return Enum.TryParse(targetType, value, ignoreCase: true, out var e) ? e : null;
 

--- a/vrcosc-magicchatbox/Core/Configuration/SettingsMigrationService.cs
+++ b/vrcosc-magicchatbox/Core/Configuration/SettingsMigrationService.cs
@@ -401,6 +401,8 @@ public static class SettingsMigrationService
         new("System",        "CountOculusSystemAsVR",          "CountOculusSystemAsVR"),
         new("Window",        "Topmost",                        "Topmost"),
         new("Update",        "JoinedAlphaChannel",             "JoinedAlphaChannel"),
+        new("Update",        "StableUpdateMode",               "StableUpdateMode"),
+        new("Update",        "PreReleaseUpdateMode",           "PreReleaseUpdateMode"),
         new("Update",        "CheckUpdateOnStartup",           "CheckUpdateOnStartup"),
         new("DEV",           "BlankEgg",                       "BlankEgg"),
         new("StatusSetting", "SwitchStatusInterval",           "SwitchStatusInterval"),

--- a/vrcosc-magicchatbox/Core/Diagnostics/BindingErrorProbe.cs
+++ b/vrcosc-magicchatbox/Core/Diagnostics/BindingErrorProbe.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Windows.Diagnostics;
+
+namespace vrcosc_magicchatbox.Core.Diagnostics;
+
+/// <summary>
+/// Counts WPF data-binding failures at runtime. A failed binding is re-evaluated and re-reported every
+/// time its source changes, so a broken path in a hot template is a running cost, not a one-off warning.
+/// </summary>
+public static class BindingErrorProbe
+{
+    private static readonly ConcurrentDictionary<string, int> Errors = new(StringComparer.Ordinal);
+
+    private static CountingListener? _listener;
+    private static SourceLevels _previousLevel;
+
+    public static int TotalErrors => Errors.Values.Sum();
+
+    public static int DistinctErrors => Errors.Count;
+
+    public static void Start()
+    {
+        if (!PerfProbe.IsEnabled || _listener != null)
+            return;
+
+        PresentationTraceSources.Refresh();
+
+        _listener = new CountingListener();
+        _previousLevel = PresentationTraceSources.DataBindingSource.Switch.Level;
+
+        PresentationTraceSources.DataBindingSource.Listeners.Add(_listener);
+        PresentationTraceSources.DataBindingSource.Switch.Level = SourceLevels.Error | SourceLevels.Warning;
+    }
+
+    public static void Stop()
+    {
+        if (_listener == null)
+            return;
+
+        PresentationTraceSources.DataBindingSource.Listeners.Remove(_listener);
+        PresentationTraceSources.DataBindingSource.Switch.Level = _previousLevel;
+        _listener = null;
+    }
+
+    public static string Describe(int top = 25)
+    {
+        var sb = new StringBuilder();
+        sb.Append("[Perf] Binding failures: ").Append(TotalErrors)
+            .Append(" total across ").Append(DistinctErrors).AppendLine(" distinct paths");
+
+        foreach (KeyValuePair<string, int> entry in Errors.OrderByDescending(e => e.Value).Take(top))
+            sb.Append("  ").Append(entry.Value).Append("x  ").AppendLine(entry.Key);
+
+        return sb.ToString();
+    }
+
+    private static void Report(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+            return;
+
+        // Collapse the per-instance tail (hash codes, item indices) so repeats of one broken path group.
+        string key = Normalize(message);
+        Errors.AddOrUpdate(key, 1, (_, count) => count + 1);
+    }
+
+    private static string Normalize(string message)
+    {
+        int detailStart = message.IndexOf("; target element is", StringComparison.Ordinal);
+        if (detailStart > 0)
+            message = message[..detailStart];
+
+        var sb = new StringBuilder(message.Length);
+        bool inNumber = false;
+
+        foreach (char c in message)
+        {
+            if (char.IsDigit(c))
+            {
+                if (!inNumber)
+                {
+                    sb.Append('#');
+                    inNumber = true;
+                }
+
+                continue;
+            }
+
+            inNumber = false;
+            sb.Append(c);
+        }
+
+        return sb.ToString().Trim();
+    }
+
+    private sealed class CountingListener : TraceListener
+    {
+        private readonly StringBuilder _pending = new();
+
+        public override void Write(string? message)
+        {
+            if (message != null)
+                _pending.Append(message);
+        }
+
+        public override void WriteLine(string? message)
+        {
+            _pending.Append(message);
+            Report(_pending.ToString());
+            _pending.Clear();
+        }
+    }
+}

--- a/vrcosc-magicchatbox/Core/Diagnostics/NavigationBenchmark.cs
+++ b/vrcosc-magicchatbox/Core/Diagnostics/NavigationBenchmark.cs
@@ -24,7 +24,7 @@ public static class NavigationBenchmark
         int rounds = 3)
     {
         if (!PerfProbe.IsEnabled)
-            return "[Perf] Navigation benchmark needs -perf.";
+            return "[Perf] Navigation benchmark needs --perf.";
 
         int startingPage = readPage();
         var results = new List<(int Page, double SwitchMs, long WorkingSetDeltaKb)>();

--- a/vrcosc-magicchatbox/Core/Diagnostics/NavigationBenchmark.cs
+++ b/vrcosc-magicchatbox/Core/Diagnostics/NavigationBenchmark.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+
+namespace vrcosc_magicchatbox.Core.Diagnostics;
+
+/// <summary>
+/// Drives the main menu through every page repeatedly and reports what each switch costs. Clicking by
+/// hand cannot separate build time from the transition animation or produce a stable average.
+/// </summary>
+public static class NavigationBenchmark
+{
+    public static async Task<string> RunAsync(
+        Window window,
+        Action<int> selectPage,
+        Func<int> readPage,
+        int pageCount = 4,
+        int rounds = 3)
+    {
+        if (!PerfProbe.IsEnabled)
+            return "[Perf] Navigation benchmark needs -perf.";
+
+        int startingPage = readPage();
+        var results = new List<(int Page, double SwitchMs, long WorkingSetDeltaKb)>();
+        var censuses = new Dictionary<int, string>();
+
+        PerfProbe.Mark($"Navigation benchmark starting: {rounds} rounds over {pageCount} pages");
+
+        for (int round = 0; round < rounds; round++)
+        {
+            for (int page = 0; page < pageCount; page++)
+            {
+                using var process = Process.GetCurrentProcess();
+                long beforeWorkingSet = process.WorkingSet64;
+
+                long startTicks = Stopwatch.GetTimestamp();
+                selectPage(page);
+
+                // Returning at Loaded priority means every build, bind and layout pass queued by the
+                // switch has already run, so the number covers the whole switch and not just the setter.
+                await window.Dispatcher.InvokeAsync(() => { }, DispatcherPriority.Loaded);
+                await window.Dispatcher.InvokeAsync(() => { }, DispatcherPriority.ContextIdle);
+
+                double switchMs = Stopwatch.GetElapsedTime(startTicks).TotalMilliseconds;
+
+                process.Refresh();
+                results.Add((page, switchMs, (process.WorkingSet64 - beforeWorkingSet) / 1024));
+
+                PerfProbe.Record($"nav.switch.page{page}", switchMs);
+
+                // Let the host's teardown timer fire so the next round measures a cold build.
+                await Task.Delay(TimeSpan.FromSeconds(4));
+
+                // Census only after teardown, or the count still includes the page we just left.
+                if (!censuses.ContainsKey(page))
+                    censuses[page] = VisualTreeCensus.Take(window).Describe($"page {page}");
+            }
+        }
+
+        selectPage(startingPage);
+
+        return Format(results, rounds) + string.Concat(censuses.OrderBy(c => c.Key).Select(c => c.Value));
+    }
+
+    /// <summary>
+    /// Scrolls a viewer top to bottom in viewport-sized steps, recording how long each step takes to
+    /// settle. This is what tells you whether lazily built content keeps up with a real scroll.
+    /// </summary>
+    public static async Task<string> SweepScrollAsync(ScrollViewer scroll, string label, int steps = 12)
+    {
+        if (!PerfProbe.IsEnabled || scroll == null)
+            return string.Empty;
+
+        double startOffset = scroll.VerticalOffset;
+        var stepTimes = new List<double>();
+
+        for (int i = 0; i <= steps; i++)
+        {
+            double target = scroll.ScrollableHeight * i / steps;
+
+            long startTicks = Stopwatch.GetTimestamp();
+            scroll.ScrollToVerticalOffset(target);
+
+            await scroll.Dispatcher.InvokeAsync(() => { }, DispatcherPriority.Loaded);
+            await scroll.Dispatcher.InvokeAsync(() => { }, DispatcherPriority.Background);
+
+            double ms = Stopwatch.GetElapsedTime(startTicks).TotalMilliseconds;
+            stepTimes.Add(ms);
+            PerfProbe.Record($"scroll.step.{label}", ms);
+
+            await Task.Delay(120);
+        }
+
+        scroll.ScrollToVerticalOffset(startOffset);
+
+        stepTimes.Sort();
+        return $"[Perf] Scroll sweep '{label}': {steps + 1} steps, median {stepTimes[stepTimes.Count / 2]:F1}ms, "
+            + $"worst {stepTimes[^1]:F1}ms, extent {scroll.ExtentHeight:F0}px\n";
+    }
+
+    private static string Format(List<(int Page, double SwitchMs, long WorkingSetDeltaKb)> results, int rounds)
+    {
+        var sb = new StringBuilder();
+        sb.Append("[Perf] Navigation benchmark, ").Append(rounds).AppendLine(" rounds:");
+
+        foreach (var group in results.GroupBy(r => r.Page).OrderBy(g => g.Key))
+        {
+            double mean = 0;
+            double max = 0;
+            long workingSet = 0;
+            int count = 0;
+
+            foreach ((int _, double switchMs, long deltaKb) in group)
+            {
+                mean += switchMs;
+                max = Math.Max(max, switchMs);
+                workingSet += deltaKb;
+                count++;
+            }
+
+            sb.Append("  page ").Append(group.Key)
+                .Append(": mean ").Append((mean / count).ToString("F1"))
+                .Append("ms, max ").Append(max.ToString("F1"))
+                .Append("ms, working set ").Append(workingSet / count)
+                .AppendLine("KB/switch");
+        }
+
+        return sb.ToString();
+    }
+}

--- a/vrcosc-magicchatbox/Core/Diagnostics/PerfProbe.cs
+++ b/vrcosc-magicchatbox/Core/Diagnostics/PerfProbe.cs
@@ -18,7 +18,8 @@ public static class PerfProbe
 {
     private const string EnableVariable = "MAGICCHATBOX_PERF";
 
-    public const string EnableArgument = "-perf";
+    public const string EnableArgument = "--perf";
+    public const string LegacyEnableArgument = "-perf";
 
     private static readonly ConcurrentDictionary<string, SampleSet> Samples = new(StringComparer.Ordinal);
     private static readonly ConcurrentQueue<string> Timeline = new();
@@ -40,13 +41,17 @@ public static class PerfProbe
                 return true;
 
             return Environment.GetCommandLineArgs()
-                .Any(a => string.Equals(a, EnableArgument, StringComparison.OrdinalIgnoreCase));
+                .Any(IsEnableArgument);
         }
         catch
         {
             return false;
         }
     }
+
+    public static bool IsEnableArgument(string? argument)
+        => string.Equals(argument, EnableArgument, StringComparison.OrdinalIgnoreCase) ||
+           string.Equals(argument, LegacyEnableArgument, StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Times a block and records elapsed milliseconds plus bytes allocated on the calling thread.

--- a/vrcosc-magicchatbox/Core/Diagnostics/PerfProbe.cs
+++ b/vrcosc-magicchatbox/Core/Diagnostics/PerfProbe.cs
@@ -1,0 +1,309 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+
+namespace vrcosc_magicchatbox.Core.Diagnostics;
+
+/// <summary>
+/// Opt-in performance instrumentation. Enabled by setting MAGICCHATBOX_PERF=1 or passing --perf.
+/// Every entry point short-circuits on <see cref="IsEnabled"/> so a normal run pays one static bool read.
+/// </summary>
+public static class PerfProbe
+{
+    private const string EnableVariable = "MAGICCHATBOX_PERF";
+
+    public const string EnableArgument = "-perf";
+
+    private static readonly ConcurrentDictionary<string, SampleSet> Samples = new(StringComparer.Ordinal);
+    private static readonly ConcurrentQueue<string> Timeline = new();
+    private static readonly Stopwatch ProcessClock = Stopwatch.StartNew();
+
+    private static int _timelineCount;
+
+    public static bool IsEnabled { get; } = ResolveEnabled();
+
+    /// <summary>Where <see cref="WriteReport"/> puts its JSON, alongside the NLog output.</summary>
+    public static string? ReportDirectory { get; set; }
+
+    private static bool ResolveEnabled()
+    {
+        try
+        {
+            string? variable = Environment.GetEnvironmentVariable(EnableVariable);
+            if (!string.IsNullOrWhiteSpace(variable) && variable.Trim() is not ("0" or "false" or "False"))
+                return true;
+
+            return Environment.GetCommandLineArgs()
+                .Any(a => string.Equals(a, EnableArgument, StringComparison.OrdinalIgnoreCase));
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Times a block and records elapsed milliseconds plus bytes allocated on the calling thread.
+    /// Returns a no-op token when instrumentation is off, so callers never branch.
+    /// </summary>
+    public static Scope Measure(string name) => IsEnabled ? new Scope(name) : default;
+
+    public static void Record(string name, double milliseconds, long allocatedBytes = 0)
+    {
+        if (!IsEnabled)
+            return;
+
+        Samples.GetOrAdd(name, _ => new SampleSet()).Add(milliseconds, allocatedBytes);
+    }
+
+    public static void Mark(string message)
+    {
+        if (!IsEnabled)
+            return;
+
+        // Bounded so a long session cannot grow the timeline without limit.
+        if (Interlocked.Increment(ref _timelineCount) > 4000)
+        {
+            Timeline.TryDequeue(out _);
+            Interlocked.Decrement(ref _timelineCount);
+        }
+
+        Timeline.Enqueue($"{ProcessClock.Elapsed.TotalMilliseconds:F1}\t{message}");
+    }
+
+    public static IReadOnlyDictionary<string, SampleSet.Snapshot> Snapshot()
+        => Samples.ToDictionary(p => p.Key, p => p.Value.Read(), StringComparer.Ordinal);
+
+    public static void Reset()
+    {
+        Samples.Clear();
+        while (Timeline.TryDequeue(out _))
+        {
+        }
+
+        Interlocked.Exchange(ref _timelineCount, 0);
+    }
+
+    /// <summary>Writes a JSON snapshot of every collected metric and returns the path, or null if disabled.</summary>
+    public static string? WriteReport(string reason)
+    {
+        if (!IsEnabled)
+            return null;
+
+        string directory = ReportDirectory ?? Path.Combine(Path.GetTempPath(), "MagicChatbox-perf");
+        Directory.CreateDirectory(directory);
+
+        string path = Path.Combine(
+            directory,
+            $"perf-{DateTime.Now:yyyyMMdd-HHmmss}-{Sanitize(reason)}.json");
+
+        var json = new StringBuilder();
+        json.AppendLine("{");
+        json.Append("  \"reason\": ").Append(Quote(reason)).AppendLine(",");
+        json.Append("  \"capturedAt\": ").Append(Quote(DateTimeOffset.Now.ToString("O", CultureInfo.InvariantCulture))).AppendLine(",");
+        json.Append("  \"uptimeMs\": ").Append(ProcessClock.Elapsed.TotalMilliseconds.ToString("F1", CultureInfo.InvariantCulture)).AppendLine(",");
+
+        AppendProcess(json);
+        AppendSamples(json);
+        AppendTimeline(json);
+
+        json.AppendLine("}");
+
+        File.WriteAllText(path, json.ToString());
+        return path;
+    }
+
+    private static void AppendProcess(StringBuilder json)
+    {
+        using var process = Process.GetCurrentProcess();
+
+        json.AppendLine("  \"process\": {");
+        json.Append("    \"workingSetBytes\": ").Append(process.WorkingSet64).AppendLine(",");
+        json.Append("    \"privateBytes\": ").Append(process.PrivateMemorySize64).AppendLine(",");
+        json.Append("    \"handles\": ").Append(process.HandleCount).AppendLine(",");
+        json.Append("    \"threads\": ").Append(process.Threads.Count).AppendLine(",");
+        json.Append("    \"managedHeapBytes\": ").Append(GC.GetTotalMemory(forceFullCollection: false)).AppendLine(",");
+
+        // Separates a real leak from garbage the collector simply has not got to yet; without both numbers
+        // a large heap says nothing about whether torn-down pages were actually released.
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+        json.Append("    \"managedHeapAfterFullGcBytes\": ").Append(GC.GetTotalMemory(forceFullCollection: false)).AppendLine(",");
+
+        process.Refresh();
+        json.Append("    \"workingSetAfterFullGcBytes\": ").Append(process.WorkingSet64).AppendLine(",");
+        json.Append("    \"totalAllocatedBytes\": ").Append(GC.GetTotalAllocatedBytes(precise: false)).AppendLine(",");
+        json.Append("    \"gen0\": ").Append(GC.CollectionCount(0)).AppendLine(",");
+        json.Append("    \"gen1\": ").Append(GC.CollectionCount(1)).AppendLine(",");
+        json.Append("    \"gen2\": ").Append(GC.CollectionCount(2)).AppendLine();
+        json.AppendLine("  },");
+    }
+
+    private static void AppendSamples(StringBuilder json)
+    {
+        json.AppendLine("  \"samples\": {");
+
+        var ordered = Samples
+            .Select(p => (p.Key, Value: p.Value.Read()))
+            .OrderByDescending(p => p.Value.TotalMs)
+            .ToList();
+
+        for (int i = 0; i < ordered.Count; i++)
+        {
+            (string key, SampleSet.Snapshot value) = ordered[i];
+
+            json.Append("    ").Append(Quote(key)).Append(": { ")
+                .Append("\"count\": ").Append(value.Count)
+                .Append(", \"totalMs\": ").Append(Number(value.TotalMs))
+                .Append(", \"meanMs\": ").Append(Number(value.MeanMs))
+                .Append(", \"maxMs\": ").Append(Number(value.MaxMs))
+                .Append(", \"p95Ms\": ").Append(Number(value.P95Ms))
+                .Append(", \"allocatedBytes\": ").Append(value.AllocatedBytes)
+                .Append(" }")
+                .AppendLine(i == ordered.Count - 1 ? string.Empty : ",");
+        }
+
+        json.AppendLine("  },");
+    }
+
+    private static void AppendTimeline(StringBuilder json)
+    {
+        json.AppendLine("  \"timeline\": [");
+
+        string[] entries = Timeline.ToArray();
+        for (int i = 0; i < entries.Length; i++)
+        {
+            json.Append("    ").Append(Quote(entries[i]))
+                .AppendLine(i == entries.Length - 1 ? string.Empty : ",");
+        }
+
+        json.AppendLine("  ]");
+    }
+
+    private static string Number(double value)
+        => value.ToString("F3", CultureInfo.InvariantCulture);
+
+    private static string Quote(string value)
+    {
+        var sb = new StringBuilder(value.Length + 2);
+        sb.Append('"');
+
+        foreach (char c in value)
+        {
+            switch (c)
+            {
+                case '"': sb.Append("\\\""); break;
+                case '\\': sb.Append("\\\\"); break;
+                case '\n': sb.Append("\\n"); break;
+                case '\r': sb.Append("\\r"); break;
+                case '\t': sb.Append("\\t"); break;
+                default:
+                    if (c < ' ')
+                        sb.Append("\\u").Append(((int)c).ToString("x4", CultureInfo.InvariantCulture));
+                    else
+                        sb.Append(c);
+                    break;
+            }
+        }
+
+        sb.Append('"');
+        return sb.ToString();
+    }
+
+    private static string Sanitize(string value)
+    {
+        var sb = new StringBuilder(value.Length);
+        foreach (char c in value)
+            sb.Append(char.IsLetterOrDigit(c) ? char.ToLowerInvariant(c) : '-');
+
+        return sb.ToString().Trim('-');
+    }
+
+    public readonly struct Scope : IDisposable
+    {
+        private readonly string? _name;
+        private readonly long _startTicks;
+        private readonly long _startAllocated;
+
+        internal Scope(string name)
+        {
+            _name = name;
+            _startTicks = Stopwatch.GetTimestamp();
+            _startAllocated = GC.GetAllocatedBytesForCurrentThread();
+        }
+
+        public void Dispose()
+        {
+            if (_name == null)
+                return;
+
+            double elapsedMs = Stopwatch.GetElapsedTime(_startTicks).TotalMilliseconds;
+            long allocated = GC.GetAllocatedBytesForCurrentThread() - _startAllocated;
+
+            Record(_name, elapsedMs, allocated);
+            Mark($"{_name} {elapsedMs:F1}ms {allocated / 1024.0:F0}KB");
+        }
+    }
+
+    public sealed class SampleSet
+    {
+        private readonly object _gate = new();
+        private readonly List<double> _values = new();
+
+        private long _allocatedBytes;
+
+        public void Add(double milliseconds, long allocatedBytes)
+        {
+            lock (_gate)
+            {
+                // Keep the newest window rather than every sample; percentiles stay meaningful and memory does not grow.
+                if (_values.Count == 2000)
+                    _values.RemoveAt(0);
+
+                _values.Add(milliseconds);
+                _allocatedBytes += allocatedBytes;
+            }
+        }
+
+        public Snapshot Read()
+        {
+            lock (_gate)
+            {
+                if (_values.Count == 0)
+                    return new Snapshot(0, 0, 0, 0, 0, _allocatedBytes);
+
+                double[] sorted = _values.ToArray();
+                Array.Sort(sorted);
+
+                double total = 0;
+                foreach (double v in sorted)
+                    total += v;
+
+                int p95Index = Math.Min(sorted.Length - 1, (int)Math.Ceiling(sorted.Length * 0.95) - 1);
+
+                return new Snapshot(
+                    sorted.Length,
+                    total,
+                    total / sorted.Length,
+                    sorted[^1],
+                    sorted[Math.Max(0, p95Index)],
+                    _allocatedBytes);
+            }
+        }
+
+        public readonly record struct Snapshot(
+            int Count,
+            double TotalMs,
+            double MeanMs,
+            double MaxMs,
+            double P95Ms,
+            long AllocatedBytes);
+    }
+}

--- a/vrcosc-magicchatbox/Core/Diagnostics/UiDriver.cs
+++ b/vrcosc-magicchatbox/Core/Diagnostics/UiDriver.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Automation.Peers;
+using System.Windows.Automation.Provider;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Media;
+using System.Windows.Threading;
+
+namespace vrcosc_magicchatbox.Core.Diagnostics;
+
+/// <summary>
+/// Finds and operates real controls through their automation peers, so a scripted run goes down the
+/// same path a click does - command, trigger, animation and all - rather than poking the view model
+/// and skipping everything the UI would actually have done.
+/// </summary>
+public static class UiDriver
+{
+    /// <summary>Every element of type T under <paramref name="root"/>, in visual-tree order.</summary>
+    public static List<T> FindAll<T>(DependencyObject? root) where T : DependencyObject
+    {
+        var found = new List<T>();
+        Collect(root, found);
+        return found;
+    }
+
+    private static void Collect<T>(DependencyObject? node, List<T> found) where T : DependencyObject
+    {
+        if (node == null)
+            return;
+
+        if (node is T match)
+            found.Add(match);
+
+        int count = VisualTreeHelper.GetChildrenCount(node);
+        for (int i = 0; i < count; i++)
+            Collect(VisualTreeHelper.GetChild(node, i), found);
+    }
+
+    public static T? FindByName<T>(DependencyObject? root, string name) where T : FrameworkElement
+        => FindAll<T>(root).FirstOrDefault(e => e.Name == name);
+
+    /// <summary>Clicks a button the way the automation layer does. Returns false if it could not be clicked.</summary>
+    public static bool Invoke(UIElement? element)
+    {
+        if (element is not UIElement { IsEnabled: true } target)
+            return false;
+
+        AutomationPeer? peer = UIElementAutomationPeer.CreatePeerForElement(target);
+        if (peer?.GetPattern(PatternInterface.Invoke) is IInvokeProvider invoke)
+        {
+            invoke.Invoke();
+            return true;
+        }
+
+        if (peer?.GetPattern(PatternInterface.Toggle) is IToggleProvider toggle)
+        {
+            toggle.Toggle();
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>Sets a toggle to a specific state, doing nothing when it is already there.</summary>
+    public static bool SetToggle(ToggleButton? button, bool on)
+    {
+        if (button == null || !button.IsEnabled || button.IsChecked == on)
+            return false;
+
+        AutomationPeer? peer = UIElementAutomationPeer.CreatePeerForElement(button);
+        if (peer?.GetPattern(PatternInterface.Toggle) is IToggleProvider toggle)
+        {
+            toggle.Toggle();
+            return true;
+        }
+
+        button.IsChecked = on;
+        return true;
+    }
+
+    /// <summary>
+    /// Returns once everything the last action queued has run. Two priorities, because layout is queued
+    /// at Loaded and the work layout itself queues lands behind it.
+    /// </summary>
+    public static async Task SettleAsync(Dispatcher dispatcher, int extraMs = 0)
+    {
+        await dispatcher.InvokeAsync(() => { }, DispatcherPriority.Loaded);
+        await dispatcher.InvokeAsync(() => { }, DispatcherPriority.ContextIdle);
+
+        if (extraMs > 0)
+            await Task.Delay(extraMs);
+    }
+
+    /// <summary>Scrolls a viewer top to bottom in viewport steps, settling at each one.</summary>
+    public static async Task ScrollThroughAsync(ScrollViewer scroll, int steps = 10, int dwellMs = 90)
+    {
+        if (scroll.ScrollableHeight <= 0)
+            return;
+
+        for (int i = 0; i <= steps; i++)
+        {
+            scroll.ScrollToVerticalOffset(scroll.ScrollableHeight * i / steps);
+            await SettleAsync(scroll.Dispatcher, dwellMs);
+        }
+
+        scroll.ScrollToVerticalOffset(0);
+        await SettleAsync(scroll.Dispatcher);
+    }
+}

--- a/vrcosc-magicchatbox/Core/Diagnostics/UiPerfMonitor.cs
+++ b/vrcosc-magicchatbox/Core/Diagnostics/UiPerfMonitor.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+using System.Windows;
+using System.Windows.Interop;
+using System.Windows.Media;
+using System.Windows.Threading;
+
+namespace vrcosc_magicchatbox.Core.Diagnostics;
+
+/// <summary>
+/// Watches the UI thread while the app runs: how late queued work is dispatched, how often frames are
+/// composed, and how often layout is invalidated. Only starts when <see cref="PerfProbe.IsEnabled"/>.
+/// </summary>
+public static class UiPerfMonitor
+{
+    private const int ProbeIntervalMs = 100;
+
+    private static readonly Stopwatch Clock = Stopwatch.StartNew();
+
+    private static DispatcherTimer? _stallProbe;
+    private static Window? _window;
+
+    private static long _lastProbeTicks;
+    private static long _lastRenderTicks;
+    private static long _layoutUpdates;
+    private static long _frames;
+    private static bool _started;
+    private static bool _frameSampling;
+
+    public static void Start(Window window)
+    {
+        if (!PerfProbe.IsEnabled || _started)
+            return;
+
+        _started = true;
+        _window = window;
+
+        LogEnvironment();
+
+        _lastProbeTicks = Clock.ElapsedTicks;
+        _lastRenderTicks = Clock.ElapsedTicks;
+
+        // Background priority: the gap between the interval and the actual tick is time the UI thread
+        // spent on higher-priority work, which is exactly the stall a user feels.
+        _stallProbe = new DispatcherTimer(DispatcherPriority.Background, window.Dispatcher)
+        {
+            Interval = TimeSpan.FromMilliseconds(ProbeIntervalMs),
+        };
+        _stallProbe.Tick += OnStallProbeTick;
+        _stallProbe.Start();
+
+        window.LayoutUpdated += OnLayoutUpdated;
+        window.Closed += OnWindowClosed;
+    }
+
+    /// <summary>
+    /// Samples frame intervals for <paramref name="duration"/>. Subscribing to CompositionTarget.Rendering
+    /// makes WPF composite every frame whether or not anything changed, so this cannot be left on: the
+    /// numbers it produces are the cost of measuring, not the cost of running.
+    /// </summary>
+    public static void SampleFrames(TimeSpan duration)
+    {
+        if (!PerfProbe.IsEnabled || _frameSampling)
+            return;
+
+        _frameSampling = true;
+        _lastRenderTicks = Clock.ElapsedTicks;
+        CompositionTarget.Rendering += OnRendering;
+
+        var stop = new DispatcherTimer(DispatcherPriority.Normal, Dispatcher.CurrentDispatcher)
+        {
+            Interval = duration,
+        };
+
+        stop.Tick += (_, _) =>
+        {
+            stop.Stop();
+            CompositionTarget.Rendering -= OnRendering;
+            _frameSampling = false;
+        };
+
+        stop.Start();
+    }
+
+    public static void Stop()
+    {
+        if (!_started)
+            return;
+
+        _started = false;
+
+        if (_stallProbe != null)
+        {
+            _stallProbe.Stop();
+            _stallProbe.Tick -= OnStallProbeTick;
+            _stallProbe = null;
+        }
+
+        if (_frameSampling)
+        {
+            CompositionTarget.Rendering -= OnRendering;
+            _frameSampling = false;
+        }
+
+        if (_window != null)
+        {
+            _window.LayoutUpdated -= OnLayoutUpdated;
+            _window.Closed -= OnWindowClosed;
+            _window = null;
+        }
+    }
+
+    public static long LayoutUpdateCount => _layoutUpdates;
+
+    public static long FrameCount => _frames;
+
+    private static void OnWindowClosed(object? sender, EventArgs e) => Stop();
+
+    private static void OnStallProbeTick(object? sender, EventArgs e)
+    {
+        long now = Clock.ElapsedTicks;
+        double actualMs = TicksToMs(now - _lastProbeTicks);
+        _lastProbeTicks = now;
+
+        double lateBy = actualMs - ProbeIntervalMs;
+        if (lateBy > 0)
+            PerfProbe.Record("ui.dispatcher.stall", lateBy);
+    }
+
+    private static void OnRendering(object? sender, EventArgs e)
+    {
+        long now = Clock.ElapsedTicks;
+        double frameMs = TicksToMs(now - _lastRenderTicks);
+        _lastRenderTicks = now;
+
+        _frames++;
+
+        // The first tick after an idle gap is not a dropped frame, it is the compositor waking up.
+        if (frameMs < 250)
+            PerfProbe.Record("ui.frame.interval", frameMs);
+    }
+
+    private static void OnLayoutUpdated(object? sender, EventArgs e) => _layoutUpdates++;
+
+    private static void LogEnvironment()
+    {
+        var sb = new StringBuilder();
+
+        int tier = RenderCapability.Tier >> 16;
+        sb.Append("[Perf] Render tier ").Append(tier);
+        sb.Append(", pixel shader 3.0 supported: ").Append(RenderCapability.IsPixelShaderVersionSupported(3, 0));
+        sb.Append(", max texture ").Append(RenderCapability.MaxHardwareTextureSize);
+        sb.Append(", DPI ").Append(GetDpiScale().ToString("F2", CultureInfo.InvariantCulture));
+        sb.Append(", processors ").Append(Environment.ProcessorCount);
+        sb.Append(", server GC ").Append(System.Runtime.GCSettings.IsServerGC);
+
+        Classes.DataAndSecurity.Logging.WriteInfo(sb.ToString());
+        PerfProbe.Mark(sb.ToString());
+    }
+
+    private static double GetDpiScale()
+    {
+        try
+        {
+            if (_window != null && PresentationSource.FromVisual(_window) is HwndSource source)
+                return source.CompositionTarget?.TransformToDevice.M11 ?? 1.0;
+        }
+        catch
+        {
+            // Diagnostics must never take the app down.
+        }
+
+        return 1.0;
+    }
+
+    private static double TicksToMs(long ticks)
+        => ticks * 1000.0 / Stopwatch.Frequency;
+}

--- a/vrcosc-magicchatbox/Core/Diagnostics/UiScenarioRunner.cs
+++ b/vrcosc-magicchatbox/Core/Diagnostics/UiScenarioRunner.cs
@@ -39,7 +39,7 @@ public sealed class UiScenarioRunner
     public async Task<string> RunAsync()
     {
         if (!PerfProbe.IsEnabled)
-            return "[Scenario] needs -perf.\n";
+            return "[Scenario] needs --perf.\n";
 
         Line($"Scenario start. Profile data path: {AppDomain.CurrentDomain.FriendlyName}");
 

--- a/vrcosc-magicchatbox/Core/Diagnostics/UiScenarioRunner.cs
+++ b/vrcosc-magicchatbox/Core/Diagnostics/UiScenarioRunner.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using vrcosc_magicchatbox.Classes.Modules;
+
+namespace vrcosc_magicchatbox.Core.Diagnostics;
+
+/// <summary>
+/// Drives the whole app the way a user would - every page, every Options section expanded, every
+/// integration switched on - and records what each step cost. Measuring the app at rest with the
+/// integrations off says nothing about what it does while it is actually working.
+/// </summary>
+/// <remarks>
+/// Run this against a throwaway profile (<c>-profile=9</c>), never a real one: it toggles integrations
+/// and expands sections, and those are persisted settings.
+/// </remarks>
+public sealed class UiScenarioRunner
+{
+    private readonly Window _window;
+    private readonly IntegrationSettings _integrations;
+    private readonly Action<int> _selectPage;
+    private readonly StringBuilder _report = new();
+
+    private readonly Dictionary<string, bool> _originalToggles = new(StringComparer.Ordinal);
+
+    public UiScenarioRunner(Window window, IntegrationSettings integrations, Action<int> selectPage)
+    {
+        _window = window;
+        _integrations = integrations;
+        _selectPage = selectPage;
+    }
+
+    public async Task<string> RunAsync()
+    {
+        if (!PerfProbe.IsEnabled)
+            return "[Scenario] needs -perf.\n";
+
+        Line($"Scenario start. Profile data path: {AppDomain.CurrentDomain.FriendlyName}");
+
+        await VisitEveryPageAsync();
+        await ExpandEveryOptionsSectionAsync();
+        await EnableEveryIntegrationAsync();
+        await SoakAsync(TimeSpan.FromSeconds(30), "integrations on");
+        await VisitEveryPageAsync("with integrations on");
+        await RestoreIntegrationsAsync();
+
+        return _report.ToString();
+    }
+
+    private async Task VisitEveryPageAsync(string label = "cold")
+    {
+        Line($"-- pages ({label}) --");
+
+        for (int page = 0; page < 4; page++)
+        {
+            long start = Stopwatch.GetTimestamp();
+            _selectPage(page);
+            await UiDriver.SettleAsync(_window.Dispatcher);
+
+            double ms = Stopwatch.GetElapsedTime(start).TotalMilliseconds;
+            PerfProbe.Record($"scenario.page{page}.{Slug(label)}", ms);
+
+            // Past the host's 3s teardown delay, or the census still counts the page we just left and
+            // every page reads as the sum of the ones before it.
+            await Task.Delay(TimeSpan.FromSeconds(4));
+
+            VisualTreeCensus.Result census = VisualTreeCensus.Take(_window);
+            Line($"page {page} ({label}): {ms:F0}ms, {census.Total} elements, "
+                + $"{census.Effects} effects, {census.UnfrozenBrushes} unfrozen brushes");
+
+            ScrollViewer? scroll = UiDriver.FindAll<ScrollViewer>(_window).FirstOrDefault(s => s.ScrollableHeight > 0);
+            if (scroll != null)
+                await UiDriver.ScrollThroughAsync(scroll, steps: 8);
+
+            await Task.Delay(400);
+        }
+    }
+
+    private async Task ExpandEveryOptionsSectionAsync()
+    {
+        Line("-- expanding every Options section --");
+
+        _selectPage(3);
+        await UiDriver.SettleAsync(_window.Dispatcher, 400);
+
+        // Realizing every section first: a collapsed placeholder has no toggle to click.
+        var page = UiDriver.FindAll<UI.Pages.OptionsPage>(_window).FirstOrDefault();
+        if (page == null)
+        {
+            Line("Options page not found; skipping.");
+            return;
+        }
+
+        page.RealizeAllSectionsForDiagnostics();
+        await UiDriver.SettleAsync(_window.Dispatcher, 500);
+
+        // Only the section headers. Every CheckBox is also a ToggleButton, so matching on the type alone
+        // clicks 250-odd real settings instead of expanding 24 sections.
+        List<ToggleButton> toggles = UiDriver.FindAll<ToggleButton>(page)
+            .Where(t => t.IsEnabled && t.IsChecked == false && IsSectionHeader(t))
+            .ToList();
+
+        Line($"found {toggles.Count} collapsed section headers");
+
+        int opened = 0;
+        foreach (ToggleButton toggle in toggles)
+        {
+            long start = Stopwatch.GetTimestamp();
+            if (!UiDriver.SetToggle(toggle, true))
+                continue;
+
+            // Settle only - no dwell - or the dwell is what gets measured.
+            await UiDriver.SettleAsync(_window.Dispatcher);
+            PerfProbe.Record("scenario.section.expand", Stopwatch.GetElapsedTime(start).TotalMilliseconds);
+            opened++;
+        }
+
+        VisualTreeCensus.Result census = VisualTreeCensus.Take(_window);
+        Line($"expanded {opened} toggles -> {census.Total} elements, depth {census.MaxDepth}, "
+            + $"{census.Effects} effects, {census.PartialOpacity} at partial opacity");
+
+        ScrollViewer? scroll = UiDriver.FindAll<ScrollViewer>(page).FirstOrDefault();
+        if (scroll != null)
+        {
+            Line($"extent with everything open: {scroll.ExtentHeight:F0}px");
+            await UiDriver.ScrollThroughAsync(scroll, steps: 16);
+        }
+
+        foreach (ToggleButton toggle in toggles)
+            UiDriver.SetToggle(toggle, false);
+
+        await UiDriver.SettleAsync(_window.Dispatcher, 300);
+    }
+
+    private async Task EnableEveryIntegrationAsync()
+    {
+        Line("-- switching every integration on --");
+
+        foreach ((string name, Action<bool> set, Func<bool> get) in IntegrationToggles())
+        {
+            _originalToggles[name] = get();
+
+            long start = Stopwatch.GetTimestamp();
+            set(true);
+
+            // Settle only. Timing a dwell measures the dwell.
+            await UiDriver.SettleAsync(_window.Dispatcher);
+            double ms = Stopwatch.GetElapsedTime(start).TotalMilliseconds;
+
+            PerfProbe.Record($"scenario.enable.{name}", ms);
+            Line($"enable {name}: {ms:F0}ms");
+
+            // Now give the module time to actually start before enabling the next one.
+            await Task.Delay(300);
+        }
+    }
+
+    private async Task RestoreIntegrationsAsync()
+    {
+        Line("-- restoring integration toggles --");
+
+        foreach ((string name, Action<bool> set, Func<bool> _) in IntegrationToggles())
+        {
+            if (_originalToggles.TryGetValue(name, out bool original))
+                set(original);
+        }
+
+        await UiDriver.SettleAsync(_window.Dispatcher, 500);
+    }
+
+    private async Task SoakAsync(TimeSpan duration, string label)
+    {
+        Line($"-- soak {duration.TotalSeconds:F0}s ({label}) --");
+
+        using var process = Process.GetCurrentProcess();
+        long startAllocated = GC.GetTotalAllocatedBytes(precise: false);
+        int gen0 = GC.CollectionCount(0);
+        process.Refresh();
+        long startWorkingSet = process.WorkingSet64;
+        int startHandles = process.HandleCount;
+
+        await Task.Delay(duration);
+
+        process.Refresh();
+        long allocated = GC.GetTotalAllocatedBytes(precise: false) - startAllocated;
+
+        Line($"soak: {allocated / 1024 / 1024} MB allocated, {GC.CollectionCount(0) - gen0} gen0 collections, "
+            + $"working set {(process.WorkingSet64 - startWorkingSet) / 1024 / 1024:+0;-0} MB, "
+            + $"handles {process.HandleCount - startHandles:+0;-0}, threads {process.Threads.Count}");
+    }
+
+    private static bool IsSectionHeader(ToggleButton toggle)
+        => toggle.Style is { } style
+        && ReferenceEquals(style, toggle.TryFindResource("ExpandCollapseToggleButtonStyle"));
+
+    private IEnumerable<(string Name, Action<bool> Set, Func<bool> Get)> IntegrationToggles()
+    {
+        yield return ("Status", v => _integrations.IntgrStatus = v, () => _integrations.IntgrStatus);
+        yield return ("WindowActivity", v => _integrations.IntgrScanWindowActivity = v, () => _integrations.IntgrScanWindowActivity);
+        yield return ("Time", v => _integrations.IntgrScanWindowTime = v, () => _integrations.IntgrScanWindowTime);
+        yield return ("HeartRate", v => _integrations.IntgrHeartRate = v, () => _integrations.IntgrHeartRate);
+        yield return ("NetworkStatistics", v => _integrations.IntgrNetworkStatistics = v, () => _integrations.IntgrNetworkStatistics);
+        yield return ("MediaLink", v => _integrations.IntgrScanMediaLink = v, () => _integrations.IntgrScanMediaLink);
+        yield return ("ComponentStats", v => _integrations.IntgrComponentStats = v, () => _integrations.IntgrComponentStats);
+        yield return ("Soundpad", v => _integrations.IntgrSoundpad = v, () => _integrations.IntgrSoundpad);
+        yield return ("Voicemod", v => _integrations.IntgrVoicemod = v, () => _integrations.IntgrVoicemod);
+        yield return ("Twitch", v => _integrations.IntgrTwitch = v, () => _integrations.IntgrTwitch);
+        yield return ("TikTokLive", v => _integrations.IntgrTikTokLive = v, () => _integrations.IntgrTikTokLive);
+        yield return ("Discord", v => _integrations.IntgrDiscord = v, () => _integrations.IntgrDiscord);
+        yield return ("Spotify", v => _integrations.IntgrSpotify = v, () => _integrations.IntgrSpotify);
+        yield return ("VrcRadar", v => _integrations.IntgrVrcRadar = v, () => _integrations.IntgrVrcRadar);
+        yield return ("TrackerBattery", v => _integrations.IntgrTrackerBattery = v, () => _integrations.IntgrTrackerBattery);
+        yield return ("VrPerformance", v => _integrations.IntgrVrPerformance = v, () => _integrations.IntgrVrPerformance);
+        yield return ("Lyrics", v => _integrations.IntgrLyrics = v, () => _integrations.IntgrLyrics);
+    }
+
+    private void Line(string text)
+    {
+        _report.Append("[Scenario] ").AppendLine(text);
+        PerfProbe.Mark(text);
+    }
+
+    private static string Slug(string text)
+        => new(text.Select(c => char.IsLetterOrDigit(c) ? char.ToLowerInvariant(c) : '-').ToArray());
+}

--- a/vrcosc-magicchatbox/Core/Diagnostics/VisualTreeCensus.cs
+++ b/vrcosc-magicchatbox/Core/Diagnostics/VisualTreeCensus.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Media;
+using System.Windows.Shapes;
+
+namespace vrcosc_magicchatbox.Core.Diagnostics;
+
+/// <summary>
+/// Walks a live visual tree and counts the things that cost render and layout time, so a claim about a
+/// page can be checked against what WPF actually built rather than against the XAML source.
+/// </summary>
+public static class VisualTreeCensus
+{
+    public static Result Take(DependencyObject root)
+    {
+        var result = new Result();
+        Walk(root, 0, result);
+        return result;
+    }
+
+    private static void Walk(DependencyObject node, int depth, Result result)
+    {
+        result.Total++;
+        result.MaxDepth = Math.Max(result.MaxDepth, depth);
+
+        string typeName = node.GetType().Name;
+        result.ByType[typeName] = result.ByType.TryGetValue(typeName, out int count) ? count + 1 : 1;
+
+        if (node is UIElement element)
+        {
+            if (element.Effect != null)
+            {
+                result.Effects++;
+                result.EffectOwners.Add($"{typeName} ({element.Effect.GetType().Name})");
+            }
+
+            if (element.Visibility == Visibility.Hidden)
+                result.HiddenNotCollapsed++;
+
+            if (element.Opacity is > 0 and < 1)
+                result.PartialOpacity++;
+
+            if (element.CacheMode != null)
+                result.CacheModes++;
+        }
+
+        if (node is Shape shapeLike && shapeLike.Fill is Brush fill && !fill.IsFrozen)
+            result.UnfrozenBrushes++;
+
+        if (node is Control control)
+        {
+            if (control.Background is { IsFrozen: false })
+                result.UnfrozenBrushes++;
+
+            if (control.Foreground is { IsFrozen: false })
+                result.UnfrozenBrushes++;
+        }
+
+        if (node is Border border && border.Background is { IsFrozen: false })
+            result.UnfrozenBrushes++;
+
+        if (node is ItemsControl items)
+            RecordItemsControl(items, typeName, result);
+
+        int children = VisualTreeHelper.GetChildrenCount(node);
+        for (int i = 0; i < children; i++)
+            Walk(VisualTreeHelper.GetChild(node, i), depth + 1, result);
+    }
+
+    private static void RecordItemsControl(ItemsControl items, string typeName, Result result)
+    {
+        // The attached property says what was asked for; only the realised items host says what was got.
+        Panel? host = FindItemsHost(items);
+
+        result.ItemsControls.Add(new ItemsControlInfo(
+            typeName,
+            items.Name,
+            items.Items.Count,
+            host is VirtualizingPanel,
+            items.ItemsSource != null,
+            VirtualizingPanel.GetVirtualizationMode(items).ToString(),
+            ScrollViewer.GetCanContentScroll(items),
+            host?.GetType().Name ?? "(not realised)"));
+    }
+
+    private static Panel? FindItemsHost(DependencyObject node)
+    {
+        int children = VisualTreeHelper.GetChildrenCount(node);
+
+        for (int i = 0; i < children; i++)
+        {
+            DependencyObject child = VisualTreeHelper.GetChild(node, i);
+
+            if (child is Panel { IsItemsHost: true } panel)
+                return panel;
+
+            // Stop at a nested ItemsControl so an outer list does not claim an inner list's panel.
+            if (child is ItemsControl)
+                continue;
+
+            if (FindItemsHost(child) is { } found)
+                return found;
+        }
+
+        return null;
+    }
+
+    public sealed class Result
+    {
+        public int Total { get; set; }
+
+        public int MaxDepth { get; set; }
+
+        public int Effects { get; set; }
+
+        public int HiddenNotCollapsed { get; set; }
+
+        public int PartialOpacity { get; set; }
+
+        public int CacheModes { get; set; }
+
+        public int UnfrozenBrushes { get; set; }
+
+        public Dictionary<string, int> ByType { get; } = new(StringComparer.Ordinal);
+
+        public List<string> EffectOwners { get; } = new();
+
+        public List<ItemsControlInfo> ItemsControls { get; } = new();
+
+        public string Describe(string label, int topTypes = 15)
+        {
+            var sb = new StringBuilder();
+
+            sb.Append("[Perf] Visual tree '").Append(label).Append("': ")
+                .Append(Total).Append(" elements, depth ").Append(MaxDepth)
+                .Append(", effects ").Append(Effects)
+                .Append(", Hidden-not-Collapsed ").Append(HiddenNotCollapsed)
+                .Append(", partial opacity ").Append(PartialOpacity)
+                .Append(", unfrozen brushes ").Append(UnfrozenBrushes)
+                .Append(", CacheMode ").Append(CacheModes)
+                .AppendLine();
+
+            sb.Append("  types: ").AppendLine(string.Join(", ", ByType
+                .OrderByDescending(p => p.Value)
+                .Take(topTypes)
+                .Select(p => $"{p.Key}={p.Value}")));
+
+            if (EffectOwners.Count > 0)
+                sb.Append("  effects on: ").AppendLine(string.Join(", ", EffectOwners.Distinct().Take(20)));
+
+            foreach (ItemsControlInfo info in ItemsControls.OrderByDescending(i => i.ItemCount))
+            {
+                sb.Append("  ").Append(info.TypeName);
+                if (!string.IsNullOrEmpty(info.Name))
+                    sb.Append(" x:Name=").Append(info.Name);
+
+                sb.Append(": items ").Append(info.ItemCount)
+                    .Append(", panel ").Append(info.ItemsHostType)
+                    .Append(", virtualizing ").Append(info.IsVirtualizing)
+                    .Append(", bound ").Append(info.HasItemsSource)
+                    .Append(", mode ").Append(info.VirtualizationMode)
+                    .Append(", canContentScroll ").Append(info.CanContentScroll)
+                    .AppendLine();
+            }
+
+            return sb.ToString();
+        }
+    }
+
+    public readonly record struct ItemsControlInfo(
+        string TypeName,
+        string? Name,
+        int ItemCount,
+        bool IsVirtualizing,
+        bool HasItemsSource,
+        string VirtualizationMode,
+        bool CanContentScroll,
+        string ItemsHostType);
+}

--- a/vrcosc-magicchatbox/Core/Osc/Providers/MediaLinkOscProvider.cs
+++ b/vrcosc-magicchatbox/Core/Osc/Providers/MediaLinkOscProvider.cs
@@ -89,7 +89,7 @@ public sealed class MediaLinkOscProvider : IOscProvider
         if (ShouldSuppressSpotifySessions(context.IsVRRunning))
             sessions = sessions.Where(s => !IsSpotifySession(s));
 
-        MediaSessionInfo session = sessions.FirstOrDefault();
+        MediaSessionInfo? session = sessions.FirstOrDefault();
         if (session == null)
             return BuildNoSessionText();
 
@@ -292,7 +292,7 @@ public sealed class MediaLinkOscProvider : IOscProvider
         }
     }
 
-    private static SeekbarStyleOptions ToSeekbarOptions(MediaLinkStyle style)
+    private static SeekbarStyleOptions ToSeekbarOptions(MediaLinkStyle? style)
     {
         if (style == null)
         {

--- a/vrcosc-magicchatbox/Core/Osc/Providers/SoundpadOscProvider.cs
+++ b/vrcosc-magicchatbox/Core/Osc/Providers/SoundpadOscProvider.cs
@@ -39,7 +39,7 @@ public sealed class SoundpadOscProvider : IOscProvider
     {
         if (!_intgr.IntgrSoundpad) return null;
 
-        string playingSong = _modules.Value.Soundpad?.GetPlayingSong();
+        string playingSong = _modules.Value.Soundpad?.GetPlayingSong() ?? string.Empty;
         if (string.IsNullOrEmpty(playingSong)) return null;
 
         string text = BuildSegment(playingSong, _app.PrefixIconSoundpad, context.RemainingCharsIf(string.Empty));

--- a/vrcosc-magicchatbox/Core/Privacy/PrivacyConsentService.cs
+++ b/vrcosc-magicchatbox/Core/Privacy/PrivacyConsentService.cs
@@ -12,7 +12,7 @@ public sealed class PrivacyConsentService : IPrivacyConsentService
     private readonly object _stateLock = new();
     private PrivacySettings Settings => _provider.Value;
 
-    public event EventHandler<ConsentChangedEventArgs> ConsentChanged;
+    public event EventHandler<ConsentChangedEventArgs> ConsentChanged = delegate { };
 
     public PrivacyConsentService(ISettingsProvider<PrivacySettings> provider)
     {

--- a/vrcosc-magicchatbox/Core/Services/IAudioService.cs
+++ b/vrcosc-magicchatbox/Core/Services/IAudioService.cs
@@ -8,6 +8,6 @@ public interface IAudioService
     bool PopulateOutputDevices();
 
     void InvalidateOutputDeviceCache();
-    List<Voice> ReadTikTokTTSVoices();
+    List<Voice>? ReadTikTokTTSVoices();
     void EnsureLogDirectoryExists(string filePath);
 }

--- a/vrcosc-magicchatbox/Core/Updates/PendingUpdate.cs
+++ b/vrcosc-magicchatbox/Core/Updates/PendingUpdate.cs
@@ -1,0 +1,103 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Globalization;
+using System.IO;
+
+namespace vrcosc_magicchatbox.Core.Updates;
+
+public sealed record PendingUpdateInfo(
+    string Version,
+    UpdateChannel Channel,
+    string StagedPath,
+    string Sha256,
+    DateTimeOffset StagedAtUtc);
+
+public static class PendingUpdate
+{
+    private const string FileName = "pending_update.json";
+
+    public static string PathFor(string dataPath) => Path.Combine(dataPath, FileName);
+
+    public static bool Write(string dataPath, PendingUpdateInfo info)
+    {
+        try
+        {
+            Directory.CreateDirectory(dataPath);
+
+            var payload = new JObject(
+                new JProperty("version", info.Version ?? string.Empty),
+                new JProperty("channel", info.Channel.ToString()),
+                new JProperty("stagedPath", info.StagedPath ?? string.Empty),
+                new JProperty("sha256", info.Sha256 ?? string.Empty),
+                new JProperty("stagedAtUtc", info.StagedAtUtc.ToString("o")));
+
+            string path = PathFor(dataPath);
+            string temporary = path + ".tmp";
+            File.WriteAllText(temporary, payload.ToString());
+            File.Move(temporary, path, overwrite: true);
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    public static PendingUpdateInfo Read(string dataPath)
+    {
+        try
+        {
+            string path = PathFor(dataPath);
+            if (!File.Exists(path))
+                return null;
+
+            string json = File.ReadAllText(path);
+            if (string.IsNullOrWhiteSpace(json))
+                return null;
+
+            // Date recognition is turned off so the timestamp survives as the text that was
+            // written. Left on, it is converted to a local DateTime while parsing and comes back
+            // out in whatever format the machine's culture prefers.
+            using var reader = new JsonTextReader(new StringReader(json))
+            {
+                DateParseHandling = DateParseHandling.None,
+            };
+
+            JObject payload = JObject.Load(reader);
+
+            if (!Enum.TryParse(payload.Value<string>("channel"), out UpdateChannel channel))
+                channel = UpdateChannel.Stable;
+
+            DateTimeOffset.TryParse(
+                payload.Value<string>("stagedAtUtc"),
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.RoundtripKind,
+                out DateTimeOffset stagedAt);
+
+            return new PendingUpdateInfo(
+                payload.Value<string>("version") ?? string.Empty,
+                channel,
+                payload.Value<string>("stagedPath") ?? string.Empty,
+                payload.Value<string>("sha256") ?? string.Empty,
+                stagedAt);
+        }
+        catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is JsonException)
+        {
+            return null;
+        }
+    }
+
+    public static void Clear(string dataPath)
+    {
+        try
+        {
+            string path = PathFor(dataPath);
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/vrcosc-magicchatbox/Core/Updates/PendingUpdate.cs
+++ b/vrcosc-magicchatbox/Core/Updates/PendingUpdate.cs
@@ -44,7 +44,7 @@ public static class PendingUpdate
         }
     }
 
-    public static PendingUpdateInfo Read(string dataPath)
+    public static PendingUpdateInfo? Read(string dataPath)
     {
         try
         {

--- a/vrcosc-magicchatbox/Core/Updates/ReleaseVersion.cs
+++ b/vrcosc-magicchatbox/Core/Updates/ReleaseVersion.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace vrcosc_magicchatbox.Core.Updates;
+
+public static class ReleaseVersion
+{
+    private static readonly Regex LeadingNumber = new(
+        @"^\s*v?(\d+(?:\.\d+)*)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    public static string Normalize(string? tag)
+    {
+        if (string.IsNullOrWhiteSpace(tag))
+            return string.Empty;
+
+        Match match = LeadingNumber.Match(tag);
+        return match.Success ? match.Groups[1].Value : string.Empty;
+    }
+
+    public static int Compare(string? left, string? right)
+    {
+        (string leftNumbers, string leftSuffix) = Split(left);
+        (string rightNumbers, string rightSuffix) = Split(right);
+
+        int byNumber = CompareNumbers(leftNumbers, rightNumbers);
+        if (byNumber != 0)
+            return byNumber;
+
+        // Semantic versioning ranks a suffixed build below the plain release it leads up to,
+        // so an -rc build must never be treated as newer than the version it is a candidate for.
+        bool leftIsPre = leftSuffix.Length > 0;
+        bool rightIsPre = rightSuffix.Length > 0;
+
+        if (leftIsPre != rightIsPre)
+            return leftIsPre ? -1 : 1;
+
+        return string.CompareOrdinal(leftSuffix, rightSuffix);
+    }
+
+    private static (string Numbers, string Suffix) Split(string? tag)
+    {
+        if (string.IsNullOrWhiteSpace(tag))
+            return (string.Empty, string.Empty);
+
+        Match match = LeadingNumber.Match(tag);
+        if (!match.Success)
+            return (string.Empty, string.Empty);
+
+        string remainder = tag[(match.Index + match.Length)..];
+
+        int buildMetadata = remainder.IndexOf('+');
+        if (buildMetadata >= 0)
+            remainder = remainder[..buildMetadata];
+
+        return (match.Groups[1].Value, remainder.Trim().TrimStart('-', '.'));
+    }
+
+    private static int CompareNumbers(string left, string right)
+    {
+        string[] leftParts = left.Length == 0 ? [] : left.Split('.');
+        string[] rightParts = right.Length == 0 ? [] : right.Split('.');
+        int length = Math.Max(leftParts.Length, rightParts.Length);
+
+        for (int i = 0; i < length; i++)
+        {
+            int leftSegment = SegmentAt(leftParts, i);
+            int rightSegment = SegmentAt(rightParts, i);
+
+            if (leftSegment != rightSegment)
+                return leftSegment.CompareTo(rightSegment);
+        }
+
+        return 0;
+    }
+
+    private static int SegmentAt(string[] parts, int index)
+        => index < parts.Length && int.TryParse(parts[index], out int value) ? value : 0;
+}

--- a/vrcosc-magicchatbox/Core/Updates/ReleaseVersion.cs
+++ b/vrcosc-magicchatbox/Core/Updates/ReleaseVersion.cs
@@ -3,18 +3,17 @@ using System.Text.RegularExpressions;
 
 namespace vrcosc_magicchatbox.Core.Updates;
 
-public static class ReleaseVersion
+public static partial class ReleaseVersion
 {
-    private static readonly Regex LeadingNumber = new(
-        @"^\s*v?(\d+(?:\.\d+)*)",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    [GeneratedRegex(@"^\s*v?(\d+(?:\.\d+)*)", RegexOptions.CultureInvariant)]
+    private static partial Regex LeadingNumber();
 
     public static string Normalize(string? tag)
     {
         if (string.IsNullOrWhiteSpace(tag))
             return string.Empty;
 
-        Match match = LeadingNumber.Match(tag);
+        Match match = LeadingNumber().Match(tag);
         return match.Success ? match.Groups[1].Value : string.Empty;
     }
 
@@ -43,7 +42,7 @@ public static class ReleaseVersion
         if (string.IsNullOrWhiteSpace(tag))
             return (string.Empty, string.Empty);
 
-        Match match = LeadingNumber.Match(tag);
+        Match match = LeadingNumber().Match(tag);
         if (!match.Success)
             return (string.Empty, string.Empty);
 

--- a/vrcosc-magicchatbox/Core/Updates/StartupHealthBeacon.cs
+++ b/vrcosc-magicchatbox/Core/Updates/StartupHealthBeacon.cs
@@ -1,0 +1,108 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.IO;
+
+namespace vrcosc_magicchatbox.Core.Updates;
+
+public sealed record StartupHealth(
+    bool StartInProgress,
+    int ConsecutiveFailures,
+    string AutoInstalledVersion)
+{
+    public static readonly StartupHealth Clean = new(false, 0, string.Empty);
+}
+
+public readonly record struct StartupHealthCheck(
+    bool PreviousStartFailed,
+    int ConsecutiveFailures,
+    string AutoInstalledVersion)
+{
+    public bool WasAutoInstalled => !string.IsNullOrWhiteSpace(AutoInstalledVersion);
+}
+
+/// <summary>
+/// Records whether the last launch ever reached a working state. An unattended install has no
+/// human watching it land, so this is the only way a build that dies during startup can be
+/// noticed and undone.
+/// </summary>
+public static class StartupHealthBeacon
+{
+    private const string FileName = "startup_health.json";
+
+    public static string PathFor(string dataPath) => Path.Combine(dataPath, FileName);
+
+    public static StartupHealth Read(string dataPath)
+    {
+        try
+        {
+            string path = PathFor(dataPath);
+            if (!File.Exists(path))
+                return StartupHealth.Clean;
+
+            string json = File.ReadAllText(path);
+            if (string.IsNullOrWhiteSpace(json))
+                return StartupHealth.Clean;
+
+            JObject payload = JObject.Parse(json);
+
+            return new StartupHealth(
+                payload.Value<bool>("startInProgress"),
+                payload.Value<int>("consecutiveFailures"),
+                payload.Value<string>("autoInstalledVersion") ?? string.Empty);
+        }
+        catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is JsonException)
+        {
+            return StartupHealth.Clean;
+        }
+    }
+
+    public static StartupHealthCheck MarkStarting(string dataPath)
+    {
+        StartupHealth previous = Read(dataPath);
+
+        int failures = previous.StartInProgress ? previous.ConsecutiveFailures + 1 : 0;
+
+        Save(dataPath, new StartupHealth(true, failures, previous.AutoInstalledVersion));
+
+        return new StartupHealthCheck(previous.StartInProgress, failures, previous.AutoInstalledVersion);
+    }
+
+    public static void MarkHealthy(string dataPath)
+        => Save(dataPath, StartupHealth.Clean);
+
+    public static void RecordAutoInstall(string dataPath, string version)
+    {
+        StartupHealth previous = Read(dataPath);
+        Save(dataPath, previous with { AutoInstalledVersion = version ?? string.Empty });
+    }
+
+    private static void Save(string dataPath, StartupHealth health)
+    {
+        try
+        {
+            Directory.CreateDirectory(dataPath);
+
+            var payload = new JObject(
+                new JProperty("startInProgress", health.StartInProgress),
+                new JProperty("consecutiveFailures", health.ConsecutiveFailures),
+                new JProperty("autoInstalledVersion", health.AutoInstalledVersion ?? string.Empty));
+
+            // Written straight through to disk: the crash this beacon exists to catch would
+            // otherwise take the record of it down with the process.
+            using var stream = new FileStream(
+                PathFor(dataPath),
+                FileMode.Create,
+                FileAccess.Write,
+                FileShare.None);
+            using var writer = new StreamWriter(stream);
+
+            writer.Write(payload.ToString());
+            writer.Flush();
+            stream.Flush(flushToDisk: true);
+        }
+        catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/vrcosc-magicchatbox/Core/Updates/UpdateBlocklist.cs
+++ b/vrcosc-magicchatbox/Core/Updates/UpdateBlocklist.cs
@@ -1,0 +1,74 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace vrcosc_magicchatbox.Core.Updates;
+
+/// <summary>
+/// Versions that were installed automatically and then failed to start. Without this the next
+/// check would keep offering the build that was just rolled back.
+/// </summary>
+public static class UpdateBlocklist
+{
+    private const string FileName = "blocked_updates.json";
+    private const int MaxEntries = 20;
+
+    public static string PathFor(string dataPath) => Path.Combine(dataPath, FileName);
+
+    public static IReadOnlyList<string> Read(string dataPath)
+    {
+        try
+        {
+            string path = PathFor(dataPath);
+            if (!File.Exists(path))
+                return [];
+
+            string json = File.ReadAllText(path);
+            if (string.IsNullOrWhiteSpace(json))
+                return [];
+
+            return JArray.Parse(json)
+                .Select(entry => entry.Value<string>())
+                .Where(version => !string.IsNullOrWhiteSpace(version))
+                .ToArray();
+        }
+        catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is JsonException)
+        {
+            return [];
+        }
+    }
+
+    public static IReadOnlyList<string> Add(string dataPath, string version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+            return Read(dataPath);
+
+        List<string> versions = Read(dataPath).ToList();
+
+        if (versions.Any(existing => ReleaseVersion.Compare(existing, version) == 0))
+            return versions;
+
+        versions.Add(version);
+
+        if (versions.Count > MaxEntries)
+            versions.RemoveRange(0, versions.Count - MaxEntries);
+
+        try
+        {
+            Directory.CreateDirectory(dataPath);
+
+            string path = PathFor(dataPath);
+            string temporary = path + ".tmp";
+            File.WriteAllText(temporary, new JArray(versions).ToString());
+            File.Move(temporary, path, overwrite: true);
+        }
+        catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+        {
+        }
+
+        return versions;
+    }
+}

--- a/vrcosc-magicchatbox/Core/Updates/UpdateBlocklist.cs
+++ b/vrcosc-magicchatbox/Core/Updates/UpdateBlocklist.cs
@@ -32,6 +32,7 @@ public static class UpdateBlocklist
 
             return JArray.Parse(json)
                 .Select(entry => entry.Value<string>())
+                .OfType<string>()
                 .Where(version => !string.IsNullOrWhiteSpace(version))
                 .ToArray();
         }

--- a/vrcosc-magicchatbox/Core/Updates/UpdateChannels.cs
+++ b/vrcosc-magicchatbox/Core/Updates/UpdateChannels.cs
@@ -1,0 +1,14 @@
+namespace vrcosc_magicchatbox.Core.Updates;
+
+public enum UpdateChannel
+{
+    Stable,
+    PreRelease,
+}
+
+public enum UpdateChannelMode
+{
+    Off,
+    Notify,
+    Auto,
+}

--- a/vrcosc-magicchatbox/Core/Updates/UpdateDecision.cs
+++ b/vrcosc-magicchatbox/Core/Updates/UpdateDecision.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace vrcosc_magicchatbox.Core.Updates;
+
+public enum UpdateAction
+{
+    None,
+    Notify,
+    AutoInstall,
+}
+
+public enum UpdateStanding
+{
+    UpToDate,
+    UpdateAvailable,
+    AheadOfReleases,
+}
+
+public readonly record struct UpdateOffer(UpdateChannel Channel, string Version, string Url, string Digest)
+{
+    public static UpdateOffer Absent(UpdateChannel channel)
+        => new(channel, string.Empty, string.Empty, string.Empty);
+
+    public bool IsPresent => !string.IsNullOrWhiteSpace(Version) && !string.IsNullOrWhiteSpace(Url);
+}
+
+public sealed record UpdateVerdict(
+    UpdateStanding Standing,
+    UpdateAction Action,
+    UpdateChannel? Channel,
+    string Version,
+    string Url,
+    string Digest);
+
+public static class UpdateDecision
+{
+    public static UpdateVerdict Decide(
+        string? currentVersion,
+        UpdateOffer stable,
+        UpdateOffer preRelease,
+        UpdateChannelMode stableMode,
+        UpdateChannelMode preReleaseMode,
+        IReadOnlyCollection<string>? blockedVersions = null)
+    {
+        List<(UpdateOffer Offer, UpdateChannelMode Mode)> candidates = [];
+
+        Consider(stable, stableMode);
+        Consider(preRelease, preReleaseMode);
+
+        // An armed channel must never be starved by a merely-watched one: a newer pre-release
+        // sitting on Notify cannot swallow the stable build the user asked to have installed.
+        var armed = candidates.Where(candidate => candidate.Mode == UpdateChannelMode.Auto).ToList();
+        if (armed.Count > 0)
+            return Offer(Best(armed), UpdateAction.AutoInstall);
+
+        if (candidates.Count > 0)
+            return Offer(Best(candidates), UpdateAction.Notify);
+
+        return Settled();
+
+        void Consider(UpdateOffer offer, UpdateChannelMode mode)
+        {
+            if (mode == UpdateChannelMode.Off || !offer.IsPresent)
+                return;
+
+            if (ReleaseVersion.Compare(currentVersion, offer.Version) >= 0)
+                return;
+
+            if (IsBlocked(offer.Version))
+                return;
+
+            candidates.Add((offer, mode));
+        }
+
+        bool IsBlocked(string version)
+            => blockedVersions is not null
+               && blockedVersions.Any(blocked => ReleaseVersion.Compare(blocked, version) == 0);
+
+        UpdateVerdict Offer(UpdateOffer offer, UpdateAction action)
+            => new(UpdateStanding.UpdateAvailable, action, offer.Channel, offer.Version, offer.Url, offer.Digest);
+
+        UpdateVerdict Settled()
+        {
+            bool levelWithPreRelease =
+                preReleaseMode != UpdateChannelMode.Off
+                && preRelease.IsPresent
+                && ReleaseVersion.Compare(currentVersion, preRelease.Version) == 0;
+
+            if (levelWithPreRelease)
+                return Idle(UpdateStanding.UpToDate, UpdateChannel.PreRelease);
+
+            bool aheadOfStable = stable.IsPresent && ReleaseVersion.Compare(currentVersion, stable.Version) > 0;
+            bool aheadOfPreRelease = !preRelease.IsPresent
+                                     || ReleaseVersion.Compare(currentVersion, preRelease.Version) > 0;
+
+            if (aheadOfStable && aheadOfPreRelease)
+                return Idle(UpdateStanding.AheadOfReleases, null);
+
+            bool levelWithStable = stable.IsPresent
+                                   && ReleaseVersion.Compare(currentVersion, stable.Version) == 0;
+
+            return Idle(UpdateStanding.UpToDate, levelWithStable ? UpdateChannel.Stable : null);
+        }
+
+        UpdateVerdict Idle(UpdateStanding standing, UpdateChannel? channel)
+            => new(standing, UpdateAction.None, channel, currentVersion ?? string.Empty, string.Empty, string.Empty);
+    }
+
+    private static UpdateOffer Best(List<(UpdateOffer Offer, UpdateChannelMode Mode)> candidates)
+        => candidates
+            .OrderByDescending(candidate => candidate.Offer.Version, VersionOrder.Instance)
+            .ThenBy(candidate => candidate.Offer.Channel)
+            .First()
+            .Offer;
+
+    private sealed class VersionOrder : IComparer<string>
+    {
+        public static readonly VersionOrder Instance = new();
+
+        public int Compare(string? x, string? y) => ReleaseVersion.Compare(x, y);
+    }
+}

--- a/vrcosc-magicchatbox/MagicChatbox.csproj
+++ b/vrcosc-magicchatbox/MagicChatbox.csproj
@@ -33,6 +33,14 @@
 		<Prefer32Bit>false</Prefer32Bit>
 		<SatelliteResourceLanguages>en</SatelliteResourceLanguages>
 		<AllowedReferenceRelatedFileExtensions>none</AllowedReferenceRelatedFileExtensions>
+		<!-- Precompiles the app's own IL so the startup path is not JIT-compiled on every launch. -->
+		<PublishReadyToRun>true</PublishReadyToRun>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<!-- Nothing in the app consumes INotifyPropertyChanging, so the toolkit default only adds an
+		     event raise and an EventArgs allocation to every one of ~990 observable property setters. -->
+		<MvvmToolkitEnableINotifyPropertyChangingSupport>false</MvvmToolkitEnableINotifyPropertyChangingSupport>
 	</PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/vrcosc-magicchatbox/MagicChatbox.csproj
+++ b/vrcosc-magicchatbox/MagicChatbox.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-	<Version>0.9.225</Version>
+	<Version>0.9.226</Version>
     <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
     <RootNamespace>vrcosc_magicchatbox</RootNamespace>
     <Nullable>enable</Nullable>

--- a/vrcosc-magicchatbox/MagicChatbox.csproj
+++ b/vrcosc-magicchatbox/MagicChatbox.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-	<Version>0.9.223</Version>
+	<Version>0.9.225</Version>
     <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
     <RootNamespace>vrcosc_magicchatbox</RootNamespace>
     <Nullable>enable</Nullable>

--- a/vrcosc-magicchatbox/MagicChatbox.csproj
+++ b/vrcosc-magicchatbox/MagicChatbox.csproj
@@ -33,13 +33,17 @@
 		<Prefer32Bit>false</Prefer32Bit>
 		<SatelliteResourceLanguages>en</SatelliteResourceLanguages>
 		<AllowedReferenceRelatedFileExtensions>none</AllowedReferenceRelatedFileExtensions>
-		<!-- Precompiles the app's own IL so the startup path is not JIT-compiled on every launch. -->
-		<PublishReadyToRun>true</PublishReadyToRun>
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<!-- Nothing in the app consumes INotifyPropertyChanging, so the toolkit default only adds an
-		     event raise and an EventArgs allocation to every one of ~990 observable property setters. -->
+		<PublishReadyToRun>true</PublishReadyToRun>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PublishReadyToRunExclude Include="SixLabors.ImageSharp.dll" />
+	</ItemGroup>
+
+	<PropertyGroup>		
 		<MvvmToolkitEnableINotifyPropertyChangingSupport>false</MvvmToolkitEnableINotifyPropertyChangingSupport>
 	</PropertyGroup>
 
@@ -247,7 +251,6 @@
     <PackageReference Include="TwitchLib.Api" Version="3.10.2" />
     <PackageReference Include="OpenVR.NET" Version="0.8.5" />
 	<PackageReference Include="SixLabors.ImageSharp" Version="2.1.13" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.11" />
     <PackageReference Include="TikTokLive_Sharp" Version="1.2.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.11" />

--- a/vrcosc-magicchatbox/MagicChatbox.csproj
+++ b/vrcosc-magicchatbox/MagicChatbox.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-	<Version>0.9.222</Version>
+	<Version>0.9.223</Version>
     <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
     <RootNamespace>vrcosc_magicchatbox</RootNamespace>
     <Nullable>enable</Nullable>

--- a/vrcosc-magicchatbox/MainWindow.xaml
+++ b/vrcosc-magicchatbox/MainWindow.xaml
@@ -506,13 +506,26 @@
                                 </LinearGradientBrush>
                             </Border.Background>
                             <StackPanel>
+                                <!--
+                                    One grid for both rows, so the check button and the tick share a
+                                    column and cannot drift apart. Its own row rather than beside the
+                                    version, because the panel is about 200px wide and squeezing all
+                                    three onto one line clipped the word INSTALLED.
+                                -->
                                 <Grid>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*" />
                                         <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
 
-                                    <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                    <StackPanel
+                                        Grid.Row="0"
+                                        Grid.Column="0"
+                                        VerticalAlignment="Center">
                                         <TextBlock
                                             FontFamily="/Fonts/#Albert Sans"
                                             FontSize="{StaticResource FontSizeMicro}"
@@ -529,8 +542,11 @@
 
                                     <Button
                                         x:Name="CheckUpdateBtnn"
+                                        Grid.Row="0"
                                         Grid.Column="1"
+                                        Margin="8,0,0,0"
                                         Padding="0"
+                                        HorizontalAlignment="Center"
                                         VerticalAlignment="Center"
                                         Command="{Binding CheckUpdateCommand}"
                                         Style="{StaticResource CircleButton}"
@@ -541,6 +557,26 @@
                                             RenderOptions.BitmapScalingMode="Linear"
                                             Source="/Img/Icons/Load_ico.png" />
                                     </Button>
+
+                                    <!--
+                                        Spanning both columns puts the tick on the same right edge as
+                                        the button above it, and makes the whole row the click target
+                                        rather than a 14px square.
+                                    -->
+                                    <CheckBox
+                                        x:Name="AutoUpdateToggle"
+                                        Grid.Row="1"
+                                        Grid.Column="0"
+                                        Grid.ColumnSpan="2"
+                                        Margin="0,10,0,0"
+                                        HorizontalAlignment="Stretch"
+                                        FontFamily="/Fonts/#Albert Sans"
+                                        Foreground="#FF9186B5"
+                                        IsChecked="{Binding AppSettingsInstance.StableUpdateMode, Converter={StaticResource AutoUpdateModeConverter}, Mode=TwoWay}"
+                                        Style="{StaticResource CompactCheckBox}"
+                                        ToolTip="Install stable updates on their own. Untick it and MagicChatbox will tell you about them instead.">
+                                        Auto update
+                                    </CheckBox>
                                 </Grid>
 
                                 <Border

--- a/vrcosc-magicchatbox/MainWindow.xaml
+++ b/vrcosc-magicchatbox/MainWindow.xaml
@@ -1052,6 +1052,10 @@
                         </StackPanel>
 
 
+                        <!--
+                            Keeping the window in front lives on the Options page; this spot is worth
+                            more to the switch you want before putting a headset on.
+                        -->
                         <StackPanel
                             Margin="0,8,0,2"
                             HorizontalAlignment="Right"
@@ -1061,12 +1065,13 @@
                                 FontFamily="/Fonts/#Albert Sans"
                                 FontSize="12"
                                 Foreground="{StaticResource TextSecondaryBrush}"
-                                Text="TopMost" />
+                                Text="Auto start in VR" />
                             <CheckBox
                                 Margin="4,0,0,0"
                                 FontSize="12"
-                                IsChecked="{Binding AppSettingsInstance.Topmost, Mode=TwoWay}"
-                                Style="{DynamicResource SettingsCheckbox}" />
+                                IsChecked="{Binding AppSettingsInstance.StartWithSteamVr, Mode=TwoWay}"
+                                Style="{DynamicResource SettingsCheckbox}"
+                                ToolTip="Start MagicChatbox with SteamVR and open it straight to the tray." />
                         </StackPanel>
                         <StackPanel
                             Margin="0,2"

--- a/vrcosc-magicchatbox/MainWindow.xaml
+++ b/vrcosc-magicchatbox/MainWindow.xaml
@@ -568,7 +568,7 @@
                                         Grid.Row="1"
                                         Grid.Column="0"
                                         Grid.ColumnSpan="2"
-                                        Margin="0,10,0,0"
+                                        Margin="0,2,3,-5"
                                         HorizontalAlignment="Stretch"
                                         FontFamily="/Fonts/#Albert Sans"
                                         Foreground="#FF9186B5"

--- a/vrcosc-magicchatbox/MainWindow.xaml.cs
+++ b/vrcosc-magicchatbox/MainWindow.xaml.cs
@@ -628,6 +628,27 @@ namespace vrcosc_magicchatbox
             if (Environment.GetEnvironmentVariable("MAGICCHATBOX_PERF_NAVBENCH") == "1")
                 RunNavigationBenchmarkAsync();
 
+            if (Environment.GetEnvironmentVariable("MAGICCHATBOX_PERF_SCENARIO") == "1")
+                RunUiScenarioAsync();
+        }
+
+        private async void RunUiScenarioAsync()
+        {
+            if (DataContext is not ViewModel viewModel)
+                return;
+
+            await Task.Delay(TimeSpan.FromSeconds(10));
+
+            var integrations = App.Services
+                .GetRequiredService<Core.Configuration.ISettingsProvider<IntegrationSettings>>().Value;
+
+            var runner = new Core.Diagnostics.UiScenarioRunner(
+                this,
+                integrations,
+                index => viewModel.SelectedMenuIndex = index);
+
+            Logging.WriteInfo(await runner.RunAsync());
+            DumpPerfSnapshot("ui-scenario");
         }
 
         private async void RunNavigationBenchmarkAsync()

--- a/vrcosc-magicchatbox/MainWindow.xaml.cs
+++ b/vrcosc-magicchatbox/MainWindow.xaml.cs
@@ -10,6 +10,7 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Shell;
 using System.Windows.Threading;
+using Microsoft.Extensions.DependencyInjection;
 using vrcosc_magicchatbox.Classes.DataAndSecurity;
 using vrcosc_magicchatbox.Classes.Modules;
 using vrcosc_magicchatbox.Core.Configuration;
@@ -288,6 +289,9 @@ namespace vrcosc_magicchatbox
             ContentRendered += OnFirstContentRendered;
             Loaded += MainWindow_Loaded;
             IsVisibleChanged += MainWindow_IsVisibleChanged;
+
+            if (Core.Diagnostics.PerfProbe.IsEnabled)
+                PreviewKeyDown += OnPerfDumpRequested;
         }
 
         public void ApplyIntegrationOrder()
@@ -563,8 +567,125 @@ namespace vrcosc_magicchatbox
             ContentRendered -= OnFirstContentRendered;
             _hasRendered = true;
 
+            Core.Diagnostics.UiPerfMonitor.Start(this);
+            Core.Diagnostics.PerfProbe.Mark("MainWindow first content rendered");
+            StartPerfAutoDump();
+
             if (_revealWanted)
                 Reveal();
+        }
+
+        /// <summary>Ctrl+Shift+F12 dumps a snapshot, Ctrl+Shift+F11 runs the navigation benchmark. -perf only.</summary>
+        private async void OnPerfDumpRequested(object sender, KeyEventArgs e)
+        {
+            if (!Core.Diagnostics.PerfProbe.IsEnabled
+                || Keyboard.Modifiers != (ModifierKeys.Control | ModifierKeys.Shift))
+            {
+                return;
+            }
+
+            if (e.Key == Key.F12)
+            {
+                e.Handled = true;
+                DumpPerfSnapshot("hotkey");
+                return;
+            }
+
+            if (e.Key != Key.F11 || DataContext is not ViewModel viewModel)
+                return;
+
+            e.Handled = true;
+            Logging.WriteInfo("[Perf] Navigation benchmark started; the window will cycle pages.");
+
+            string report = await Core.Diagnostics.NavigationBenchmark.RunAsync(
+                this,
+                index => viewModel.SelectedMenuIndex = index,
+                () => viewModel.SelectedMenuIndex);
+
+            Logging.WriteInfo(report);
+            DumpPerfSnapshot("nav-benchmark");
+        }
+
+        private void StartPerfAutoDump()
+        {
+            if (!Core.Diagnostics.PerfProbe.IsEnabled)
+                return;
+
+            // Periodic dumps make a soak run self-recording; without them a snapshot needs someone at the keyboard.
+            var timer = new DispatcherTimer(DispatcherPriority.ApplicationIdle, Dispatcher)
+            {
+                Interval = TimeSpan.FromSeconds(60),
+            };
+            timer.Tick += (_, _) => DumpPerfSnapshot("auto");
+            timer.Start();
+
+            Closed += (_, _) =>
+            {
+                timer.Stop();
+                DumpPerfSnapshot("shutdown");
+            };
+
+            if (Environment.GetEnvironmentVariable("MAGICCHATBOX_PERF_NAVBENCH") == "1")
+                RunNavigationBenchmarkAsync();
+
+        }
+
+        private async void RunNavigationBenchmarkAsync()
+        {
+            if (DataContext is not ViewModel viewModel)
+                return;
+
+            // Let the first page settle so the benchmark measures switches and not the tail of startup.
+            await Task.Delay(TimeSpan.FromSeconds(10));
+
+            string report = await Core.Diagnostics.NavigationBenchmark.RunAsync(
+                this,
+                index => viewModel.SelectedMenuIndex = index,
+                () => viewModel.SelectedMenuIndex);
+
+            report += await SweepOptionsScrollAsync(viewModel);
+
+            Logging.WriteInfo(report);
+            DumpPerfSnapshot("nav-benchmark");
+        }
+
+        private async Task<string> SweepOptionsScrollAsync(ViewModel viewModel)
+        {
+            viewModel.SelectedMenuIndex = 3;
+            await Dispatcher.InvokeAsync(() => { }, DispatcherPriority.Loaded);
+            await Task.Delay(500);
+
+            var page = FindDescendant<UI.Pages.OptionsPage>(optionsHost);
+            ScrollViewer? scroll = page == null ? null : FindDescendant<ScrollViewer>(page);
+
+            return scroll == null
+                ? "[Perf] Scroll sweep skipped: Options scroll viewer not found.\n"
+                : await Core.Diagnostics.NavigationBenchmark.SweepScrollAsync(scroll, "options");
+        }
+
+        internal void DumpPerfSnapshot(string reason)
+        {
+            if (!Core.Diagnostics.PerfProbe.IsEnabled)
+                return;
+
+            Core.Diagnostics.VisualTreeCensus.Result census = Core.Diagnostics.VisualTreeCensus.Take(this);
+            Logging.WriteInfo(census.Describe("MainWindow"));
+            Logging.WriteInfo(Core.Diagnostics.BindingErrorProbe.Describe());
+            Logging.WriteInfo(
+                $"[Perf] Layout updates {Core.Diagnostics.UiPerfMonitor.LayoutUpdateCount}, "
+                + $"frames {Core.Diagnostics.UiPerfMonitor.FrameCount}");
+
+            foreach ((string name, Core.Diagnostics.PerfProbe.SampleSet.Snapshot sample)
+                in Core.Diagnostics.PerfProbe.Snapshot())
+            {
+                Logging.WriteInfo(
+                    $"[Perf] {name}: n={sample.Count} mean={sample.MeanMs:F2}ms "
+                    + $"p95={sample.P95Ms:F2}ms max={sample.MaxMs:F2}ms alloc={sample.AllocatedBytes / 1024}KB");
+            }
+
+            string? path = Core.Diagnostics.PerfProbe.WriteReport(reason);
+            if (path != null)
+                Logging.WriteInfo($"[Perf] Snapshot written to {path}");
         }
 
         public void FadeInAfterStartup(Action? onVisible = null)

--- a/vrcosc-magicchatbox/MainWindow.xaml.cs
+++ b/vrcosc-magicchatbox/MainWindow.xaml.cs
@@ -570,6 +570,7 @@ namespace vrcosc_magicchatbox
             Core.Diagnostics.UiPerfMonitor.Start(this);
             Core.Diagnostics.PerfProbe.Mark("MainWindow first content rendered");
             StartPerfAutoDump();
+            ApplyReducedVisuals();
 
             if (_revealWanted)
                 Reveal();
@@ -604,6 +605,40 @@ namespace vrcosc_magicchatbox
 
             Logging.WriteInfo(report);
             DumpPerfSnapshot("nav-benchmark");
+        }
+
+        private void ApplyReducedVisuals()
+        {
+            var settings = _appSettingsProvider?.Value;
+            if (settings == null)
+                return;
+
+            bool forced = Environment.GetEnvironmentVariable("MAGICCHATBOX_REDUCED_VISUALS") == "1";
+            var appState = App.Services.GetRequiredService<IAppState>();
+
+            void Resolve() => UI.Controls.ReducedVisuals.IsEnabled =
+                forced
+                || settings.ReducedVisuals
+                || (settings.ReducedVisualsInVr && appState.IsVRRunning);
+
+            settings.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName is nameof(AppSettings.ReducedVisuals) or nameof(AppSettings.ReducedVisualsInVr))
+                    Resolve();
+            };
+
+            if (appState is INotifyPropertyChanged observableState)
+            {
+                observableState.PropertyChanged += (_, e) =>
+                {
+                    if (e.PropertyName == nameof(IAppState.IsVRRunning))
+                        Dispatcher.BeginInvoke(Resolve);
+                };
+            }
+
+            UI.Controls.ReducedVisuals.Changed += () => Dispatcher.BeginInvoke(() => UI.Controls.ReducedVisuals.Refresh(this));
+            Resolve();
+            UI.Controls.ReducedVisuals.Refresh(this);
         }
 
         private void StartPerfAutoDump()

--- a/vrcosc-magicchatbox/MainWindow.xaml.cs
+++ b/vrcosc-magicchatbox/MainWindow.xaml.cs
@@ -575,7 +575,7 @@ namespace vrcosc_magicchatbox
                 Reveal();
         }
 
-        /// <summary>Ctrl+Shift+F12 dumps a snapshot, Ctrl+Shift+F11 runs the navigation benchmark. -perf only.</summary>
+        /// <summary>Ctrl+Shift+F12 dumps a snapshot, Ctrl+Shift+F11 runs the navigation benchmark. --perf only.</summary>
         private async void OnPerfDumpRequested(object sender, KeyEventArgs e)
         {
             if (!Core.Diagnostics.PerfProbe.IsEnabled

--- a/vrcosc-magicchatbox/MainWindow.xaml.cs
+++ b/vrcosc-magicchatbox/MainWindow.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System;
 using System.ComponentModel;
 using System.Threading.Tasks;
 using System.Windows;
@@ -191,7 +190,7 @@ namespace vrcosc_magicchatbox
             }
         }
 
-        private void MainWindow_StateChanged(object sender, EventArgs e)
+        private void MainWindow_StateChanged(object? sender, EventArgs e)
         {
             if (WindowState == WindowState.Maximized)
             {
@@ -372,7 +371,7 @@ namespace vrcosc_magicchatbox
             _ = _scanLoop.Scantick(true);
         }
 
-        public static event EventHandler ShadowOpacityChanged;
+        public static event EventHandler? ShadowOpacityChanged;
 
         private void Button_close_Click(object sender, RoutedEventArgs e)
         {
@@ -420,7 +419,7 @@ namespace vrcosc_magicchatbox
             return notificationText;
         }
 
-        private async void MainWindow_ClosingAsync(object sender, System.ComponentModel.CancelEventArgs e)
+        private async void MainWindow_ClosingAsync(object? sender, System.ComponentModel.CancelEventArgs e)
         {
             SaveWindowPlacement();
 

--- a/vrcosc-magicchatbox/Services/AppHistoryService.cs
+++ b/vrcosc-magicchatbox/Services/AppHistoryService.cs
@@ -30,7 +30,7 @@ public sealed class AppHistoryService : IAppHistoryService
         {
             string appHistoryPath = Path.Combine(_env.DataPath, "AppHistory.json");
             string appHistoryLegacy = Path.Combine(_env.DataPath, "AppHistory.xml");
-            string appHistoryFile = File.Exists(appHistoryPath) ? appHistoryPath
+            string? appHistoryFile = File.Exists(appHistoryPath) ? appHistoryPath
                                   : File.Exists(appHistoryLegacy) ? appHistoryLegacy : null;
 
             if (appHistoryFile != null)

--- a/vrcosc-magicchatbox/Services/AppInfoService.cs
+++ b/vrcosc-magicchatbox/Services/AppInfoService.cs
@@ -11,7 +11,12 @@ public class AppInfoService : IAppInfoService
         try
         {
             var assembly = Assembly.GetExecutingAssembly();
-            string versionString = assembly.GetName().Version.ToString();
+            string? versionString = assembly.GetName().Version?.ToString();
+            if (versionString == null)
+            {
+                Logging.WriteInfo("Error reading version: assembly version is unavailable.");
+                return "69.420.666";
+            }
             return new ViewModels.Models.Version(versionString).VersionNumber;
         }
         catch (Exception ex)

--- a/vrcosc-magicchatbox/Services/AudioService.cs
+++ b/vrcosc-magicchatbox/Services/AudioService.cs
@@ -130,15 +130,16 @@ public sealed class AudioService : IAudioService
         }
     }
 
-    public List<Voice> ReadTikTokTTSVoices()
+    public List<Voice>? ReadTikTokTTSVoices()
     {
         try
         {
-            string currentrunningAppdir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            // Not published single-file, so the executing assembly's location always has a directory.
+            string currentrunningAppdir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
 
             string voicesFilePath = Path.Combine(currentrunningAppdir, "Json", "voices.json");
             string json = File.ReadAllText(voicesFilePath);
-            List<Voice> ConfirmList = JsonConvert.DeserializeObject<List<Voice>>(json);
+            List<Voice> ConfirmList = JsonConvert.DeserializeObject<List<Voice>>(json)!;
 
             var ttsSettings = _ttsSettingsProvider.Value;
 
@@ -148,7 +149,7 @@ public sealed class AudioService : IAudioService
             }
             if (!string.IsNullOrEmpty(ttsSettings.RecentTikTokTTSVoice) || ConfirmList.Count == 0)
             {
-                Voice selectedVoice = ConfirmList.FirstOrDefault(v => v.ApiName == ttsSettings.RecentTikTokTTSVoice);
+                Voice? selectedVoice = ConfirmList.FirstOrDefault(v => v.ApiName == ttsSettings.RecentTikTokTTSVoice);
                 if (selectedVoice != null)
                 {
                     _dispatcher.BeginInvoke(() => _ttsAudio.SelectedTikTokTTSVoice = selectedVoice);
@@ -166,8 +167,8 @@ public sealed class AudioService : IAudioService
 
     public void EnsureLogDirectoryExists(string filePath)
     {
-        string directory = Path.GetDirectoryName(filePath);
-        if (!Directory.Exists(directory))
+        string? directory = Path.GetDirectoryName(filePath);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
         {
             Directory.CreateDirectory(directory);
         }

--- a/vrcosc-magicchatbox/Services/AutoUpdateService.cs
+++ b/vrcosc-magicchatbox/Services/AutoUpdateService.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using vrcosc_magicchatbox.Classes.DataAndSecurity;
+using vrcosc_magicchatbox.Classes.Modules;
+using vrcosc_magicchatbox.Core.Configuration;
+using vrcosc_magicchatbox.Core.State;
+using vrcosc_magicchatbox.Core.Toast;
+using vrcosc_magicchatbox.Core.Updates;
+using vrcosc_magicchatbox.ViewModels.State;
+
+namespace vrcosc_magicchatbox.Services;
+
+/// <summary>
+/// Installs updates without being asked. The download and the checksum happen while the app is
+/// running; swapping the files never does, because that always means restarting. A package is
+/// staged and then applied at the next cold start, which is the one moment nothing is connected.
+/// </summary>
+public sealed class AutoUpdateService : IAutoUpdateService
+{
+    private const int FailedStartsBeforeRollback = 3;
+
+    private readonly AppUpdateState _updateState;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IUiDispatcher _dispatcher;
+    private readonly ISettingsProvider<AppSettings> _appSettingsProvider;
+    private readonly Lazy<IToastService> _toast;
+
+    private readonly SemaphoreSlim _stagingGate = new(1, 1);
+    private IReadOnlyList<string> _blockedVersions = [];
+    private string _dataPath;
+
+    public AutoUpdateService(
+        AppUpdateState updateState,
+        IHttpClientFactory httpClientFactory,
+        IUiDispatcher dispatcher,
+        ISettingsProvider<AppSettings> appSettingsProvider,
+        Lazy<IToastService> toast)
+    {
+        _updateState = updateState;
+        _httpClientFactory = httpClientFactory;
+        _dispatcher = dispatcher;
+        _appSettingsProvider = appSettingsProvider;
+        _toast = toast;
+    }
+
+    public IReadOnlyList<string> BlockedVersions => _blockedVersions;
+
+    public StartupUpdateOutcome PrepareForStartup(bool launchedBySteamVr)
+    {
+        UpdateApp updater;
+
+        try
+        {
+            updater = CreateUpdater();
+            _dataPath = updater.DataDirectory;
+            _blockedVersions = UpdateBlocklist.Read(_dataPath);
+        }
+        catch (Exception ex)
+        {
+            Logging.WriteException(ex, MSGBox: false);
+            return StartupUpdateOutcome.Continue;
+        }
+
+        StartupHealthCheck health = StartupHealthBeacon.MarkStarting(_dataPath);
+
+        if (ShouldRollBack(health) && TryRollBack(updater, health))
+            return StartupUpdateOutcome.HandingOff;
+
+        if (_appSettingsProvider.Value.UseCustomProfile)
+            return StartupUpdateOutcome.Continue;
+
+        // Being started by SteamVR is the opening moment of a session, not a quiet one. The
+        // package keeps until a launch that is not about to put someone in a headset.
+        if (launchedBySteamVr)
+            return StartupUpdateOutcome.Continue;
+
+        return TryApplyStagedUpdate(updater)
+            ? StartupUpdateOutcome.HandingOff
+            : StartupUpdateOutcome.Continue;
+    }
+
+    public void ReportStartupHealthy()
+    {
+        if (_dataPath == null)
+            return;
+
+        StartupHealth health = StartupHealthBeacon.Read(_dataPath);
+        StartupHealthBeacon.MarkHealthy(_dataPath);
+
+        // Someone who never clicked anything is now on a different version than they closed on.
+        // Saying so once is the difference between a feature and an unexplained change.
+        if (!string.IsNullOrWhiteSpace(health.AutoInstalledVersion))
+        {
+            Announce(
+                "MagicChatbox updated itself",
+                $"You are now on {health.AutoInstalledVersion}. Options has a button to go back.",
+                ToastType.Success,
+                $"auto-update-installed-{health.AutoInstalledVersion}");
+        }
+    }
+
+    public async Task ConsiderAsync(UpdateVerdict verdict)
+    {
+        if (verdict is not { Action: UpdateAction.AutoInstall, Standing: UpdateStanding.UpdateAvailable })
+            return;
+
+        if (string.IsNullOrWhiteSpace(verdict.Url) || string.IsNullOrWhiteSpace(verdict.Version))
+            return;
+
+        if (_appSettingsProvider.Value.UseCustomProfile)
+            return;
+
+        if (!await _stagingGate.WaitAsync(0))
+            return;
+
+        try
+        {
+            UpdateApp updater = CreateUpdater();
+            _dataPath = updater.DataDirectory;
+
+            PendingUpdateInfo staged = PendingUpdate.Read(_dataPath);
+            if (staged != null && ReleaseVersion.Compare(staged.Version, verdict.Version) >= 0)
+                return;
+
+            if (staged != null)
+                updater.DiscardStagedUpdate();
+
+            Logging.WriteInfo($"Downloading {verdict.Version} in the background for an unattended install.");
+
+            await updater.PrepareUpdate(unattended: true);
+
+            if (PendingUpdate.Read(_dataPath) == null)
+                return;
+
+            _updateState.CanUpdate = false;
+            _updateState.CanUpdateLabel = false;
+
+            Announce(
+                "Update ready",
+                $"MagicChatbox {verdict.Version} is downloaded and installs the next time you start it.",
+                ToastType.Success,
+                $"auto-update-staged-{verdict.Version}");
+        }
+        catch (Exception ex)
+        {
+            Logging.WriteException(ex, MSGBox: false);
+
+            Announce(
+                "Update could not be downloaded",
+                "MagicChatbox will try again later. You can still install it from Options.",
+                ToastType.Warning,
+                "auto-update-failed");
+        }
+        finally
+        {
+            _stagingGate.Release();
+        }
+    }
+
+    private bool TryApplyStagedUpdate(UpdateApp updater)
+    {
+        PendingUpdateInfo staged = PendingUpdate.Read(_dataPath);
+        if (staged == null)
+            return false;
+
+        if (IsBlocked(staged.Version))
+        {
+            Logging.WriteInfo($"Discarding the staged {staged.Version}: it failed to start before.");
+            updater.DiscardStagedUpdate();
+            return false;
+        }
+
+        // Cleared first so the deliberate exit below is not counted as a failed start, then the
+        // incoming version is put on probation until it reports a healthy launch of its own.
+        StartupHealthBeacon.MarkHealthy(_dataPath);
+        StartupHealthBeacon.RecordAutoInstall(_dataPath, staged.Version);
+
+        if (updater.TryStartStagedInstall())
+            return true;
+
+        StartupHealthBeacon.MarkHealthy(_dataPath);
+        return false;
+    }
+
+    private bool ShouldRollBack(StartupHealthCheck health)
+        => health.PreviousStartFailed
+           && health.WasAutoInstalled
+           && health.ConsecutiveFailures >= FailedStartsBeforeRollback;
+
+    private bool TryRollBack(UpdateApp updater, StartupHealthCheck health)
+    {
+        try
+        {
+            Logging.WriteInfo(
+                $"{health.AutoInstalledVersion} failed to start {health.ConsecutiveFailures} times running. " +
+                "Going back to the previous version and switching automatic installs off.");
+
+            _blockedVersions = UpdateBlocklist.Add(_dataPath, health.AutoInstalledVersion);
+
+            AppSettings settings = _appSettingsProvider.Value;
+            if (settings.StableUpdateMode == UpdateChannelMode.Auto)
+                settings.StableUpdateMode = UpdateChannelMode.Notify;
+            if (settings.PreReleaseUpdateMode == UpdateChannelMode.Auto)
+                settings.PreReleaseUpdateMode = UpdateChannelMode.Notify;
+
+            updater.DiscardStagedUpdate();
+            StartupHealthBeacon.MarkHealthy(_dataPath);
+
+            if (!updater.CheckIfBackupExists())
+            {
+                Logging.WriteInfo("No backup was available to go back to.");
+                return false;
+            }
+
+            updater.StartRollback();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Logging.WriteException(ex, MSGBox: false);
+            StartupHealthBeacon.MarkHealthy(_dataPath);
+            return false;
+        }
+    }
+
+    private bool IsBlocked(string version)
+    {
+        foreach (string blocked in _blockedVersions)
+        {
+            if (ReleaseVersion.Compare(blocked, version) == 0)
+                return true;
+        }
+
+        return false;
+    }
+
+    private UpdateApp CreateUpdater()
+        => new(_updateState, _httpClientFactory, _dispatcher);
+
+    private void Announce(string title, string message, ToastType type, string key)
+    {
+        try
+        {
+            _toast.Value.Show(title, message, type, key: key);
+        }
+        catch (Exception ex)
+        {
+            Logging.WriteInfo($"Could not show the update notice: {ex.Message}");
+        }
+    }
+}

--- a/vrcosc-magicchatbox/Services/AutoUpdateService.cs
+++ b/vrcosc-magicchatbox/Services/AutoUpdateService.cs
@@ -30,7 +30,7 @@ public sealed class AutoUpdateService : IAutoUpdateService
 
     private readonly SemaphoreSlim _stagingGate = new(1, 1);
     private IReadOnlyList<string> _blockedVersions = [];
-    private string _dataPath;
+    private string _dataPath = string.Empty;
 
     public AutoUpdateService(
         AppUpdateState updateState,
@@ -84,7 +84,7 @@ public sealed class AutoUpdateService : IAutoUpdateService
 
     public void ReportStartupHealthy()
     {
-        if (_dataPath == null)
+        if (string.IsNullOrEmpty(_dataPath))
             return;
 
         StartupHealth health = StartupHealthBeacon.Read(_dataPath);
@@ -121,7 +121,7 @@ public sealed class AutoUpdateService : IAutoUpdateService
             UpdateApp updater = CreateUpdater();
             _dataPath = updater.DataDirectory;
 
-            PendingUpdateInfo staged = PendingUpdate.Read(_dataPath);
+            PendingUpdateInfo? staged = PendingUpdate.Read(_dataPath);
             if (staged != null && ReleaseVersion.Compare(staged.Version, verdict.Version) >= 0)
                 return;
 
@@ -162,7 +162,7 @@ public sealed class AutoUpdateService : IAutoUpdateService
 
     private bool TryApplyStagedUpdate(UpdateApp updater)
     {
-        PendingUpdateInfo staged = PendingUpdate.Read(_dataPath);
+        PendingUpdateInfo? staged = PendingUpdate.Read(_dataPath);
         if (staged == null)
             return false;
 

--- a/vrcosc-magicchatbox/Services/ChatHistoryService.cs
+++ b/vrcosc-magicchatbox/Services/ChatHistoryService.cs
@@ -72,7 +72,7 @@ public sealed class ChatHistoryService : IChatHistoryService
         {
             Logging.WriteException(ex, MSGBox: false);
 
-            if (_chatStatus?.LastMessages == null)
+            if (_chatStatus.LastMessages == null)
             {
                 _dispatcher.BeginInvoke(() => _chatStatus.LastMessages = new());
             }

--- a/vrcosc-magicchatbox/Services/EmojiService.cs
+++ b/vrcosc-magicchatbox/Services/EmojiService.cs
@@ -21,7 +21,7 @@ public partial class EmojiService : ObservableObject
     private IReadOnlyList<string> _emojiSnapshot = Array.Empty<string>();
 
     [ObservableProperty]
-    private string _currentEmoji;
+    private string _currentEmoji = string.Empty;
 
     public string EmojiListString
     {

--- a/vrcosc-magicchatbox/Services/HardwareMonitorService.cs
+++ b/vrcosc-magicchatbox/Services/HardwareMonitorService.cs
@@ -15,7 +15,7 @@ using vrcosc_magicchatbox.Services.Hardware;
 
 namespace vrcosc_magicchatbox.Services;
 
-public sealed class HardwareMonitorService : IHardwareMonitorService
+public sealed partial class HardwareMonitorService : IHardwareMonitorService
 {
     private readonly object _lock = new();
     private readonly LhmGpuSensorProvider _vendorGpu = new();
@@ -64,12 +64,15 @@ public sealed class HardwareMonitorService : IHardwareMonitorService
         "VideoProcessing",
         "Copy",
     };
-    private static readonly Regex GpuCounterLuidRegex = new(
+    [GeneratedRegex(
         @"luid_0x(?<high>[0-9a-f]+)_0x(?<low>[0-9a-f]+)",
-        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
-    private static readonly Regex GpuEngineCounterRegex = new(
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex GpuCounterLuidRegex();
+
+    [GeneratedRegex(
         @"luid_0x(?<high>[0-9a-f]+)_0x(?<low>[0-9a-f]+)_phys_(?<phys>\d+)_eng_(?<engine>\d+)_engtype_(?<type>.+)$",
-        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex GpuEngineCounterRegex();
     private static readonly Guid DxgiFactory1Guid = new("770aae78-f26f-4dba-a829-253c83d1b387");
     private const int DxgiErrorNotFound = unchecked((int)0x887A0002);
     private const uint DxgiAdapterFlagSoftware = 2;
@@ -977,7 +980,7 @@ public sealed class HardwareMonitorService : IHardwareMonitorService
 
     private static bool TryParseGpuEngineCounter(string instanceName, out string? luidToken, out string engineKey, out string engineType)
     {
-        var match = GpuEngineCounterRegex.Match(instanceName);
+        var match = GpuEngineCounterRegex().Match(instanceName);
         if (!match.Success)
         {
             luidToken = null;
@@ -994,7 +997,7 @@ public sealed class HardwareMonitorService : IHardwareMonitorService
 
     private static string? TryParseLuidToken(string instanceName)
     {
-        var match = GpuCounterLuidRegex.Match(instanceName);
+        var match = GpuCounterLuidRegex().Match(instanceName);
         return match.Success
             ? NormalizeLuidToken(match.Groups["high"].Value, match.Groups["low"].Value)
             : null;

--- a/vrcosc-magicchatbox/Services/HardwareMonitorService.cs
+++ b/vrcosc-magicchatbox/Services/HardwareMonitorService.cs
@@ -18,6 +18,7 @@ namespace vrcosc_magicchatbox.Services;
 public sealed partial class HardwareMonitorService : IHardwareMonitorService
 {
     private readonly object _lock = new();
+    private readonly object _nvidiaSmiQueryLock = new();
     private readonly LhmGpuSensorProvider _vendorGpu = new();
     private IReadOnlyList<string>? _gpuCache;
     private IReadOnlyList<GpuInfo>? _gpuInfoCache;
@@ -1064,35 +1065,38 @@ public sealed partial class HardwareMonitorService : IHardwareMonitorService
         if (!HasNvidiaAdapter())
             return Array.Empty<NvidiaSmiSample>();
 
-        lock (_lock)
+        lock (_nvidiaSmiQueryLock)
         {
-            if (_nvidiaSmiCache != null &&
-                DateTime.UtcNow - _nvidiaSmiCapturedAtUtc < NvidiaSmiSampleTtl)
+            lock (_lock)
             {
-                return _nvidiaSmiCache;
-            }
+                if (_nvidiaSmiCache != null &&
+                    DateTime.UtcNow - _nvidiaSmiCapturedAtUtc < NvidiaSmiSampleTtl)
+                {
+                    return _nvidiaSmiCache;
+                }
 
-            if (_nvidiaSmiUnavailable)
-                return Array.Empty<NvidiaSmiSample>();
-
-            if (_nvidiaSmiRetryAfterUtc != default)
-            {
-                if (DateTime.UtcNow < _nvidiaSmiRetryAfterUtc)
+                if (_nvidiaSmiUnavailable)
                     return Array.Empty<NvidiaSmiSample>();
 
-                _nvidiaSmiRetryAfterUtc = default;
-                _nvidiaSmiFailures = 0;
+                if (_nvidiaSmiRetryAfterUtc != default)
+                {
+                    if (DateTime.UtcNow < _nvidiaSmiRetryAfterUtc)
+                        return Array.Empty<NvidiaSmiSample>();
+
+                    _nvidiaSmiRetryAfterUtc = default;
+                    _nvidiaSmiFailures = 0;
+                }
             }
-        }
 
-        IReadOnlyList<NvidiaSmiSample> samples = QueryNvidiaSmiAsync().GetAwaiter().GetResult();
-        lock (_lock)
-        {
-            _nvidiaSmiCache = samples;
-            _nvidiaSmiCapturedAtUtc = DateTime.UtcNow;
-        }
+            IReadOnlyList<NvidiaSmiSample> samples = QueryNvidiaSmiAsync().GetAwaiter().GetResult();
+            lock (_lock)
+            {
+                _nvidiaSmiCache = samples;
+                _nvidiaSmiCapturedAtUtc = DateTime.UtcNow;
+            }
 
-        return samples;
+            return samples;
+        }
     }
 
     private async Task<IReadOnlyList<NvidiaSmiSample>> QueryNvidiaSmiAsync()

--- a/vrcosc-magicchatbox/Services/IAutoUpdateService.cs
+++ b/vrcosc-magicchatbox/Services/IAutoUpdateService.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using vrcosc_magicchatbox.Core.Updates;
+
+namespace vrcosc_magicchatbox.Services;
+
+public enum StartupUpdateOutcome
+{
+    Continue,
+    HandingOff,
+}
+
+public interface IAutoUpdateService
+{
+    IReadOnlyList<string> BlockedVersions { get; }
+
+    StartupUpdateOutcome PrepareForStartup(bool launchedBySteamVr);
+
+    void ReportStartupHealthy();
+
+    Task ConsiderAsync(UpdateVerdict verdict);
+}

--- a/vrcosc-magicchatbox/Services/IPulsoidClient.cs
+++ b/vrcosc-magicchatbox/Services/IPulsoidClient.cs
@@ -32,5 +32,5 @@ public interface IPulsoidClient : IDisposable
 
     Task DisconnectAsync();
 
-    Task<PulsoidStatisticsResponse> FetchStatisticsAsync(string accessToken, string timeRange);
+    Task<PulsoidStatisticsResponse?> FetchStatisticsAsync(string accessToken, string timeRange);
 }

--- a/vrcosc-magicchatbox/Services/MediaLinkPersistenceService.cs
+++ b/vrcosc-magicchatbox/Services/MediaLinkPersistenceService.cs
@@ -276,7 +276,7 @@ public sealed class MediaLinkPersistenceService : IMediaLinkPersistenceService, 
             nextAvailableID = 100;
         }
 
-        MediaLinkStyle template = _mediaLink.SelectedMediaLinkSeekbarStyle
+        MediaLinkStyle? template = _mediaLink.SelectedMediaLinkSeekbarStyle
             ?? _mediaLink.MediaLinkSeekbarStyles.FirstOrDefault(s => s.SystemDefault)
             ?? _mediaLink.MediaLinkSeekbarStyles.FirstOrDefault();
 
@@ -297,20 +297,21 @@ public sealed class MediaLinkPersistenceService : IMediaLinkPersistenceService, 
 
     public void DeleteSelectedSeekbarStyleAndSelectDefault()
     {
-        if (_mediaLink.SelectedMediaLinkSeekbarStyle == null)
+        var selectedStyle = _mediaLink.SelectedMediaLinkSeekbarStyle;
+        if (selectedStyle == null)
         {
             return;
         }
 
-        if (_mediaLink.SelectedMediaLinkSeekbarStyle.SystemDefault)
+        if (selectedStyle.SystemDefault)
         {
             Logging.WriteInfo("Cannot delete system default media link style.");
             return;
         }
 
-        int deletedId = _mediaLink.SelectedMediaLinkSeekbarStyle.ID;
+        int deletedId = selectedStyle.ID;
 
-        _mediaLink.MediaLinkSeekbarStyles.Remove(_mediaLink.SelectedMediaLinkSeekbarStyle);
+        _mediaLink.MediaLinkSeekbarStyles.Remove(selectedStyle);
         _mediaLink.SelectedMediaLinkSeekbarStyle = _mediaLink.MediaLinkSeekbarStyles.FirstOrDefault(s => s.SystemDefault)
             ?? _mediaLink.MediaLinkSeekbarStyles.FirstOrDefault();
 
@@ -323,12 +324,13 @@ public sealed class MediaLinkPersistenceService : IMediaLinkPersistenceService, 
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
 
+        var selectedStyle = _mediaLink.SelectedMediaLinkSeekbarStyle;
         var data = new MediaLinkStylesData
         {
             CustomStyles = new ObservableCollection<MediaLinkStyle>(
                 _mediaLink.MediaLinkSeekbarStyles.Where(s => !s.SystemDefault)),
-            SelectedStyleId = _mediaLink.SelectedMediaLinkSeekbarStyle?.SystemDefault == false
-                ? _mediaLink.SelectedMediaLinkSeekbarStyle.ID
+            SelectedStyleId = selectedStyle != null && !selectedStyle.SystemDefault
+                ? selectedStyle.ID
                 : null
         };
 

--- a/vrcosc-magicchatbox/Services/ModuleBootstrapper.cs
+++ b/vrcosc-magicchatbox/Services/ModuleBootstrapper.cs
@@ -475,7 +475,7 @@ public class ModuleBootstrapper
                 vrcRadar.OnVrcWorldStateChanged += OnVrcWorldStateChanged;
                 TrackSubscription(() => vrcRadar.OnVrcWorldStateChanged -= OnVrcWorldStateChanged);
 
-                void OnDiscordRichPresenceSettingsChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+                void OnDiscordRichPresenceSettingsChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
                 {
                     if (e.PropertyName is nameof(DiscordSettings.EnableRichPresence)
                         or nameof(DiscordSettings.RichPresenceDetails)
@@ -545,7 +545,7 @@ public class ModuleBootstrapper
                     TrackSubscription(() => notifier.PropertyChanged -= vrcRadar.PropertyChangedHandler);
                 }
 
-                void OnMasterSwitchChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+                void OnMasterSwitchChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
                 {
                     if (e.PropertyName == nameof(IAppState.MasterSwitch) && !_appState.MasterSwitch)
                     {

--- a/vrcosc-magicchatbox/Services/ModuleHost.cs
+++ b/vrcosc-magicchatbox/Services/ModuleHost.cs
@@ -14,22 +14,22 @@ public partial class ModuleHost : ObservableObject, IModuleHost
     private readonly List<IModule> _modules = new();
     private readonly object _modulesLock = new();
 
-    [ObservableProperty] private ComponentStatsModule _componentStats;
+    [ObservableProperty] private ComponentStatsModule? _componentStats;
 
-    [ObservableProperty] private IntelliChatModule _intelliChat;
-    [ObservableProperty] private TwitchModule _twitch;
-    [ObservableProperty] private TikTokLiveModule _tikTokLive;
-    [ObservableProperty] private DiscordModule _discord;
-    [ObservableProperty] private SpotifyModule _spotify;
-    [ObservableProperty] private VrcLogModule _vrcRadar;
-    [ObservableProperty] private PulsoidModule _pulsoid;
-    [ObservableProperty] private SoundpadModule _soundpad;
-    [ObservableProperty] private VoicemodModule _voicemod;
-    [ObservableProperty] private TrackerBatteryModule _trackerBattery;
-    [ObservableProperty] private vrcosc_magicchatbox.Classes.Modules.Vr.VrPerformanceModule _vrPerformance;
-    [ObservableProperty] private vrcosc_magicchatbox.Classes.Modules.Lyrics.LyricsModule _lyrics;
-    [ObservableProperty] private WhisperModule _whisper;
-    [ObservableProperty] private AfkModule _afk;
+    [ObservableProperty] private IntelliChatModule? _intelliChat;
+    [ObservableProperty] private TwitchModule? _twitch;
+    [ObservableProperty] private TikTokLiveModule? _tikTokLive;
+    [ObservableProperty] private DiscordModule? _discord;
+    [ObservableProperty] private SpotifyModule? _spotify;
+    [ObservableProperty] private VrcLogModule? _vrcRadar;
+    [ObservableProperty] private PulsoidModule? _pulsoid;
+    [ObservableProperty] private SoundpadModule? _soundpad;
+    [ObservableProperty] private VoicemodModule? _voicemod;
+    [ObservableProperty] private TrackerBatteryModule? _trackerBattery;
+    [ObservableProperty] private vrcosc_magicchatbox.Classes.Modules.Vr.VrPerformanceModule? _vrPerformance;
+    [ObservableProperty] private vrcosc_magicchatbox.Classes.Modules.Lyrics.LyricsModule? _lyrics;
+    [ObservableProperty] private WhisperModule? _whisper;
+    [ObservableProperty] private AfkModule? _afk;
 
     public IReadOnlyList<IModule> AllModules
     {

--- a/vrcosc-magicchatbox/Services/OptionsSectionResetService.cs
+++ b/vrcosc-magicchatbox/Services/OptionsSectionResetService.cs
@@ -282,6 +282,8 @@ public sealed class OptionsSectionResetService : IOptionsSectionResetService
         nameof(AppSettings.OscMessageSuffix),
         nameof(AppSettings.SeperateWithENTERS),
         nameof(AppSettings.CountOculusSystemAsVR),
+        nameof(AppSettings.StartWithSteamVr),
+        nameof(AppSettings.QuitWithSteamVr),
         nameof(AppSettings.Topmost),
         nameof(AppSettings.CheckUpdateOnStartup),
         nameof(AppSettings.AppOpacity),

--- a/vrcosc-magicchatbox/Services/OptionsSectionResetService.cs
+++ b/vrcosc-magicchatbox/Services/OptionsSectionResetService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -418,6 +418,7 @@ public sealed class OptionsSectionResetService : IOptionsSectionResetService
         nameof(AppSettings.EnableTrayNotifications),
         nameof(AppSettings.ShowTrayRunningReminder),
         nameof(AppSettings.OpenTrayWithAltX),
+        nameof(AppSettings.ShowHiddenIntegrationWarning),
         nameof(AppSettings.ReducedVisuals),
         nameof(AppSettings.ReducedVisualsInVr),
     ];

--- a/vrcosc-magicchatbox/Services/OptionsSectionResetService.cs
+++ b/vrcosc-magicchatbox/Services/OptionsSectionResetService.cs
@@ -286,6 +286,8 @@ public sealed class OptionsSectionResetService : IOptionsSectionResetService
         nameof(AppSettings.QuitWithSteamVr),
         nameof(AppSettings.Topmost),
         nameof(AppSettings.CheckUpdateOnStartup),
+        nameof(AppSettings.StableUpdateMode),
+        nameof(AppSettings.PreReleaseUpdateMode),
         nameof(AppSettings.AppOpacity),
         nameof(AppSettings.AppIsEnabled),
         nameof(AppSettings.StartInBackground),

--- a/vrcosc-magicchatbox/Services/OptionsSectionResetService.cs
+++ b/vrcosc-magicchatbox/Services/OptionsSectionResetService.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using vrcosc_magicchatbox.Classes.DataAndSecurity;
 using vrcosc_magicchatbox.Classes.Modules;
@@ -33,6 +35,8 @@ public sealed class OptionsSectionResetService : IOptionsSectionResetService
     private readonly ISettingsProvider<OscSettings> _osc;
     private readonly ISettingsProvider<PrivacySettings> _privacy;
     private readonly ISettingsProvider<VoicemodSettings> _voicemod;
+    private readonly ISettingsProvider<vrcosc_magicchatbox.Classes.Modules.Lyrics.LyricsSettings> _lyrics;
+    private readonly ISettingsProvider<vrcosc_magicchatbox.Classes.Modules.Vr.VrPerformanceSettings> _vrPerformance;
     private readonly Lazy<IModuleHost> _moduleHost;
     private readonly DiscordRichPresenceService _discordRichPresence;
 
@@ -59,6 +63,8 @@ public sealed class OptionsSectionResetService : IOptionsSectionResetService
         ISettingsProvider<OscSettings> osc,
         ISettingsProvider<PrivacySettings> privacy,
         ISettingsProvider<VoicemodSettings> voicemod,
+        ISettingsProvider<vrcosc_magicchatbox.Classes.Modules.Lyrics.LyricsSettings> lyrics,
+        ISettingsProvider<vrcosc_magicchatbox.Classes.Modules.Vr.VrPerformanceSettings> vrPerformance,
         Lazy<IModuleHost> moduleHost,
         DiscordRichPresenceService discordRichPresence)
     {
@@ -84,6 +90,8 @@ public sealed class OptionsSectionResetService : IOptionsSectionResetService
         _osc = osc;
         _privacy = privacy;
         _voicemod = voicemod;
+        _lyrics = lyrics;
+        _vrPerformance = vrPerformance;
         _moduleHost = moduleHost;
         _discordRichPresence = discordRichPresence;
     }
@@ -92,8 +100,6 @@ public sealed class OptionsSectionResetService : IOptionsSectionResetService
     {
         var key = NormalizeKey(sectionKey);
         int count = 0;
-        bool restarted = false;
-        bool restartFailed = false;
 
         switch (key)
         {
@@ -103,18 +109,33 @@ public sealed class OptionsSectionResetService : IOptionsSectionResetService
                 return Result("Status", count);
 
             case "vrc-radar":
-                count += _reset.ResetAll(_vrcLog);
-                count += ResetIntegration(nameof(IntegrationSettings.IntgrVrcRadar), nameof(IntegrationSettings.IntgrVrcRadar_VR), nameof(IntegrationSettings.IntgrVrcRadar_DESKTOP));
-                restarted |= await RestartIfRunningAsync(_moduleHost.Value.VrcRadar, () => restartFailed = true).ConfigureAwait(false);
-                return Result("VRChat Reader", count, restarted, restartFailed);
+                return await ResetModuleSectionAsync(
+                    "VRChat Reader",
+                    _moduleHost.Value.VrcRadar,
+                    () => _reset.ResetAll(_vrcLog)
+                        + ResetIntegration(nameof(IntegrationSettings.IntgrVrcRadar_VR), nameof(IntegrationSettings.IntgrVrcRadar_DESKTOP)))
+                    .ConfigureAwait(false);
 
             case "pulsoid":
-                count += _reset.ResetAll(_pulsoid);
-                _moduleHost.Value.Pulsoid?.RefreshTrendSymbols();
-                _moduleHost.Value.Pulsoid?.RefreshTimeRanges();
-                count += ResetIntegration(nameof(IntegrationSettings.IntgrHeartRate), nameof(IntegrationSettings.IntgrHeartRate_VR), nameof(IntegrationSettings.IntgrHeartRate_DESKTOP), nameof(IntegrationSettings.IntgrHeartRate_OSC));
-                restarted |= await RestartIfRunningAsync(_moduleHost.Value.Pulsoid, () => restartFailed = true).ConfigureAwait(false);
-                return Result("Heart Rate", count, restarted, restartFailed);
+                return await ResetModuleSectionAsync(
+                    "Heart Rate",
+                    _moduleHost.Value.Pulsoid,
+                    () =>
+                    {
+                        int reset = _reset.ResetAll(_pulsoid);
+                        _moduleHost.Value.Pulsoid?.RefreshTrendSymbols();
+                        _moduleHost.Value.Pulsoid?.RefreshTimeRanges();
+
+                        // Rebuilding the trend symbols and time ranges mutates the settings again after
+                        // the reset already wrote them, so the rebuilt lists need a write of their own.
+                        _pulsoid.FlushPendingSave();
+
+                        return reset + ResetIntegration(
+                            nameof(IntegrationSettings.IntgrHeartRate_VR),
+                            nameof(IntegrationSettings.IntgrHeartRate_DESKTOP),
+                            nameof(IntegrationSettings.IntgrHeartRate_OSC));
+                    })
+                    .ConfigureAwait(false);
 
             case "time":
                 count += _reset.ResetAll(_time);
@@ -127,29 +148,60 @@ public sealed class OptionsSectionResetService : IOptionsSectionResetService
                 return Result("Weather", count);
 
             case "twitch":
-                count += _reset.ResetAll(_twitch);
-                count += ResetIntegration(nameof(IntegrationSettings.IntgrTwitch), nameof(IntegrationSettings.IntgrTwitch_VR), nameof(IntegrationSettings.IntgrTwitch_DESKTOP));
-                restarted |= await RestartIfRunningAsync(_moduleHost.Value.Twitch, () => restartFailed = true).ConfigureAwait(false);
-                return Result("Twitch", count, restarted, restartFailed);
+                return await ResetModuleSectionAsync(
+                    "Twitch",
+                    _moduleHost.Value.Twitch,
+                    () => _reset.ResetAll(_twitch)
+                        + ResetIntegration(nameof(IntegrationSettings.IntgrTwitch_VR), nameof(IntegrationSettings.IntgrTwitch_DESKTOP)))
+                    .ConfigureAwait(false);
 
             case "tiktok-live":
-                count += _reset.ResetAll(_tikTokLive);
-                count += ResetIntegration(nameof(IntegrationSettings.IntgrTikTokLive), nameof(IntegrationSettings.IntgrTikTokLive_VR), nameof(IntegrationSettings.IntgrTikTokLive_DESKTOP));
-                restarted |= await RestartIfRunningAsync(_moduleHost.Value.TikTokLive, () => restartFailed = true).ConfigureAwait(false);
-                return Result("TikTok", count, restarted, restartFailed);
+                return await ResetModuleSectionAsync(
+                    "TikTok",
+                    _moduleHost.Value.TikTokLive,
+                    () => _reset.ResetAll(_tikTokLive)
+                        + ResetIntegration(nameof(IntegrationSettings.IntgrTikTokLive_VR), nameof(IntegrationSettings.IntgrTikTokLive_DESKTOP)))
+                    .ConfigureAwait(false);
 
             case "discord":
-                count += _reset.ResetAll(_discord);
-                count += ResetIntegration(nameof(IntegrationSettings.IntgrDiscord), nameof(IntegrationSettings.IntgrDiscord_VR), nameof(IntegrationSettings.IntgrDiscord_DESKTOP));
-                await _discordRichPresence.ClearAsync().ConfigureAwait(false);
-                restarted |= await RestartIfRunningAsync(_moduleHost.Value.Discord, () => restartFailed = true).ConfigureAwait(false);
-                return Result("Discord", count, restarted, restartFailed);
+                return await ResetModuleSectionAsync(
+                    "Discord",
+                    _moduleHost.Value.Discord,
+                    () => _reset.ResetAll(_discord)
+                        + ResetIntegration(nameof(IntegrationSettings.IntgrDiscord_VR), nameof(IntegrationSettings.IntgrDiscord_DESKTOP)),
+                    afterReset: () => _discordRichPresence.ClearAsync())
+                    .ConfigureAwait(false);
 
             case "spotify":
-                count += _reset.ResetAll(_spotify);
-                count += ResetIntegration(nameof(IntegrationSettings.IntgrSpotify), nameof(IntegrationSettings.IntgrSpotify_VR), nameof(IntegrationSettings.IntgrSpotify_DESKTOP), nameof(IntegrationSettings.IntgrSpotifyStatus_VR), nameof(IntegrationSettings.IntgrSpotifyStatus_DESKTOP));
-                restarted |= await RestartIfRunningAsync(_moduleHost.Value.Spotify, () => restartFailed = true).ConfigureAwait(false);
-                return Result("Spotify", count, restarted, restartFailed);
+                return await ResetModuleSectionAsync(
+                    "Spotify",
+                    _moduleHost.Value.Spotify,
+                    () => _reset.ResetAll(_spotify)
+                        + ResetIntegration(
+                            nameof(IntegrationSettings.IntgrSpotify_VR),
+                            nameof(IntegrationSettings.IntgrSpotify_DESKTOP),
+                            nameof(IntegrationSettings.IntgrSpotifyStatus_VR),
+                            nameof(IntegrationSettings.IntgrSpotifyStatus_DESKTOP)))
+                    .ConfigureAwait(false);
+
+            case "lyrics":
+                return await ResetModuleSectionAsync(
+                    "Lyrics",
+                    _moduleHost.Value.Lyrics,
+                    () => _reset.ResetAll(_lyrics)
+                        + ResetIntegration(
+                            nameof(IntegrationSettings.IntgrLyrics_Spotify),
+                            nameof(IntegrationSettings.IntgrLyrics_MediaLink),
+                            nameof(IntegrationSettings.IntgrLyrics_VR),
+                            nameof(IntegrationSettings.IntgrLyrics_DESKTOP)))
+                    .ConfigureAwait(false);
+
+            case "vr-performance":
+                return await ResetModuleSectionAsync(
+                    "VR Performance",
+                    _moduleHost.Value.VrPerformance,
+                    () => _reset.ResetAll(_vrPerformance))
+                    .ConfigureAwait(false);
 
             case "openai":
                 count += _reset.ResetAll(_openAI);
@@ -157,15 +209,20 @@ public sealed class OptionsSectionResetService : IOptionsSectionResetService
                 return Result("OpenAI", count, note: "Credentials were preserved.");
 
             case "component-stats":
-                count += _reset.ResetAll(_componentStats);
-                count += ResetIntegration(nameof(IntegrationSettings.IntgrComponentStats), nameof(IntegrationSettings.IntgrComponentStats_VR), nameof(IntegrationSettings.IntgrComponentStats_DESKTOP));
-                restarted |= await RestartIfRunningAsync(_moduleHost.Value.ComponentStats, () => restartFailed = true).ConfigureAwait(false);
-                return Result("Component Stats", count, restarted, restartFailed);
+                return await ResetModuleSectionAsync(
+                    "Component Stats",
+                    _moduleHost.Value.ComponentStats,
+                    () => _reset.ResetAll(_componentStats)
+                        + ResetIntegration(nameof(IntegrationSettings.IntgrComponentStats_VR), nameof(IntegrationSettings.IntgrComponentStats_DESKTOP)))
+                    .ConfigureAwait(false);
 
             case "network-statistics":
-                count += _reset.ResetAll(_networkStats);
-                count += ResetIntegration(nameof(IntegrationSettings.IntgrNetworkStatistics), nameof(IntegrationSettings.IntgrNetworkStatistics_VR), nameof(IntegrationSettings.IntgrNetworkStatistics_DESKTOP));
-                return Result("Network Statistics", count);
+                return await ResetModuleSectionAsync(
+                    "Network Statistics",
+                    FindModule<NetworkStatisticsModule>(),
+                    () => _reset.ResetAll(_networkStats)
+                        + ResetIntegration(nameof(IntegrationSettings.IntgrNetworkStatistics_VR), nameof(IntegrationSettings.IntgrNetworkStatistics_DESKTOP)))
+                    .ConfigureAwait(false);
 
             case "chatting":
                 count += _reset.ResetAll(_chat);
@@ -176,13 +233,13 @@ public sealed class OptionsSectionResetService : IOptionsSectionResetService
                 return Result("Speech To Text / TTS", count);
 
             case "voicemod":
-                count += _reset.ResetAll(_voicemod);
-                count += ResetIntegration(
-                    nameof(IntegrationSettings.IntgrVoicemod),
-                    nameof(IntegrationSettings.IntgrVoicemod_VR),
-                    nameof(IntegrationSettings.IntgrVoicemod_DESKTOP));
-                restarted |= await RestartIfRunningAsync(_moduleHost.Value.Voicemod, () => restartFailed = true).ConfigureAwait(false);
-                return Result("Voicemod", count, restarted, restartFailed, note: "Credentials were preserved.");
+                return await ResetModuleSectionAsync(
+                    "Voicemod",
+                    _moduleHost.Value.Voicemod,
+                    () => _reset.ResetAll(_voicemod)
+                        + ResetIntegration(nameof(IntegrationSettings.IntgrVoicemod_VR), nameof(IntegrationSettings.IntgrVoicemod_DESKTOP)),
+                    note: "Credentials were preserved.")
+                    .ConfigureAwait(false);
 
             case "media-link":
                 count += _reset.ResetAll(_mediaLink);
@@ -199,10 +256,11 @@ public sealed class OptionsSectionResetService : IOptionsSectionResetService
                 return Result("Egg Options", count);
 
             case "tracker-battery":
-                count += _reset.ResetAll(_trackerBattery);
-                count += ResetIntegration(nameof(IntegrationSettings.IntgrTrackerBattery));
-                restarted |= await RestartIfRunningAsync(_moduleHost.Value.TrackerBattery, () => restartFailed = true).ConfigureAwait(false);
-                return Result("Tracker Battery", count, restarted, restartFailed);
+                return await ResetModuleSectionAsync(
+                    "Tracker Battery",
+                    _moduleHost.Value.TrackerBattery,
+                    () => _reset.ResetAll(_trackerBattery))
+                    .ConfigureAwait(false);
 
             case "privacy":
                 count += _reset.ResetAll(_privacy, preserveCredentials: false);
@@ -219,6 +277,78 @@ public sealed class OptionsSectionResetService : IOptionsSectionResetService
         }
     }
 
+    /// <summary>
+    /// Stops the section's module, resets the section, and brings the module back up when it was
+    /// running beforehand.
+    /// </summary>
+    private static async Task<OptionsSectionResetResult> ResetModuleSectionAsync(
+        string displayName,
+        IModule? module,
+        Func<int> resetSettings,
+        Func<Task>? afterReset = null,
+        string? note = null)
+    {
+        // Read this before anything is written: a module whose running state is derived from the
+        // settings being reset can no longer answer the question afterwards.
+        bool wasRunning = module is { IsRunning: true };
+        bool stopFailed = false;
+
+        if (wasRunning)
+        {
+            try
+            {
+                Logging.WriteInfo($"[SettingsReset] Stopping '{module!.Name}' before resetting its settings.");
+                await module.StopAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                Logging.WriteException(ex, MSGBox: false);
+                stopFailed = true;
+            }
+        }
+
+        int count = resetSettings();
+
+        if (afterReset is not null)
+        {
+            try
+            {
+                await afterReset().ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                Logging.WriteException(ex, MSGBox: false);
+            }
+        }
+
+        if (!wasRunning)
+            return Result(displayName, count, note: note);
+
+        if (stopFailed)
+            return Result(displayName, count, restartFailed: true, note: note);
+
+        try
+        {
+            await module!.StartAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Logging.WriteException(ex, MSGBox: false);
+            return Result(displayName, count, restartFailed: true, note: note);
+        }
+
+        // Claim a restart only when the module says it is up again, not merely because the calls returned.
+        return Result(displayName, count, restarted: module!.IsRunning, note: note);
+    }
+
+    private IModule? FindModule<T>() where T : class, IModule
+        => _moduleHost.Value.AllModules.OfType<T>().FirstOrDefault();
+
+    /// <summary>
+    /// Resets integration flags. Sections that own a module pass their display-mode flags only: the
+    /// master integration toggle is the user's on/off choice rather than a tuning value, so it
+    /// survives the reset and the module can be brought back up on it.
+    /// </summary>
     private int ResetIntegration(params string[] propertyNames)
         => _reset.ResetProperties(_integrations, propertyNames, preserveCredentials: false);
 
@@ -232,31 +362,22 @@ public sealed class OptionsSectionResetService : IOptionsSectionResetService
         if (restartFailed)
             return new(displayName, count, RestartRequired: true, "Running module could not be restarted automatically; restart MagicChatbox.");
 
-        return new(displayName, count, RestartRequired: false, restarted ? "Running module was restarted." : note);
+        return new(displayName, count, RestartRequired: false, JoinNotes(restarted ? "Running module was restarted." : null, note));
+    }
+
+    private static string? JoinNotes(string? first, string? second)
+    {
+        var parts = new List<string>(2);
+        if (!string.IsNullOrWhiteSpace(first))
+            parts.Add(first!);
+        if (!string.IsNullOrWhiteSpace(second))
+            parts.Add(second!);
+
+        return parts.Count == 0 ? null : string.Join(" ", parts);
     }
 
     private static string NormalizeKey(string sectionKey)
         => (sectionKey ?? string.Empty).Trim().ToLowerInvariant().Replace("_", "-").Replace(" ", "-");
-
-    private static async Task<bool> RestartIfRunningAsync(IModule? module, Action onFailure)
-    {
-        if (module is null || !module.IsRunning)
-            return false;
-
-        try
-        {
-            Logging.WriteInfo($"[SettingsReset] Restarting running module '{module.Name}' after settings reset.");
-            await module.StopAsync().ConfigureAwait(false);
-            await module.StartAsync().ConfigureAwait(false);
-            return true;
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            Logging.WriteException(ex, MSGBox: false);
-            onFailure();
-            return false;
-        }
-    }
 
     private static readonly string[] StatusAppSettings =
     [
@@ -297,6 +418,8 @@ public sealed class OptionsSectionResetService : IOptionsSectionResetService
         nameof(AppSettings.EnableTrayNotifications),
         nameof(AppSettings.ShowTrayRunningReminder),
         nameof(AppSettings.OpenTrayWithAltX),
+        nameof(AppSettings.ReducedVisuals),
+        nameof(AppSettings.ReducedVisualsInVr),
     ];
 
     private static readonly string[] EggSettings =

--- a/vrcosc-magicchatbox/Services/OscSenderService.cs
+++ b/vrcosc-magicchatbox/Services/OscSenderService.cs
@@ -18,6 +18,7 @@ public sealed class OscSenderService : IOscSender, IDisposable
     private const string INPUT_VOICE = "/input/Voice";
     private const int TYPING_DURATION = 2000;
     private static readonly TimeSpan DuplicateKeepAliveInterval = TimeSpan.FromSeconds(12);
+    private static readonly TimeSpan FailedEndpointRetryDelay = TimeSpan.FromSeconds(30);
 
     private readonly OscSettings _oscSettings;
     private readonly AppSettings _appSettings;
@@ -26,12 +27,14 @@ public sealed class OscSenderService : IOscSender, IDisposable
     private readonly ChatStatusDisplayState _chatStatus;
     private readonly OscDisplayState _oscDisplay;
     private readonly TtsAudioDisplayState _ttsAudio;
+    private readonly TimeProvider _timeProvider;
 
     private UDPSender? _oscSender;
     private UDPSender? _secOscSender;
     private UDPSender? _thirdOscSender;
     private bool _senderRebuildFailureLogged;
     private string? _lastFailedEndpoint;
+    private DateTimeOffset _lastFailedEndpointRetryAfterUtc;
     private readonly object _senderLock = new();
     private readonly object _typingLock = new();
 
@@ -49,7 +52,8 @@ public sealed class OscSenderService : IOscSender, IDisposable
         IAppState appState,
         ChatStatusDisplayState chatStatus,
         OscDisplayState oscDisplay,
-        TtsAudioDisplayState ttsAudio)
+        TtsAudioDisplayState ttsAudio,
+        TimeProvider? timeProvider = null)
     {
         _oscSettings = oscSettings.Value;
         _appSettings = appSettings.Value;
@@ -58,6 +62,7 @@ public sealed class OscSenderService : IOscSender, IDisposable
         _chatStatus = chatStatus;
         _oscDisplay = oscDisplay;
         _ttsAudio = ttsAudio;
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     private OscSettings OS => _oscSettings;
@@ -431,7 +436,8 @@ public sealed class OscSenderService : IOscSender, IDisposable
             return current;
 
         string endpoint = $"{address}:{port}";
-        if (endpoint == _lastFailedEndpoint)
+        if (endpoint == _lastFailedEndpoint &&
+            _timeProvider.GetUtcNow() < _lastFailedEndpointRetryAfterUtc)
             return current;
 
         try
@@ -440,11 +446,14 @@ public sealed class OscSenderService : IOscSender, IDisposable
             current?.Close();
             _senderRebuildFailureLogged = false;
             _lastFailedEndpoint = null;
+            _lastFailedEndpointRetryAfterUtc = default;
             return replacement;
         }
         catch (Exception ex)
         {
             _lastFailedEndpoint = endpoint;
+            _lastFailedEndpointRetryAfterUtc =
+                _timeProvider.GetUtcNow().Add(FailedEndpointRetryDelay);
             if (!_senderRebuildFailureLogged)
             {
                 _senderRebuildFailureLogged = true;

--- a/vrcosc-magicchatbox/Services/PulsoidApiClient.cs
+++ b/vrcosc-magicchatbox/Services/PulsoidApiClient.cs
@@ -24,15 +24,15 @@ public sealed class PulsoidApiClient : IPulsoidClient
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IPulsoidTokenValidator _tokenValidator;
     private readonly Random _jitter = new();
-    private ClientWebSocket _webSocket;
-    private HttpClient _statsClient;
+    private ClientWebSocket? _webSocket;
+    private HttpClient? _statsClient;
     private bool _disposed;
 
     private HttpClient StatsClient => _statsClient ??= _httpClientFactory.CreateClient("Pulsoid");
 
-    public event Action<int> HeartRateReceived;
-    public event Action<PulsoidConnectionError, string> ConnectionFailed;
-    public event Action<bool> ConnectionStateChanged;
+    public event Action<int>? HeartRateReceived;
+    public event Action<PulsoidConnectionError, string>? ConnectionFailed;
+    public event Action<bool>? ConnectionStateChanged;
 
     public bool IsConnected => _webSocket?.State == WebSocketState.Open;
 
@@ -54,13 +54,14 @@ public sealed class PulsoidApiClient : IPulsoidClient
 
             try
             {
-                _webSocket = new ClientWebSocket();
-                _webSocket.Options.KeepAliveInterval = KeepAliveInterval;
-                _webSocket.Options.CollectHttpResponseDetails = true;
+                var socket = new ClientWebSocket();
+                _webSocket = socket;
+                socket.Options.KeepAliveInterval = KeepAliveInterval;
+                socket.Options.CollectHttpResponseDetails = true;
 
                 var wsUri = new Uri(
                     $"wss://dev.pulsoid.net/api/v1/data/real_time?access_token={Uri.EscapeDataString(accessToken)}");
-                await _webSocket.ConnectAsync(wsUri, ct).ConfigureAwait(false);
+                await socket.ConnectAsync(wsUri, ct).ConfigureAwait(false);
 
                 handshakeSucceeded = true;
                 attempt = 0;
@@ -161,11 +162,11 @@ public sealed class PulsoidApiClient : IPulsoidClient
 
     public async Task DisconnectAsync()
     {
-        if (_webSocket != null && _webSocket.State == WebSocketState.Open)
+        if (_webSocket is { State: WebSocketState.Open } socket)
         {
             try
             {
-                await _webSocket.CloseAsync(
+                await socket.CloseAsync(
                     WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None).ConfigureAwait(false);
             }
             catch (Exception ex)
@@ -178,7 +179,7 @@ public sealed class PulsoidApiClient : IPulsoidClient
         ConnectionStateChanged?.Invoke(false);
     }
 
-    public async Task<PulsoidStatisticsResponse> FetchStatisticsAsync(string accessToken, string timeRange)
+    public async Task<PulsoidStatisticsResponse?> FetchStatisticsAsync(string accessToken, string timeRange)
     {
         try
         {
@@ -238,8 +239,7 @@ public sealed class PulsoidApiClient : IPulsoidClient
     {
         var buffer = new byte[1024];
 
-        while (_webSocket != null &&
-               _webSocket.State == WebSocketState.Open &&
+        while (_webSocket is { State: WebSocketState.Open } socket &&
                !ct.IsCancellationRequested)
         {
             WebSocketReceiveResult result;
@@ -248,12 +248,12 @@ public sealed class PulsoidApiClient : IPulsoidClient
             {
                 do
                 {
-                    result = await _webSocket.ReceiveAsync(
+                    result = await socket.ReceiveAsync(
                         new ArraySegment<byte>(buffer), ct).ConfigureAwait(false);
 
                     if (result.MessageType == WebSocketMessageType.Close)
                     {
-                        await _webSocket.CloseAsync(
+                        await socket.CloseAsync(
                             WebSocketCloseStatus.NormalClosure, "Closing", ct).ConfigureAwait(false);
                         return;
                     }

--- a/vrcosc-magicchatbox/Services/ServiceRegistration.cs
+++ b/vrcosc-magicchatbox/Services/ServiceRegistration.cs
@@ -316,7 +316,8 @@ public static class ServiceRegistration
         services.AddSingleton<ComponentStatsSectionViewModel>(sp => new ComponentStatsSectionViewModel(
             sp.GetRequiredService<ISettingsProvider<AppSettings>>(),
             new Lazy<ComponentStatsModule>(() => sp.GetRequiredService<ComponentStatsModule>(), LazyThreadSafetyMode.PublicationOnly),
-            new Lazy<ComponentStatsViewModel>(() => sp.GetRequiredService<ComponentStatsViewModel>(), LazyThreadSafetyMode.PublicationOnly)));
+            new Lazy<ComponentStatsViewModel>(() => sp.GetRequiredService<ComponentStatsViewModel>(), LazyThreadSafetyMode.PublicationOnly),
+            sp.GetRequiredService<IAppState>()));
         services.AddSingleton<StatusSectionViewModel>(sp => new StatusSectionViewModel(
             sp.GetRequiredService<ISettingsProvider<AppSettings>>(),
             sp.GetRequiredService<ISettingsProvider<TimeSettings>>(),

--- a/vrcosc-magicchatbox/Services/ServiceRegistration.cs
+++ b/vrcosc-magicchatbox/Services/ServiceRegistration.cs
@@ -64,6 +64,16 @@ public static class ServiceRegistration
             utcNow: null,
             isUiThread: () => System.Windows.Application.Current?.Dispatcher?.CheckAccess() == true));
 
+        services.AddSingleton<Services.Vr.ISteamVrApplications>(sp => new Services.Vr.SteamVrApplications(
+            sp.GetRequiredService<Services.Vr.IOpenVrSessionService>()));
+        services.AddSingleton<Services.Vr.ISteamVrAutoStartService>(sp => new Services.Vr.SteamVrAutoStartService(
+            sp.GetRequiredService<Services.Vr.ISteamVrApplications>(),
+            sp.GetRequiredService<ISettingsProvider<AppSettings>>(),
+            sp.GetRequiredService<IAppState>(),
+            sp.GetRequiredService<IProcessPresenceService>(),
+            () => System.Windows.Application.Current?.Dispatcher?.BeginInvoke(
+                () => (System.Windows.Application.Current as App)?.ShutdownFromSteamVr())));
+
         services.AddSingleton<IPrivacyConsentService, PrivacyConsentService>();
         services.AddSingleton<PrivacySectionViewModel>();
 

--- a/vrcosc-magicchatbox/Services/ServiceRegistration.cs
+++ b/vrcosc-magicchatbox/Services/ServiceRegistration.cs
@@ -561,9 +561,15 @@ public static class ServiceRegistration
         services.AddHttpClient(Constants.HttpClients.TikTok, client =>
         {
             client.BaseAddress = new Uri("https://www.tiktok.com/");
-            client.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) MagicChatbox/1.0");
-            client.DefaultRequestHeaders.Add("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
+            client.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36");
+            client.DefaultRequestHeaders.Add("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8");
+            client.DefaultRequestHeaders.Add("Accept-Language", "en-US,en;q=0.9");
+            client.DefaultRequestHeaders.Add("Upgrade-Insecure-Requests", "1");
             client.Timeout = Constants.DefaultApiTimeout;
+        })
+        .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+        {
+            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate | DecompressionMethods.Brotli,
         })
         .AddPolicyHandler(request =>
             request.Method == HttpMethod.Get

--- a/vrcosc-magicchatbox/Services/ServiceRegistration.cs
+++ b/vrcosc-magicchatbox/Services/ServiceRegistration.cs
@@ -499,11 +499,18 @@ public static class ServiceRegistration
             sp.GetRequiredService<IUiDispatcher>()));
         services.AddSingleton<IStatusListService, StatusListService>();
         services.AddSingleton<IComponentStatsPersistenceService, ComponentStatsPersistenceService>();
+        services.AddSingleton<IAutoUpdateService>(sp => new AutoUpdateService(
+            sp.GetRequiredService<AppUpdateState>(),
+            sp.GetRequiredService<IHttpClientFactory>(),
+            sp.GetRequiredService<IUiDispatcher>(),
+            sp.GetRequiredService<ISettingsProvider<AppSettings>>(),
+            new Lazy<IToastService>(() => sp.GetRequiredService<IToastService>())));
         services.AddSingleton<IVersionService>(sp => new VersionService(
             sp.GetRequiredService<IHttpClientFactory>(),
             sp.GetRequiredService<AppUpdateState>(),
             sp.GetRequiredService<ISettingsProvider<AppSettings>>(),
-            sp.GetRequiredService<IUiDispatcher>()));
+            sp.GetRequiredService<IUiDispatcher>(),
+            sp.GetRequiredService<IAutoUpdateService>()));
         services.AddSingleton<IAudioService>(sp => new AudioService(
             sp.GetRequiredService<TtsAudioDisplayState>(),
             sp.GetRequiredService<ISettingsProvider<TtsSettings>>(),

--- a/vrcosc-magicchatbox/Services/ServiceRegistration.cs
+++ b/vrcosc-magicchatbox/Services/ServiceRegistration.cs
@@ -205,6 +205,7 @@ public static class ServiceRegistration
             new Lazy<IModuleHost>(() => sp.GetRequiredService<IModuleHost>()),
             new Lazy<OSCController>(() => sp.GetRequiredService<OSCController>()),
             sp.GetRequiredService<ISettingsProvider<IntegrationSettings>>(),
+            sp.GetRequiredService<ISettingsProvider<AppSettings>>(),
             sp.GetRequiredService<ISettingsProvider<MediaLinkSettings>>(),
             sp.GetRequiredService<ISettingsProvider<SpotifySettings>>(),
             sp.GetRequiredService<ISettingsProvider<WeatherSettings>>(),

--- a/vrcosc-magicchatbox/Services/ServiceRegistration.cs
+++ b/vrcosc-magicchatbox/Services/ServiceRegistration.cs
@@ -184,7 +184,8 @@ public static class ServiceRegistration
             sp.GetRequiredService<IStatusListService>(),
             sp.GetRequiredService<IMenuNavigationService>(),
             sp.GetRequiredService<ISettingsProvider<AppSettings>>(),
-            sp.GetRequiredService<Core.State.IUiDispatcher>()));
+            sp.GetRequiredService<Core.State.IUiDispatcher>(),
+            sp.GetRequiredService<Core.Toast.IToastService>()));
         services.AddSingleton<ChattingPageViewModel>(sp => new ChattingPageViewModel(
             sp.GetRequiredService<ChatStatusDisplayState>(),
             sp.GetRequiredService<IAppState>(),

--- a/vrcosc-magicchatbox/Services/SettingsResetService.cs
+++ b/vrcosc-magicchatbox/Services/SettingsResetService.cs
@@ -37,6 +37,8 @@ public sealed class SettingsResetService : ISettingsResetService
         "LocalClientKeyEncrypted"
     };
 
+    private const string EncryptedSuffix = "Encrypted";
+
     public int ResetAll<T>(ISettingsProvider<T> provider, bool preserveCredentials = true) where T : class, new()
     {
         var propertyNames = typeof(T)
@@ -59,6 +61,7 @@ public sealed class SettingsResetService : ISettingsResetService
 
         var current = provider.Value;
         var defaults = new T();
+        var written = new HashSet<string>(StringComparer.Ordinal);
         int resetCount = 0;
 
         foreach (var propertyName in propertyNames.Distinct(StringComparer.Ordinal))
@@ -73,19 +76,25 @@ public sealed class SettingsResetService : ISettingsResetService
             if (!CanResetProperty(property, preserveCredentials))
                 continue;
 
+            var target = ResolveWriteTarget<T>(property);
+            if (!written.Add(target.Name))
+                continue;
+
             try
             {
-                var defaultValue = property.GetValue(defaults);
-                property.SetValue(current, defaultValue);
+                var defaultValue = target.GetValue(defaults);
+                target.SetValue(current, defaultValue);
                 resetCount++;
             }
             catch (Exception ex)
             {
-                Logging.WriteInfo($"[SettingsReset] Failed to reset {typeof(T).Name}.{property.Name}: {ex.Message}");
+                Logging.WriteInfo($"[SettingsReset] Failed to reset {typeof(T).Name}.{target.Name}: {ex.Message}");
             }
         }
 
-        provider.Save();
+        // Flush rather than save: the writes above armed the debounced auto-save, and letting that
+        // fire afterwards would persist whatever a listener wrote back while reacting to the reset.
+        provider.FlushPendingSave();
         Logging.WriteInfo($"[SettingsReset] Reset {resetCount} setting(s) on {typeof(T).Name}.");
         return resetCount;
     }
@@ -104,12 +113,37 @@ public sealed class SettingsResetService : ISettingsResetService
         if (IsJsonIgnoredNonCredential(property))
             return false;
 
-        return !preserveCredentials || !CredentialPropertyNames.Contains(property.Name);
+        return !preserveCredentials || !IsPreservedCredential(property.Name);
     }
 
     private static bool IsJsonIgnoredNonCredential(PropertyInfo property)
     {
         return property.GetCustomAttribute<JsonIgnoreAttribute>() != null
-            && !CredentialPropertyNames.Contains(property.Name);
+            && !IsPreservedCredential(property.Name);
+    }
+
+    // Half of an encrypted pair cannot be protected on its own: the two halves share one stored value
+    // and each setter rewrites the other, so clearing either one also clears the one being protected.
+    private static bool IsPreservedCredential(string propertyName)
+        => CredentialPropertyNames.Contains(propertyName)
+            || CredentialPropertyNames.Contains(TwinPropertyName(propertyName));
+
+    private static string TwinPropertyName(string propertyName)
+        => propertyName.EndsWith(EncryptedSuffix, StringComparison.OrdinalIgnoreCase)
+            ? propertyName[..^EncryptedSuffix.Length]
+            : propertyName + EncryptedSuffix;
+
+    // For the same reason, an encrypted half is reset through its plaintext twin: writing the
+    // encrypted half directly blanks the plaintext one instead of restoring its default.
+    private static PropertyInfo ResolveWriteTarget<T>(PropertyInfo property)
+    {
+        if (!property.Name.EndsWith(EncryptedSuffix, StringComparison.Ordinal))
+            return property;
+
+        var plaintext = typeof(T).GetProperty(
+            property.Name[..^EncryptedSuffix.Length],
+            BindingFlags.Public | BindingFlags.Instance);
+
+        return plaintext is { CanRead: true, CanWrite: true } ? plaintext : property;
     }
 }

--- a/vrcosc-magicchatbox/Services/TtsPlaybackService.cs
+++ b/vrcosc-magicchatbox/Services/TtsPlaybackService.cs
@@ -79,7 +79,9 @@ public sealed class TtsPlaybackService : ITtsPlaybackService
 
                 await _tts.Value.PlayTikTokAudioAsSpeechAsync(
                     audioFromApi,
-                    _ttsAudio.SelectedPlaybackOutputDevice.ID,
+                    // Both call sites gate TTS on a prior successful PopulateOutputDevices(), which
+                    // assigns this before the API round-trip above has a chance to complete.
+                    _ttsAudio.SelectedPlaybackOutputDevice!.ID,
                     token);
 
                 _chatStatus.ChatFeedbackTxt = resent

--- a/vrcosc-magicchatbox/Services/VersionService.cs
+++ b/vrcosc-magicchatbox/Services/VersionService.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Concurrent;
@@ -52,7 +52,7 @@ public sealed class VersionService : IVersionService
         {
             var assembly = Assembly.GetExecutingAssembly();
             var assemblyName = assembly.GetName();
-            string versionString = assemblyName.Version.ToString();
+            string versionString = assemblyName.Version!.ToString();
             var version = new ViewModels.Models.Version(versionString);
             return version.VersionNumber;
         }
@@ -91,7 +91,7 @@ public sealed class VersionService : IVersionService
 
     private async Task CheckForUpdateAsync()
     {
-        UpdateVerdict verdict = null;
+        UpdateVerdict? verdict = null;
 
         try
         {
@@ -225,12 +225,12 @@ public sealed class VersionService : IVersionService
 
     private static UpdateOffer ReadOffer(JToken release, UpdateChannel channel)
     {
-        string tag = release.Value<string>("tag_name");
+        string? tag = release.Value<string>("tag_name");
         if (string.IsNullOrWhiteSpace(tag))
             return UpdateOffer.Absent(channel);
 
-        JArray assets = release.Value<JArray>("assets");
-        JToken asset = assets?.FirstOrDefault(candidate =>
+        JArray? assets = release.Value<JArray>("assets");
+        JToken? asset = assets?.FirstOrDefault(candidate =>
                            (candidate.Value<string>("name") ?? string.Empty)
                            .EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
                        ?? assets?.FirstOrDefault();
@@ -350,7 +350,7 @@ public sealed class VersionService : IVersionService
         response.EnsureSuccessStatusCode();
 
         string body = await response.Content.ReadAsStringAsync();
-        string etag = response.Headers.ETag?.ToString();
+        string? etag = response.Headers.ETag?.ToString();
 
         if (!string.IsNullOrEmpty(etag))
             _cache[url] = new CachedResponse(etag, body);
@@ -370,7 +370,7 @@ public sealed class VersionService : IVersionService
             using var response = await client.GetAsync(Core.Constants.GitHubRateLimitUrl);
             var data = JsonConvert.DeserializeObject<JObject>(await response.Content.ReadAsStringAsync());
 
-            JToken core = data?["resources"]?["core"];
+            JToken? core = data?["resources"]?["core"];
             if (core == null)
                 return RateLimitStatus.Unknown;
 
@@ -395,7 +395,7 @@ public sealed class VersionService : IVersionService
         if (string.IsNullOrEmpty(OpenAISettings.DefaultApiStream))
             return false;
 
-        string token = EncryptionMethods.DecryptString(OpenAISettings.DefaultApiStream);
+        string? token = EncryptionMethods.DecryptString(OpenAISettings.DefaultApiStream);
         if (string.IsNullOrEmpty(token))
             return false;
 

--- a/vrcosc-magicchatbox/Services/VersionService.cs
+++ b/vrcosc-magicchatbox/Services/VersionService.cs
@@ -1,9 +1,11 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Reflection;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using vrcosc_magicchatbox.Classes.DataAndSecurity;
@@ -11,28 +13,35 @@ using vrcosc_magicchatbox.Classes.Modules;
 using vrcosc_magicchatbox.Core.Configuration;
 using vrcosc_magicchatbox.Core.Services;
 using vrcosc_magicchatbox.Core.State;
+using vrcosc_magicchatbox.Core.Updates;
 using vrcosc_magicchatbox.ViewModels.State;
 
 namespace vrcosc_magicchatbox.Services;
 
 public sealed class VersionService : IVersionService
 {
+    private const int ReleasePageSize = 15;
+
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly AppUpdateState _updateState;
     private readonly ISettingsProvider<AppSettings> _appSettingsProvider;
     private readonly IUiDispatcher _dispatcher;
+    private readonly IAutoUpdateService _autoUpdate;
     private readonly SemaphoreSlim _updateLock = new(1, 1);
+    private readonly ConcurrentDictionary<string, CachedResponse> _cache = new();
 
     public VersionService(
         IHttpClientFactory httpClientFactory,
         AppUpdateState updateState,
         ISettingsProvider<AppSettings> appSettingsProvider,
-        IUiDispatcher dispatcher)
+        IUiDispatcher dispatcher,
+        IAutoUpdateService autoUpdate)
     {
         _httpClientFactory = httpClientFactory;
         _updateState = updateState;
         _appSettingsProvider = appSettingsProvider;
         _dispatcher = dispatcher;
+        _autoUpdate = autoUpdate;
     }
 
     public string GetApplicationVersion()
@@ -80,14 +89,13 @@ public sealed class VersionService : IVersionService
 
     private async Task CheckForUpdateAsync()
     {
+        UpdateVerdict verdict = null;
+
         try
         {
-            const string urlLatest = Core.Constants.GitHubReleasesLatestUrl;
-            const string urlPreRelease = Core.Constants.GitHubReleasesUrl;
-
-            bool isWithinRateLimit = await CheckRateLimitAsync();
             var client = _httpClientFactory.CreateClient("GitHub");
 
+            bool isWithinRateLimit = await CheckRateLimitAsync();
             if (!isWithinRateLimit && !string.IsNullOrEmpty(OpenAISettings.DefaultApiStream))
             {
                 string token = EncryptionMethods.DecryptString(OpenAISettings.DefaultApiStream);
@@ -95,50 +103,57 @@ public sealed class VersionService : IVersionService
                     client.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", $"Token {token}");
             }
 
-            using var responseLatest = await client.GetAsync(urlLatest);
-            var jsonLatest = await responseLatest.Content.ReadAsStringAsync();
-            JObject releaseLatest = JObject.Parse(jsonLatest);
-            string latestVersion = releaseLatest.Value<string>("tag_name");
+            UpdateOffer stable = UpdateOffer.Absent(UpdateChannel.Stable);
+            UpdateOffer preRelease = UpdateOffer.Absent(UpdateChannel.PreRelease);
 
-            _updateState.LatestReleaseVersion = new ViewModels.Models.Version(
-                Regex.Replace(latestVersion, "[^0-9.]", string.Empty));
+            string listUrl = $"{Core.Constants.GitHubReleasesUrl}?per_page={ReleasePageSize}";
+            string listJson = await GetWithCacheAsync(client, listUrl);
 
-            JArray assetsLatest = releaseLatest.Value<JArray>("assets");
-            if (assetsLatest != null && assetsLatest.Count > 0)
+            if (!string.IsNullOrWhiteSpace(listJson))
             {
-                _updateState.LatestReleaseURL = assetsLatest[0].Value<string>("browser_download_url");
-                _updateState.LatestReleaseDigest = assetsLatest[0].Value<string>("digest") ?? string.Empty;
-            }
+                JArray releases = JArray.Parse(listJson);
 
-            using var responsePreRelease = await client.GetAsync(urlPreRelease);
-            var jsonPreRelease = await responsePreRelease.Content.ReadAsStringAsync();
-            JArray releases = JArray.Parse(jsonPreRelease);
-
-            foreach (var release in releases)
-            {
-                if (release.Value<bool>("prerelease"))
+                foreach (var release in releases)
                 {
-                    string preReleaseVersion = release.Value<string>("tag_name");
-                    JArray assetsPreRelease = release.Value<JArray>("assets");
-                    string preReleaseDownloadUrl = null;
-                    string preReleaseDigest = null;
+                    if (release.Value<bool>("draft"))
+                        continue;
 
-                    if (assetsPreRelease != null && assetsPreRelease.Count > 0)
-                    {
-                        preReleaseDownloadUrl = assetsPreRelease[0].Value<string>("browser_download_url");
-                        preReleaseDigest = assetsPreRelease[0].Value<string>("digest");
-                    }
+                    bool isPreRelease = release.Value<bool>("prerelease");
 
-                    if (_appSettingsProvider.Value.JoinedAlphaChannel && !string.IsNullOrEmpty(preReleaseVersion))
-                    {
-                        _updateState.PreReleaseVersion = new ViewModels.Models.Version(
-                            Regex.Replace(preReleaseVersion, "[^0-9.]", string.Empty));
-                        _updateState.PreReleaseURL = preReleaseDownloadUrl ?? string.Empty;
-                        _updateState.PreReleaseDigest = preReleaseDigest ?? string.Empty;
-                    }
-                    break;
+                    if (isPreRelease && preRelease.IsPresent)
+                        continue;
+                    if (!isPreRelease && stable.IsPresent)
+                        continue;
+
+                    UpdateOffer offer = ReadOffer(
+                        release,
+                        isPreRelease ? UpdateChannel.PreRelease : UpdateChannel.Stable);
+
+                    if (!offer.IsPresent)
+                        continue;
+
+                    if (isPreRelease)
+                        preRelease = offer;
+                    else
+                        stable = offer;
+
+                    if (stable.IsPresent && preRelease.IsPresent)
+                        break;
                 }
             }
+
+            // A repository can publish more pre-releases than fit on one page, which would leave
+            // the stable channel looking empty. The dedicated endpoint always resolves it.
+            if (!stable.IsPresent)
+            {
+                string latestJson = await GetWithCacheAsync(client, Core.Constants.GitHubReleasesLatestUrl);
+                if (!string.IsNullOrWhiteSpace(latestJson))
+                    stable = ReadOffer(JObject.Parse(latestJson), UpdateChannel.Stable);
+            }
+
+            PublishOffers(stable, preRelease);
+
+            verdict = Decide(stable, preRelease);
 
             var updater = new UpdateApp(_updateState, _httpClientFactory, _dispatcher);
             _updateState.RollBackUpdateAvailable = updater.CheckIfBackupExists();
@@ -146,14 +161,161 @@ public sealed class VersionService : IVersionService
         catch (Exception ex)
         {
             Logging.WriteException(ex, MSGBox: false);
+
+            // A check that never completed says nothing about which version is current, so the
+            // failure stands rather than being painted over with a reassuring "up-to-date".
+            _updateState.CanUpdate = false;
+            _updateState.CanUpdateLabel = false;
+            _updateState.PendingUpdateChannel = null;
             _updateState.VersionTxt = "Can't check updates";
             _updateState.VersionTxtColor = "#F36734";
             _updateState.VersionTxtUnderLine = false;
+            return;
         }
-        finally
+
+        ApplyVerdict(verdict);
+
+        if (verdict.Action == UpdateAction.AutoInstall)
+            await _autoUpdate.ConsiderAsync(verdict);
+    }
+
+    private UpdateVerdict Decide(UpdateOffer stable, UpdateOffer preRelease)
+    {
+        AppSettings settings = _appSettingsProvider.Value;
+
+        return UpdateDecision.Decide(
+            _updateState.AppVersion?.VersionNumber,
+            stable,
+            preRelease,
+            settings.StableUpdateMode,
+            settings.PreReleaseUpdateMode,
+            _autoUpdate.BlockedVersions);
+    }
+
+    private static UpdateOffer ReadOffer(JToken release, UpdateChannel channel)
+    {
+        string tag = release.Value<string>("tag_name");
+        if (string.IsNullOrWhiteSpace(tag))
+            return UpdateOffer.Absent(channel);
+
+        JArray assets = release.Value<JArray>("assets");
+        JToken asset = assets?.FirstOrDefault(candidate =>
+                           (candidate.Value<string>("name") ?? string.Empty)
+                           .EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
+                       ?? assets?.FirstOrDefault();
+
+        if (asset == null)
+            return UpdateOffer.Absent(channel);
+
+        return new UpdateOffer(
+            channel,
+            ReleaseVersion.Normalize(tag),
+            asset.Value<string>("browser_download_url") ?? string.Empty,
+            asset.Value<string>("digest") ?? string.Empty);
+    }
+
+    private void PublishOffers(UpdateOffer stable, UpdateOffer preRelease)
+    {
+        _updateState.LatestReleaseVersion = stable.IsPresent
+            ? new ViewModels.Models.Version(stable.Version)
+            : null;
+        _updateState.LatestReleaseURL = stable.Url;
+        _updateState.LatestReleaseDigest = stable.Digest;
+
+        // Cleared every pass: a pre-release that has been superseded or switched off must not
+        // leave a live download URL behind for a later decision to pick up.
+        bool exposePreRelease = _appSettingsProvider.Value.PreReleaseUpdateMode != UpdateChannelMode.Off
+                                && preRelease.IsPresent;
+
+        _updateState.PreReleaseVersion = exposePreRelease
+            ? new ViewModels.Models.Version(preRelease.Version)
+            : null;
+        _updateState.PreReleaseURL = exposePreRelease ? preRelease.Url : string.Empty;
+        _updateState.PreReleaseDigest = exposePreRelease ? preRelease.Digest : string.Empty;
+    }
+
+    private void ApplyVerdict(UpdateVerdict verdict)
+    {
+        try
         {
-            CompareVersions();
+            _updateState.PendingUpdateChannel = verdict.Standing == UpdateStanding.UpdateAvailable
+                ? verdict.Channel
+                : null;
+            _updateState.UpdateURL = verdict.Url;
+            _updateState.UpdateDigest = verdict.Digest;
+            _updateState.UpdateVersion = verdict.Version;
+
+            switch (verdict.Standing)
+            {
+                case UpdateStanding.UpdateAvailable when verdict.Channel == UpdateChannel.PreRelease:
+                    _updateState.VersionTxt = "Try new pre-release";
+                    _updateState.VersionTxtColor = "#2FD9FF";
+                    _updateState.VersionTxtUnderLine = true;
+                    _updateState.CanUpdate = true;
+                    _updateState.CanUpdateLabel = false;
+                    break;
+
+                case UpdateStanding.UpdateAvailable:
+                    _updateState.VersionTxt = "Update now";
+                    _updateState.VersionTxtColor = "#FF8AFF04";
+                    _updateState.VersionTxtUnderLine = true;
+                    _updateState.CanUpdate = true;
+                    _updateState.CanUpdateLabel = true;
+                    break;
+
+                case UpdateStanding.AheadOfReleases:
+                    _updateState.VersionTxt = "✨ Supporter version ✨";
+                    _updateState.VersionTxtColor = "#FFD700";
+                    _updateState.VersionTxtUnderLine = false;
+                    _updateState.CanUpdate = false;
+                    _updateState.CanUpdateLabel = false;
+                    break;
+
+                case UpdateStanding.UpToDate when verdict.Channel == UpdateChannel.PreRelease:
+                    _updateState.VersionTxt = "Up-to-date (pre-release)";
+                    _updateState.VersionTxtColor = "#75D5FE";
+                    _updateState.VersionTxtUnderLine = false;
+                    _updateState.CanUpdate = false;
+                    _updateState.CanUpdateLabel = false;
+                    break;
+
+                default:
+                    _updateState.VersionTxt = "You are up-to-date";
+                    _updateState.VersionTxtColor = "#FF92CC90";
+                    _updateState.VersionTxtUnderLine = false;
+                    _updateState.CanUpdate = false;
+                    _updateState.CanUpdateLabel = false;
+                    break;
+            }
         }
+        catch (Exception ex)
+        {
+            Logging.WriteException(ex, MSGBox: false);
+        }
+    }
+
+    private async Task<string> GetWithCacheAsync(HttpClient client, string url)
+    {
+        _cache.TryGetValue(url, out CachedResponse cached);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        if (!string.IsNullOrEmpty(cached.ETag))
+            request.Headers.TryAddWithoutValidation("If-None-Match", cached.ETag);
+
+        using var response = await client.SendAsync(request);
+
+        if (response.StatusCode == HttpStatusCode.NotModified && cached.Body != null)
+            return cached.Body;
+
+        response.EnsureSuccessStatusCode();
+
+        string body = await response.Content.ReadAsStringAsync();
+        string etag = response.Headers.ETag?.ToString();
+
+        if (!string.IsNullOrEmpty(etag))
+            _cache[url] = new CachedResponse(etag, body);
+
+        return body;
     }
 
     private async Task<bool> CheckRateLimitAsync()
@@ -174,91 +336,5 @@ public sealed class VersionService : IVersionService
         }
     }
 
-    private void CompareVersions()
-    {
-        try
-        {
-            int compareWithLatest = CompareVersionNumbers(
-                _updateState.AppVersion?.VersionNumber,
-                _updateState.LatestReleaseVersion?.VersionNumber);
-
-            if (compareWithLatest < 0)
-            {
-                _updateState.VersionTxt = "Update now";
-                _updateState.VersionTxtColor = "#FF8AFF04";
-                _updateState.VersionTxtUnderLine = true;
-                _updateState.CanUpdate = true;
-                _updateState.CanUpdateLabel = true;
-                _updateState.UpdateURL = _updateState.LatestReleaseURL;
-                _updateState.UpdateDigest = _updateState.LatestReleaseDigest;
-                return;
-            }
-
-            if (_appSettingsProvider.Value.JoinedAlphaChannel && _updateState.PreReleaseVersion != null)
-            {
-                int compareWithPre = CompareVersionNumbers(
-                    _updateState.AppVersion?.VersionNumber,
-                    _updateState.PreReleaseVersion.VersionNumber);
-
-                if (compareWithPre < 0)
-                {
-                    _updateState.VersionTxt = "Try new pre-release";
-                    _updateState.VersionTxtUnderLine = true;
-                    _updateState.VersionTxtColor = "#2FD9FF";
-                    _updateState.CanUpdate = true;
-                    _updateState.CanUpdateLabel = false;
-                    _updateState.UpdateURL = _updateState.PreReleaseURL;
-                    _updateState.UpdateDigest = _updateState.PreReleaseDigest;
-                    return;
-                }
-                else if (compareWithPre == 0)
-                {
-                    _updateState.VersionTxt = "Up-to-date (pre-release)";
-                    _updateState.VersionTxtUnderLine = false;
-                    _updateState.VersionTxtColor = "#75D5FE";
-                    _updateState.CanUpdateLabel = false;
-                    _updateState.CanUpdate = false;
-                    return;
-                }
-            }
-
-            if (compareWithLatest > 0)
-            {
-                _updateState.VersionTxt = "✨ Supporter version ✨";
-                _updateState.VersionTxtColor = "#FFD700";
-                _updateState.VersionTxtUnderLine = false;
-                _updateState.CanUpdate = false;
-                _updateState.CanUpdateLabel = false;
-                return;
-            }
-
-            _updateState.VersionTxt = "You are up-to-date";
-            _updateState.VersionTxtUnderLine = false;
-            _updateState.VersionTxtColor = "#FF92CC90";
-            _updateState.CanUpdateLabel = false;
-            _updateState.CanUpdate = false;
-        }
-        catch (Exception ex)
-        {
-            Logging.WriteException(ex, MSGBox: false);
-        }
-    }
-
-    private static int CompareVersionNumbers(string a, string b)
-    {
-        if (string.IsNullOrEmpty(a) || string.IsNullOrEmpty(b))
-            return string.Compare(a ?? "", b ?? "", StringComparison.Ordinal);
-
-        var partsA = a.Split('.');
-        var partsB = b.Split('.');
-        int maxLen = Math.Max(partsA.Length, partsB.Length);
-
-        for (int i = 0; i < maxLen; i++)
-        {
-            int segA = i < partsA.Length && int.TryParse(partsA[i], out int va) ? va : 0;
-            int segB = i < partsB.Length && int.TryParse(partsB[i], out int vb) ? vb : 0;
-            if (segA != segB) return segA.CompareTo(segB);
-        }
-        return 0;
-    }
+    private readonly record struct CachedResponse(string ETag, string Body);
 }

--- a/vrcosc-magicchatbox/Services/VersionService.cs
+++ b/vrcosc-magicchatbox/Services/VersionService.cs
@@ -30,6 +30,8 @@ public sealed class VersionService : IVersionService
     private readonly SemaphoreSlim _updateLock = new(1, 1);
     private readonly ConcurrentDictionary<string, CachedResponse> _cache = new();
 
+    private DateTimeOffset _quotaResetsAtUtc = DateTimeOffset.MinValue;
+
     public VersionService(
         IHttpClientFactory httpClientFactory,
         AppUpdateState updateState,
@@ -93,14 +95,30 @@ public sealed class VersionService : IVersionService
 
         try
         {
+            // Waiting out a limit that is already known, rather than spending a request to be
+            // told about it again: GitHub answers an exhausted quota with an error, not the data.
+            if (DateTimeOffset.UtcNow < _quotaResetsAtUtc)
+            {
+                ShowQuotaPause();
+                return;
+            }
+
             var client = _httpClientFactory.CreateClient("GitHub");
 
-            bool isWithinRateLimit = await CheckRateLimitAsync();
-            if (!isWithinRateLimit && !string.IsNullOrEmpty(OpenAISettings.DefaultApiStream))
+            RateLimitStatus limit = await ReadRateLimitAsync();
+            if (limit.Exhausted)
             {
-                string token = EncryptionMethods.DecryptString(OpenAISettings.DefaultApiStream);
-                if (token != null)
-                    client.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", $"Token {token}");
+                _quotaResetsAtUtc = limit.ResetsAtUtc;
+
+                if (!TryAttachFallbackToken(client))
+                {
+                    Logging.WriteInfo(
+                        "GitHub's hourly allowance for this address is used up, so the update check is " +
+                        $"held until {_quotaResetsAtUtc.ToLocalTime():HH:mm}. This is shared by everything " +
+                        "on the connection, not just MagicChatbox.");
+                    ShowQuotaPause();
+                    return;
+                }
             }
 
             UpdateOffer stable = UpdateOffer.Absent(UpdateChannel.Stable);
@@ -157,6 +175,19 @@ public sealed class VersionService : IVersionService
 
             var updater = new UpdateApp(_updateState, _httpClientFactory, _dispatcher);
             _updateState.RollBackUpdateAvailable = updater.CheckIfBackupExists();
+        }
+        catch (QuotaExhaustedException ex)
+        {
+            // The pre-flight reading can be a little behind, and the quota is shared by everything
+            // on this address, so an exhausted response can still arrive after a clean check.
+            _quotaResetsAtUtc = ex.ResetsAtUtc > DateTimeOffset.UtcNow
+                ? ex.ResetsAtUtc
+                : DateTimeOffset.UtcNow.AddMinutes(10);
+
+            Logging.WriteInfo(
+                $"GitHub is not answering update checks from this address until {_quotaResetsAtUtc.ToLocalTime():HH:mm}.");
+            ShowQuotaPause();
+            return;
         }
         catch (Exception ex)
         {
@@ -307,6 +338,15 @@ public sealed class VersionService : IVersionService
         if (response.StatusCode == HttpStatusCode.NotModified && cached.Body != null)
             return cached.Body;
 
+        if (response.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.TooManyRequests
+            && ReadHeader(response, "x-ratelimit-remaining") == 0)
+        {
+            long reset = ReadHeader(response, "x-ratelimit-reset") ?? 0;
+            throw new QuotaExhaustedException(reset > 0
+                ? DateTimeOffset.FromUnixTimeSeconds(reset)
+                : DateTimeOffset.UtcNow.AddMinutes(10));
+        }
+
         response.EnsureSuccessStatusCode();
 
         string body = await response.Content.ReadAsStringAsync();
@@ -318,7 +358,11 @@ public sealed class VersionService : IVersionService
         return body;
     }
 
-    private async Task<bool> CheckRateLimitAsync()
+    /// <summary>
+    /// Asks how much of the hourly allowance is left. This endpoint is not itself counted
+    /// against that allowance, so it costs nothing to ask before spending a request.
+    /// </summary>
+    private async Task<RateLimitStatus> ReadRateLimitAsync()
     {
         try
         {
@@ -326,14 +370,62 @@ public sealed class VersionService : IVersionService
             using var response = await client.GetAsync(Core.Constants.GitHubRateLimitUrl);
             var data = JsonConvert.DeserializeObject<JObject>(await response.Content.ReadAsStringAsync());
 
-            var remaining = (int)data["resources"]["core"]["remaining"];
-            return remaining > 0;
+            JToken core = data?["resources"]?["core"];
+            if (core == null)
+                return RateLimitStatus.Unknown;
+
+            int remaining = core.Value<int?>("remaining") ?? 1;
+            long reset = core.Value<long?>("reset") ?? 0;
+
+            return new RateLimitStatus(
+                remaining <= 0,
+                reset > 0 ? DateTimeOffset.FromUnixTimeSeconds(reset) : DateTimeOffset.UtcNow.AddMinutes(10));
         }
         catch (Exception ex)
         {
-            Logging.WriteException(ex, MSGBox: false);
-            return false;
+            // Not knowing is not the same as being out. The request itself is still worth trying,
+            // and it reports its own exhaustion accurately if that turns out to be the case.
+            Logging.WriteInfo($"Could not read the GitHub allowance: {ex.Message}");
+            return RateLimitStatus.Unknown;
         }
+    }
+
+    private static bool TryAttachFallbackToken(HttpClient client)
+    {
+        if (string.IsNullOrEmpty(OpenAISettings.DefaultApiStream))
+            return false;
+
+        string token = EncryptionMethods.DecryptString(OpenAISettings.DefaultApiStream);
+        if (string.IsNullOrEmpty(token))
+            return false;
+
+        client.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", $"Token {token}");
+        return true;
+    }
+
+    private void ShowQuotaPause()
+    {
+        // Not an error and not a version claim: the last thing that was learned about updates
+        // still stands, so nothing about the update state is disturbed here.
+        _updateState.VersionTxt = $"Update check paused until {_quotaResetsAtUtc.ToLocalTime():HH:mm}";
+        _updateState.VersionTxtColor = "#FBB644";
+        _updateState.VersionTxtUnderLine = false;
+    }
+
+    private static long? ReadHeader(HttpResponseMessage response, string name)
+        => response.Headers.TryGetValues(name, out var values)
+           && long.TryParse(values.FirstOrDefault(), out long value)
+            ? value
+            : null;
+
+    private readonly record struct RateLimitStatus(bool Exhausted, DateTimeOffset ResetsAtUtc)
+    {
+        public static readonly RateLimitStatus Unknown = new(false, DateTimeOffset.MinValue);
+    }
+
+    private sealed class QuotaExhaustedException(DateTimeOffset resetsAtUtc) : Exception("GitHub request allowance exhausted.")
+    {
+        public DateTimeOffset ResetsAtUtc { get; } = resetsAtUtc;
     }
 
     private readonly record struct CachedResponse(string ETag, string Body);

--- a/vrcosc-magicchatbox/Services/Voicemod/VoicemodArtworkCache.cs
+++ b/vrcosc-magicchatbox/Services/Voicemod/VoicemodArtworkCache.cs
@@ -32,6 +32,9 @@ public sealed class VoicemodArtworkCache : IVoicemodArtworkCache
 
     private const int MaximumBytes = 512 * 1024;
 
+    /// <summary>Covers the largest seat the artwork gets (33px) at 200% DPI, with headroom.</summary>
+    private const int DecodeWidth = 96;
+
     private readonly ConcurrentDictionary<string, ImageSource> _images = new(StringComparer.OrdinalIgnoreCase);
 
     // Insertion order, so a full cache can drop its oldest entry instead of refusing every new one.
@@ -108,6 +111,10 @@ public sealed class VoicemodArtworkCache : IVoicemodArtworkCache
             bitmap.BeginInit();
             bitmap.CacheOption = BitmapCacheOption.OnLoad;
             bitmap.StreamSource = stream;
+
+            // These are shown at ~33px. Without a decode size the full-resolution pixel buffer is what
+            // stays resident, once per cached sound.
+            bitmap.DecodePixelWidth = DecodeWidth;
             bitmap.EndInit();
             bitmap.Freeze();
             image = bitmap;

--- a/vrcosc-magicchatbox/Services/Vr/ISteamVrApplications.cs
+++ b/vrcosc-magicchatbox/Services/Vr/ISteamVrApplications.cs
@@ -1,0 +1,28 @@
+namespace vrcosc_magicchatbox.Services.Vr;
+
+public enum SteamVrOutcome
+{
+    Done,
+    SteamVrUnavailable,
+    Failed,
+}
+
+public readonly record struct SteamVrResult(SteamVrOutcome Outcome, string Detail)
+{
+    public static SteamVrResult Done() => new(SteamVrOutcome.Done, string.Empty);
+
+    public static SteamVrResult Unavailable(string detail) => new(SteamVrOutcome.SteamVrUnavailable, detail);
+
+    public static SteamVrResult Failed(string detail) => new(SteamVrOutcome.Failed, detail);
+
+    public bool Succeeded => Outcome == SteamVrOutcome.Done;
+}
+
+public interface ISteamVrApplications
+{
+    SteamVrResult Register(string manifestPath, string appKey);
+
+    SteamVrResult Unregister(string manifestPath, string appKey);
+
+    bool IsAutoLaunchEnabled(string appKey);
+}

--- a/vrcosc-magicchatbox/Services/Vr/OpenVrSessionService.cs
+++ b/vrcosc-magicchatbox/Services/Vr/OpenVrSessionService.cs
@@ -28,8 +28,8 @@ public sealed class OpenVrSessionService : IOpenVrSessionService
     private static readonly TimeSpan AttachRetryInterval = TimeSpan.FromSeconds(5);
 
     private readonly IOpenVrRuntime _runtime;
-    private readonly IAppState _appState;
-    private readonly IPrivacyConsentService _consent;
+    private readonly IAppState? _appState;
+    private readonly IPrivacyConsentService? _consent;
     private readonly Func<DateTime> _utcNow;
     private readonly Func<bool> _isUiThread;
     private readonly object _lock = new();
@@ -45,8 +45,8 @@ public sealed class OpenVrSessionService : IOpenVrSessionService
 
     public OpenVrSessionService(
         IOpenVrRuntime runtime,
-        IAppState appState,
-        IPrivacyConsentService consent,
+        IAppState? appState,
+        IPrivacyConsentService? consent,
         Func<DateTime>? utcNow = null,
         Func<bool>? isUiThread = null)
     {

--- a/vrcosc-magicchatbox/Services/Vr/SteamVrApplications.cs
+++ b/vrcosc-magicchatbox/Services/Vr/SteamVrApplications.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Diagnostics;
+using Valve.VR;
+
+namespace vrcosc_magicchatbox.Services.Vr;
+
+/// <summary>
+/// Talks to SteamVR's application registry, which is what decides whether MagicChatbox appears
+/// in SteamVR's startup list and starts along with it.
+/// </summary>
+/// <remarks>
+/// OpenVR is initialised once per process, so this borrows the session service's runtime handle
+/// whenever one is already open and never shuts it down underneath it. On its own it opens a
+/// short-lived utility session instead, which is the one application type documented to work
+/// without a headset attached.
+/// </remarks>
+public sealed class SteamVrApplications : ISteamVrApplications
+{
+    private readonly IOpenVrSessionService _session;
+    private readonly object _lock = new();
+
+    public SteamVrApplications(IOpenVrSessionService session)
+    {
+        _session = session;
+    }
+
+    public SteamVrResult Register(string manifestPath, string appKey)
+        => Run(applications =>
+        {
+            EVRApplicationError error = applications.AddApplicationManifest(manifestPath, false);
+            if (error != EVRApplicationError.None)
+                return SteamVrResult.Failed($"AddApplicationManifest returned {error}");
+
+            // Naming the running process against the key gives SteamVR the link between the
+            // manifest and this instance, and settles the entry before auto-launch is set.
+            applications.IdentifyApplication((uint)Environment.ProcessId, appKey);
+
+            error = applications.SetApplicationAutoLaunch(appKey, true);
+            if (error != EVRApplicationError.None)
+                return SteamVrResult.Failed($"SetApplicationAutoLaunch returned {error}");
+
+            return SteamVrResult.Done();
+        });
+
+    public SteamVrResult Unregister(string manifestPath, string appKey)
+        => Run(applications =>
+        {
+            // The auto-launch flag lives under the key rather than the manifest and survives the
+            // manifest being removed, so it is cleared first or a later re-register comes back
+            // already armed.
+            if (applications.IsApplicationInstalled(appKey))
+                applications.SetApplicationAutoLaunch(appKey, false);
+
+            if (!string.IsNullOrWhiteSpace(manifestPath))
+                applications.RemoveApplicationManifest(manifestPath);
+
+            return SteamVrResult.Done();
+        });
+
+    public bool IsAutoLaunchEnabled(string appKey)
+    {
+        bool enabled = false;
+
+        SteamVrResult result = Run(applications =>
+        {
+            enabled = applications.IsApplicationInstalled(appKey)
+                      && applications.GetApplicationAutoLaunch(appKey);
+            return SteamVrResult.Done();
+        });
+
+        return result.Succeeded && enabled;
+    }
+
+    private SteamVrResult Run(Func<CVRApplications, SteamVrResult> work)
+    {
+        lock (_lock)
+        {
+            bool borrowed = _session.IsAttached;
+            bool initialised = false;
+
+            try
+            {
+                if (!borrowed)
+                {
+                    EVRInitError error = EVRInitError.None;
+                    Valve.VR.OpenVR.Init(ref error, EVRApplicationType.VRApplication_Utility);
+
+                    if (error != EVRInitError.None)
+                        return SteamVrResult.Unavailable($"SteamVR is not available ({error})");
+
+                    initialised = true;
+                }
+
+                CVRApplications applications = Valve.VR.OpenVR.Applications;
+                if (applications == null)
+                    return SteamVrResult.Unavailable("SteamVR did not offer its application registry");
+
+                return work(applications);
+            }
+            catch (Exception ex)
+            {
+                return SteamVrResult.Failed(ex.Message);
+            }
+            finally
+            {
+                // Never tears down a handle the session service has taken over in the meantime.
+                if (initialised && !_session.IsAttached)
+                    Valve.VR.OpenVR.Shutdown();
+            }
+        }
+    }
+}

--- a/vrcosc-magicchatbox/Services/Vr/SteamVrAutoStartService.cs
+++ b/vrcosc-magicchatbox/Services/Vr/SteamVrAutoStartService.cs
@@ -1,0 +1,270 @@
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using vrcosc_magicchatbox.Classes.DataAndSecurity;
+using vrcosc_magicchatbox.Classes.Modules;
+using vrcosc_magicchatbox.Core.Configuration;
+using vrcosc_magicchatbox.Core.State;
+
+namespace vrcosc_magicchatbox.Services.Vr;
+
+public interface ISteamVrAutoStartService
+{
+    void Start();
+
+    void Stop();
+}
+
+/// <summary>
+/// Keeps SteamVR's copy of the startup registration in step with the setting, and with wherever
+/// this copy of MagicChatbox currently lives.
+/// </summary>
+public sealed class SteamVrAutoStartService : ISteamVrAutoStartService, IDisposable
+{
+    private const string SteamVrProcessName = "vrmonitor";
+
+    private readonly ISteamVrApplications _applications;
+    private readonly ISettingsProvider<AppSettings> _settingsProvider;
+    private readonly IAppState _appState;
+    private readonly IProcessPresenceService _processes;
+    private readonly Action _requestShutdown;
+    private readonly Func<string> _executablePath;
+    private readonly string _manifestPath;
+
+    private int _reconcileInProgress;
+    private int _reconcileRequested;
+    private bool _retryPending;
+    private bool _sawSteamVrRunning;
+    private bool _started;
+    private bool _disposed;
+
+    public SteamVrAutoStartService(
+        ISteamVrApplications applications,
+        ISettingsProvider<AppSettings> settingsProvider,
+        IAppState appState,
+        IProcessPresenceService processes,
+        Action requestShutdown,
+        string localAppDataPath = null,
+        Func<string> executablePath = null)
+    {
+        _applications = applications;
+        _settingsProvider = settingsProvider;
+        _appState = appState;
+        _processes = processes;
+        _requestShutdown = requestShutdown;
+        _executablePath = executablePath ?? ResolveExecutablePath;
+        _manifestPath = SteamVrManifest.PathFor(
+            localAppDataPath ?? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData));
+    }
+
+    public void Start()
+    {
+        if (_started || _disposed)
+            return;
+
+        _started = true;
+        _settingsProvider.Value.PropertyChanged += OnSettingChanged;
+
+        if (_appState != null)
+        {
+            _sawSteamVrRunning = _appState.IsVRRunning && IsSteamVrPresent();
+            _appState.PropertyChanged += OnAppStateChanged;
+        }
+
+        Reconcile();
+    }
+
+    public void Stop()
+    {
+        if (!_started)
+            return;
+
+        _started = false;
+        _settingsProvider.Value.PropertyChanged -= OnSettingChanged;
+
+        if (_appState != null)
+            _appState.PropertyChanged -= OnAppStateChanged;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        Stop();
+    }
+
+    private void OnSettingChanged(object sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(AppSettings.StartWithSteamVr))
+            Reconcile();
+    }
+
+    private void OnAppStateChanged(object sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(IAppState.IsVRRunning))
+            return;
+
+        if (_appState.IsVRRunning)
+        {
+            if (!IsSteamVrPresent())
+                return;
+
+            _sawSteamVrRunning = true;
+
+            if (_retryPending)
+            {
+                _retryPending = false;
+                Reconcile();
+            }
+
+            return;
+        }
+
+        if (!_sawSteamVrRunning)
+            return;
+
+        _sawSteamVrRunning = false;
+
+        AppSettings settings = _settingsProvider.Value;
+        if (!settings.StartWithSteamVr || !settings.QuitWithSteamVr)
+            return;
+
+        // IsVRRunning also covers the Oculus runtime, so this confirms it was SteamVR that went
+        // away before taking the app down with it.
+        _processes?.Invalidate(SteamVrProcessName);
+        if (IsSteamVrPresent())
+            return;
+
+        Logging.WriteInfo("SteamVR closed, so MagicChatbox is closing with it.");
+        _requestShutdown?.Invoke();
+    }
+
+    private bool IsSteamVrPresent()
+        => _processes?.IsRunning(SteamVrProcessName) ?? true;
+
+    private void Reconcile()
+    {
+        if (_disposed)
+            return;
+
+        if (Interlocked.CompareExchange(ref _reconcileInProgress, 1, 0) == 1)
+        {
+            // A change that arrives while one of these is already running is remembered rather
+            // than dropped. Without it a quick double-toggle leaves SteamVR holding the state
+            // the user just moved away from.
+            Interlocked.Exchange(ref _reconcileRequested, 1);
+            return;
+        }
+
+        _ = Task.Run(() =>
+        {
+            try
+            {
+                ReconcileCore();
+            }
+            catch (Exception ex)
+            {
+                Logging.WriteException(ex, MSGBox: false);
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _reconcileInProgress, 0);
+            }
+
+            if (Interlocked.Exchange(ref _reconcileRequested, 0) == 1)
+                Reconcile();
+        });
+    }
+
+    private void ReconcileCore()
+    {
+        AppSettings settings = _settingsProvider.Value;
+
+        SteamVrResult result = settings.StartWithSteamVr
+            ? Register(settings)
+            : Unregister(settings);
+
+        switch (result.Outcome)
+        {
+            case SteamVrOutcome.Done:
+                Logging.WriteInfo(settings.StartWithSteamVr
+                    ? "MagicChatbox is registered to start with SteamVR."
+                    : "MagicChatbox no longer starts with SteamVR.");
+                break;
+
+            case SteamVrOutcome.SteamVrUnavailable:
+                // Nothing is wrong: SteamVR simply is not up yet. The setting stands and the
+                // registration is applied the next time a session appears.
+                Logging.WriteInfo($"Leaving the SteamVR startup setting until SteamVR is running. {result.Detail}");
+                ArmRetry();
+                break;
+
+            case SteamVrOutcome.Failed:
+                Logging.WriteInfo($"Could not update the SteamVR startup setting: {result.Detail}");
+                ArmRetry();
+                break;
+        }
+    }
+
+    private SteamVrResult Register(AppSettings settings)
+    {
+        string executable = _executablePath();
+        if (string.IsNullOrWhiteSpace(executable) || !File.Exists(executable))
+            return SteamVrResult.Failed("Could not work out where MagicChatbox is running from.");
+
+        if (!SteamVrManifest.TryWrite(_manifestPath, executable, App.SteamVrLaunchArgument))
+            return SteamVrResult.Failed($"Could not write {_manifestPath}");
+
+        // Re-asserted on every launch rather than once, because SteamVR is known to lose the
+        // auto-launch flag across its own restarts and the call costs nothing when it is already
+        // set. It also picks up an executable that moved since last time.
+        SteamVrResult result = _applications.Register(_manifestPath, SteamVrManifest.AppKey);
+
+        if (result.Succeeded)
+            settings.SteamVrManifestPath = _manifestPath;
+
+        return result;
+    }
+
+    private SteamVrResult Unregister(AppSettings settings)
+    {
+        string registered = string.IsNullOrWhiteSpace(settings.SteamVrManifestPath)
+            ? _manifestPath
+            : settings.SteamVrManifestPath;
+
+        SteamVrResult result = _applications.Unregister(registered, SteamVrManifest.AppKey);
+
+        if (result.Outcome == SteamVrOutcome.SteamVrUnavailable)
+            return result;
+
+        SteamVrManifest.Delete(registered);
+        if (!string.Equals(registered, _manifestPath, StringComparison.OrdinalIgnoreCase))
+            SteamVrManifest.Delete(_manifestPath);
+
+        settings.SteamVrManifestPath = string.Empty;
+        return result;
+    }
+
+    private void ArmRetry() => _retryPending = true;
+
+    private static string ResolveExecutablePath()
+    {
+        try
+        {
+            string path = Environment.ProcessPath;
+            if (!string.IsNullOrWhiteSpace(path))
+                return Path.GetFullPath(path);
+
+            return Process.GetCurrentProcess().MainModule?.FileName;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException || ex is Win32Exception)
+        {
+            return null;
+        }
+    }
+}

--- a/vrcosc-magicchatbox/Services/Vr/SteamVrAutoStartService.cs
+++ b/vrcosc-magicchatbox/Services/Vr/SteamVrAutoStartService.cs
@@ -31,7 +31,7 @@ public sealed class SteamVrAutoStartService : ISteamVrAutoStartService, IDisposa
     private readonly IAppState _appState;
     private readonly IProcessPresenceService _processes;
     private readonly Action _requestShutdown;
-    private readonly Func<string> _executablePath;
+    private readonly Func<string?> _executablePath;
     private readonly string _manifestPath;
 
     private int _reconcileInProgress;
@@ -47,8 +47,8 @@ public sealed class SteamVrAutoStartService : ISteamVrAutoStartService, IDisposa
         IAppState appState,
         IProcessPresenceService processes,
         Action requestShutdown,
-        string localAppDataPath = null,
-        Func<string> executablePath = null)
+        string? localAppDataPath = null,
+        Func<string?>? executablePath = null)
     {
         _applications = applications;
         _settingsProvider = settingsProvider;
@@ -98,13 +98,13 @@ public sealed class SteamVrAutoStartService : ISteamVrAutoStartService, IDisposa
         Stop();
     }
 
-    private void OnSettingChanged(object sender, PropertyChangedEventArgs e)
+    private void OnSettingChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (e.PropertyName == nameof(AppSettings.StartWithSteamVr))
             Reconcile();
     }
 
-    private void OnAppStateChanged(object sender, PropertyChangedEventArgs e)
+    private void OnAppStateChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (e.PropertyName != nameof(IAppState.IsVRRunning))
             return;
@@ -213,7 +213,7 @@ public sealed class SteamVrAutoStartService : ISteamVrAutoStartService, IDisposa
 
     private SteamVrResult Register(AppSettings settings)
     {
-        string executable = _executablePath();
+        string? executable = _executablePath();
         if (string.IsNullOrWhiteSpace(executable) || !File.Exists(executable))
             return SteamVrResult.Failed("Could not work out where MagicChatbox is running from.");
 
@@ -252,11 +252,11 @@ public sealed class SteamVrAutoStartService : ISteamVrAutoStartService, IDisposa
 
     private void ArmRetry() => _retryPending = true;
 
-    private static string ResolveExecutablePath()
+    private static string? ResolveExecutablePath()
     {
         try
         {
-            string path = Environment.ProcessPath;
+            string? path = Environment.ProcessPath;
             if (!string.IsNullOrWhiteSpace(path))
                 return Path.GetFullPath(path);
 

--- a/vrcosc-magicchatbox/Services/Vr/SteamVrManifest.cs
+++ b/vrcosc-magicchatbox/Services/Vr/SteamVrManifest.cs
@@ -53,7 +53,7 @@ public static class SteamVrManifest
     {
         try
         {
-            string directory = Path.GetDirectoryName(manifestPath);
+            string? directory = Path.GetDirectoryName(manifestPath);
             if (!string.IsNullOrEmpty(directory))
                 Directory.CreateDirectory(directory);
 

--- a/vrcosc-magicchatbox/Services/Vr/SteamVrManifest.cs
+++ b/vrcosc-magicchatbox/Services/Vr/SteamVrManifest.cs
@@ -1,0 +1,88 @@
+using Newtonsoft.Json.Linq;
+using System;
+using System.IO;
+
+namespace vrcosc_magicchatbox.Services.Vr;
+
+/// <summary>
+/// The application manifest SteamVR reads to offer MagicChatbox as a startup app.
+/// </summary>
+/// <remarks>
+/// SteamVR records the manifest by its absolute path and keys removal on that same path, and
+/// registering one key from a second path leaves both entries in place. The file therefore has
+/// a fixed home of its own and the executable path inside it is rewritten on every launch,
+/// which keeps a portable copy that moves — or an update that replaces the installation — from
+/// leaving SteamVR pointed at an executable that is no longer there.
+/// </remarks>
+public static class SteamVrManifest
+{
+    public const string AppKey = "boihanny.magicchatbox";
+    public const string FileName = "magicchatbox.vrmanifest";
+
+    public static string DirectoryFor(string localAppDataPath)
+        => Path.Combine(localAppDataPath, "Vrcosc-MagicChatbox", "steamvr");
+
+    public static string PathFor(string localAppDataPath)
+        => Path.Combine(DirectoryFor(localAppDataPath), FileName);
+
+    public static string Build(string executablePath, string launchArgument)
+    {
+        var strings = new JObject(
+            new JProperty("en_us", new JObject(
+                new JProperty("name", "MagicChatbox"),
+                new JProperty("description", "Sends your status, music and stats to the VRChat chatbox."))));
+
+        var application = new JObject(
+            new JProperty("app_key", AppKey),
+            new JProperty("launch_type", "binary"),
+            new JProperty("binary_path_windows", executablePath ?? string.Empty),
+            new JProperty("arguments", launchArgument ?? string.Empty),
+            // Only overlay applications are eligible for auto-launch. The flag buys a place in
+            // SteamVR's startup list; the process itself still attaches as a background app.
+            new JProperty("is_dashboard_overlay", true),
+            new JProperty("strings", strings));
+
+        var manifest = new JObject(
+            new JProperty("source", "builtin"),
+            new JProperty("applications", new JArray(application)));
+
+        return manifest.ToString();
+    }
+
+    public static bool TryWrite(string manifestPath, string executablePath, string launchArgument)
+    {
+        try
+        {
+            string directory = Path.GetDirectoryName(manifestPath);
+            if (!string.IsNullOrEmpty(directory))
+                Directory.CreateDirectory(directory);
+
+            string contents = Build(executablePath, launchArgument);
+
+            if (File.Exists(manifestPath) &&
+                string.Equals(File.ReadAllText(manifestPath), contents, StringComparison.Ordinal))
+                return true;
+
+            string temporary = manifestPath + ".tmp";
+            File.WriteAllText(temporary, contents);
+            File.Move(temporary, manifestPath, overwrite: true);
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    public static void Delete(string manifestPath)
+    {
+        try
+        {
+            if (!string.IsNullOrWhiteSpace(manifestPath) && File.Exists(manifestPath))
+                File.Delete(manifestPath);
+        }
+        catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/vrcosc-magicchatbox/UI/Controls/LazyPageHost.cs
+++ b/vrcosc-magicchatbox/UI/Controls/LazyPageHost.cs
@@ -104,6 +104,9 @@ namespace vrcosc_magicchatbox.UI.Controls
 
             string name = Child.GetType().Name;
 
+            // Coercion catches values set from here on; this settles what the page was built with.
+            ReducedVisuals.Refresh(Child);
+
             Core.Diagnostics.PerfProbe.Record(
                 $"nav.build.{name}",
                 Stopwatch.GetElapsedTime(startTicks).TotalMilliseconds,
@@ -166,6 +169,9 @@ namespace vrcosc_magicchatbox.UI.Controls
 
         private void PlayEnterTransition()
         {
+            if (ReducedVisuals.IsEnabled)
+                return;
+
             var ease = new CubicEase { EasingMode = EasingMode.EaseOut };
 
             BeginAnimation(OpacityProperty, new DoubleAnimation(0.0, 1.0, EnterDuration)

--- a/vrcosc-magicchatbox/UI/Controls/LazyPageHost.cs
+++ b/vrcosc-magicchatbox/UI/Controls/LazyPageHost.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using vrcosc_magicchatbox.Classes.DataAndSecurity;
 using System.Windows;
 using System.Windows.Controls;
@@ -93,10 +94,22 @@ namespace vrcosc_magicchatbox.UI.Controls
             if (Child != null || PageTemplate == null)
                 return;
 
+            long startTicks = Stopwatch.GetTimestamp();
+            long startAllocated = GC.GetAllocatedBytesForCurrentThread();
+
             Child = PageTemplate.LoadContent() as UIElement;
 
-            if (Child != null)
-                Logging.WriteInfo($"Page built: {Child.GetType().Name}");
+            if (Child == null)
+                return;
+
+            string name = Child.GetType().Name;
+
+            Core.Diagnostics.PerfProbe.Record(
+                $"nav.build.{name}",
+                Stopwatch.GetElapsedTime(startTicks).TotalMilliseconds,
+                GC.GetAllocatedBytesForCurrentThread() - startAllocated);
+
+            Logging.WriteInfo($"Page built: {name}");
         }
 
         public void Release()
@@ -111,7 +124,12 @@ namespace vrcosc_magicchatbox.UI.Controls
             ReleaseFocus();
 
             string released = Child.GetType().Name;
+
+            long startTicks = Stopwatch.GetTimestamp();
             Child = null;
+            Core.Diagnostics.PerfProbe.Record(
+                $"nav.release.{released}",
+                Stopwatch.GetElapsedTime(startTicks).TotalMilliseconds);
 
             Logging.WriteInfo($"Page released: {released}");
         }

--- a/vrcosc-magicchatbox/UI/Controls/ReducedVisuals.cs
+++ b/vrcosc-magicchatbox/UI/Controls/ReducedVisuals.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
+using System.Windows.Media.Effects;
+
+namespace vrcosc_magicchatbox.UI.Controls;
+
+/// <summary>
+/// Gives the graphics card back the time the app spends on decoration: drop shadows, glows, partial
+/// opacity and animation. Every <see cref="UIElement.Effect"/> and every element below full opacity
+/// makes WPF render that subtree into an offscreen surface and composite it again, once per frame.
+/// </summary>
+/// <remarks>
+/// This works by coercion rather than by walking the tree and overwriting values. A sweep is wrong here:
+/// most of these values come from style and template triggers, so hovering a button or selecting a tab
+/// puts the shadow straight back, and the sweep only ever caught what happened to exist when it ran.
+/// A <see cref="CoerceValueCallback"/> runs on every write from every source, including triggers and
+/// animations, so there is nowhere for one to come back from.
+///
+/// While the mode is off, both callbacks hand back the value they were given, so nothing about normal
+/// rendering changes.
+/// </remarks>
+public static class ReducedVisuals
+{
+    /// <summary>
+    /// Elements whose effect was a blur. A blur is never structural - the element exists only to be a
+    /// soft glow - so dropping the effect would leave a hard-edged block sitting there. Those get
+    /// hidden instead. A drop shadow is decoration on real content, so that content stays.
+    /// </summary>
+    private static readonly ConditionalWeakTable<UIElement, object> BlurredDecoration = new();
+
+    private static readonly object Marker = new();
+
+    /// <summary>Animation frame rate while reduced. Low enough to be cheap, not zero, so state still settles.</summary>
+    private const int ReducedFrameRate = 10;
+
+    private static bool _installed;
+    private static bool _enabled;
+
+    public static bool IsEnabled
+    {
+        get => _enabled;
+        set
+        {
+            if (_enabled == value)
+                return;
+
+            _enabled = value;
+            Changed?.Invoke();
+        }
+    }
+
+    /// <summary>Raised when the mode is turned on or off, so live trees can be re-coerced.</summary>
+    public static event Action? Changed;
+
+    /// <summary>
+    /// Hooks the properties. Must run before the first window is built, because metadata cannot be
+    /// overridden once a type is in use.
+    /// </summary>
+    public static void Install()
+    {
+        if (_installed)
+            return;
+
+        _installed = true;
+
+        UIElement.EffectProperty.OverrideMetadata(
+            typeof(FrameworkElement),
+            new FrameworkPropertyMetadata(
+                null,
+                FrameworkPropertyMetadataOptions.AffectsRender,
+                null,
+                CoerceEffect));
+
+        UIElement.OpacityProperty.OverrideMetadata(
+            typeof(FrameworkElement),
+            new FrameworkPropertyMetadata(
+                1.0,
+                FrameworkPropertyMetadataOptions.AffectsRender,
+                null,
+                CoerceOpacity));
+
+        Timeline.DesiredFrameRateProperty.OverrideMetadata(
+            typeof(Timeline),
+            new FrameworkPropertyMetadata(null, null, CoerceFrameRate));
+    }
+
+    /// <summary>Re-runs the coercion over a subtree, for content that already exists.</summary>
+    public static void Refresh(DependencyObject? root)
+    {
+        if (root == null)
+            return;
+
+        if (root is UIElement element)
+        {
+            element.CoerceValue(UIElement.EffectProperty);
+            element.CoerceValue(UIElement.OpacityProperty);
+        }
+
+        int children = VisualTreeHelper.GetChildrenCount(root);
+        for (int i = 0; i < children; i++)
+            Refresh(VisualTreeHelper.GetChild(root, i));
+    }
+
+    private static object? CoerceEffect(DependencyObject d, object? baseValue)
+    {
+        if (d is UIElement element)
+        {
+            if (baseValue is BlurEffect)
+                BlurredDecoration.AddOrUpdate(element, Marker);
+            else if (baseValue == null)
+                BlurredDecoration.Remove(element);
+        }
+
+        return _enabled ? null : baseValue;
+    }
+
+    private static object CoerceOpacity(DependencyObject d, object baseValue)
+    {
+        if (!_enabled || baseValue is not double opacity)
+            return baseValue;
+
+        // Something deliberately hidden stays hidden.
+        if (opacity <= 0)
+            return baseValue;
+
+        if (d is UIElement element && BlurredDecoration.TryGetValue(element, out _))
+            return 0d;
+
+        return opacity < 1 ? 1d : baseValue;
+    }
+
+    private static object? CoerceFrameRate(DependencyObject d, object? baseValue)
+    {
+        if (!_enabled)
+            return baseValue;
+
+        return baseValue is int requested && requested > 0 && requested < ReducedFrameRate
+            ? baseValue
+            : ReducedFrameRate;
+    }
+}

--- a/vrcosc-magicchatbox/UI/Controls/ScrollMemory.cs
+++ b/vrcosc-magicchatbox/UI/Controls/ScrollMemory.cs
@@ -1,0 +1,114 @@
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+using vrcosc_magicchatbox.Classes.Modules;
+using vrcosc_magicchatbox.Core.Configuration;
+
+namespace vrcosc_magicchatbox.UI.Controls;
+
+/// <summary>
+/// Remembers where each page was scrolled to and puts it back when the page is rebuilt, including
+/// after the app is closed and reopened. Offsets are recorded as the user scrolls rather than on
+/// Unloaded, because a page host tears its child out synchronously while Unloaded arrives later.
+/// </summary>
+public static class ScrollMemory
+{
+    private static readonly DependencyProperty KeyProperty = DependencyProperty.RegisterAttached(
+        "ScrollMemoryKey", typeof(string), typeof(ScrollMemory), new PropertyMetadata(null));
+
+    public static void Attach(ScrollViewer scroll, string key)
+    {
+        if (scroll == null || string.IsNullOrEmpty(key))
+            return;
+
+        scroll.SetValue(KeyProperty, key);
+        scroll.ScrollChanged -= OnScrollChanged;
+        scroll.ScrollChanged += OnScrollChanged;
+    }
+
+    public static void Detach(ScrollViewer scroll)
+    {
+        if (scroll == null)
+            return;
+
+        Remember(scroll, scroll.GetValue(KeyProperty) as string);
+        scroll.ScrollChanged -= OnScrollChanged;
+        MarkDirty();
+    }
+
+    /// <summary>
+    /// Settings auto-save is driven by PropertyChanged, and mutating a dictionary in place raises nothing.
+    /// This arms the save so offsets survive more than a clean shutdown.
+    /// </summary>
+    public static void MarkDirty()
+        => Settings()?.MarkScrollStateChanged();
+
+    /// <summary>
+    /// Puts the scroll viewer back where it was. <paramref name="beforeSettle"/> runs between the two
+    /// passes so lazily built content can be created before the final offset is applied.
+    /// </summary>
+    public static void Restore(ScrollViewer scroll, string key, Action? beforeSettle = null)
+    {
+        if (scroll == null || string.IsNullOrEmpty(key))
+            return;
+
+        Attach(scroll, key);
+
+        if (!TryRead(key, out double offset) || offset <= 0)
+            return;
+
+        // Two passes: the first gives the content its height, the second lands on the real offset once
+        // the extent is known. A single pass silently clamps to whatever was measured first.
+        scroll.Dispatcher.BeginInvoke(DispatcherPriority.Loaded, () =>
+        {
+            scroll.ScrollToVerticalOffset(offset);
+            beforeSettle?.Invoke();
+
+            scroll.Dispatcher.BeginInvoke(DispatcherPriority.ContextIdle, () =>
+            {
+                scroll.ScrollToVerticalOffset(offset);
+                beforeSettle?.Invoke();
+            });
+        });
+    }
+
+    public static void Remember(ScrollViewer? scroll, string? key)
+    {
+        if (scroll == null || string.IsNullOrEmpty(key))
+            return;
+
+        // A zero offset on a viewer that has not measured yet is teardown noise, not a real position.
+        if (scroll.VerticalOffset <= 0 && scroll.ExtentHeight <= scroll.ViewportHeight)
+            return;
+
+        Store(key, scroll.VerticalOffset);
+    }
+
+    private static void OnScrollChanged(object sender, ScrollChangedEventArgs e)
+    {
+        if (sender is ScrollViewer scroll && Math.Abs(e.VerticalChange) > 0)
+            Remember(scroll, scroll.GetValue(KeyProperty) as string);
+    }
+
+    private static bool TryRead(string key, out double offset)
+    {
+        offset = 0;
+        var offsets = Offsets();
+        return offsets != null && offsets.TryGetValue(key, out offset);
+    }
+
+    private static void Store(string key, double offset)
+    {
+        var offsets = Offsets();
+        if (offsets != null)
+            offsets[key] = offset;
+    }
+
+    private static Dictionary<string, double>? Offsets() => Settings()?.PageScrollOffsets;
+
+    private static AppSettings? Settings()
+        => App.Services?.GetService<ISettingsProvider<AppSettings>>()?.Value;
+}

--- a/vrcosc-magicchatbox/UI/Controls/SectionRealizer.cs
+++ b/vrcosc-magicchatbox/UI/Controls/SectionRealizer.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
+using System.Windows.Threading;
+
+namespace vrcosc_magicchatbox.UI.Controls;
+
+/// <summary>
+/// Builds a long page's sections only as they approach the viewport, and remembers how tall each one
+/// turned out so the placeholder it replaces can reserve the right space next time. Reserving the space
+/// is what makes the scrollbar honest and lets a saved scroll offset be restored without building
+/// everything above it first.
+/// </summary>
+public sealed class SectionRealizer
+{
+    /// <summary>Assumed height for a section whose real height has never been measured.</summary>
+    public const double DefaultSectionHeight = 320;
+
+    private readonly List<Slot> _slots = new();
+    private readonly ScrollViewer _scroll;
+    private readonly IDictionary<string, double> _heights;
+
+    private bool _attached;
+    private bool _passQueued;
+
+    public SectionRealizer(ScrollViewer scroll, IDictionary<string, double> rememberedHeights)
+    {
+        _scroll = scroll ?? throw new ArgumentNullException(nameof(scroll));
+        _heights = rememberedHeights ?? new Dictionary<string, double>();
+    }
+
+    /// <summary>How much beyond the viewport, in viewport heights, is built ahead of the user.</summary>
+    public double LookaheadViewports { get; set; } = 0.5;
+
+    /// <summary>
+    /// Sections built per pass. Realizing invalidates layout, which raises SizeChanged, which asks to
+    /// realize again; without a cap one navigation turns into a storm of layout passes.
+    /// </summary>
+    public int MaxPerPass { get; set; } = 2;
+
+    public int RealizedCount => _slots.Count(s => s.IsRealized);
+
+    public int TotalCount => _slots.Count;
+
+    public void Add(string key, ContentControl wrapper, Func<FrameworkElement> factory, string dataContextPath)
+    {
+        if (wrapper == null || factory == null)
+            return;
+
+        var slot = new Slot(key, wrapper, factory, dataContextPath);
+        _slots.Add(slot);
+
+        if (_heights.TryGetValue(key, out double height) && height > 0)
+            wrapper.MinHeight = height;
+        else
+            wrapper.MinHeight = DefaultSectionHeight;
+    }
+
+    public void Start()
+    {
+        if (_attached)
+            return;
+
+        _attached = true;
+        _scroll.ScrollChanged += OnScrollChanged;
+        _scroll.SizeChanged += OnScrollSizeChanged;
+        RealizeVisible();
+    }
+
+    public void Stop()
+    {
+        if (!_attached)
+            return;
+
+        _attached = false;
+        _scroll.ScrollChanged -= OnScrollChanged;
+        _scroll.SizeChanged -= OnScrollSizeChanged;
+    }
+
+    /// <summary>Builds every remaining section. Needed before any operation that must see the whole page.</summary>
+    public void RealizeAll()
+    {
+        foreach (Slot slot in _slots)
+            Realize(slot, animate: false);
+    }
+
+    /// <summary>Queues a realization pass. Safe to call from layout callbacks; passes coalesce.</summary>
+    public void RealizeVisible()
+    {
+        if (_passQueued || _slots.Count == 0)
+            return;
+
+        _passQueued = true;
+        _scroll.Dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(RealizePass));
+    }
+
+    private void RealizePass()
+    {
+        _passQueued = false;
+
+        if (!_attached)
+            return;
+
+        double viewportHeight = _scroll.ViewportHeight > 0 ? _scroll.ViewportHeight : _scroll.ActualHeight;
+        if (viewportHeight <= 0)
+            return;
+
+        double lookahead = viewportHeight * LookaheadViewports;
+        int built = 0;
+
+        foreach (Slot slot in _slots)
+        {
+            if (slot.IsRealized || !TryGetViewportBounds(slot, out double top, out double bottom))
+                continue;
+
+            if (bottom < -lookahead || top > viewportHeight + lookahead)
+                continue;
+
+            Realize(slot, animate: true);
+
+            if (++built >= MaxPerPass)
+            {
+                // More may still be in range; let layout settle first and pick them up next pass.
+                RealizeVisible();
+                return;
+            }
+        }
+    }
+
+    /// <summary>Position of a wrapper relative to the top of the viewport; negative means scrolled past.</summary>
+    private bool TryGetViewportBounds(Slot slot, out double top, out double bottom)
+    {
+        top = 0;
+        bottom = 0;
+
+        if (!slot.Wrapper.IsDescendantOf(_scroll))
+            return false;
+
+        try
+        {
+            top = slot.Wrapper.TransformToAncestor(_scroll).Transform(default).Y;
+            bottom = top + Math.Max(slot.Wrapper.ActualHeight, slot.Wrapper.MinHeight);
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            // The wrapper is not connected to the scroll viewer yet; a later scroll or resize retries.
+            return false;
+        }
+    }
+
+    private void Realize(Slot slot, bool animate)
+    {
+        if (slot.IsRealized)
+            return;
+
+        slot.IsRealized = true;
+
+        long startTicks = System.Diagnostics.Stopwatch.GetTimestamp();
+        long startAllocated = GC.GetAllocatedBytesForCurrentThread();
+
+        FrameworkElement content = slot.Factory();
+        content.SetBinding(FrameworkElement.DataContextProperty, new Binding(slot.DataContextPath));
+
+        Core.Diagnostics.PerfProbe.Record(
+            $"options.section.{slot.Key}",
+            System.Diagnostics.Stopwatch.GetElapsedTime(startTicks).TotalMilliseconds,
+            GC.GetAllocatedBytesForCurrentThread() - startAllocated);
+
+        // The reservation exists only to hold space for the placeholder; real content sizes itself.
+        slot.Wrapper.MinHeight = 0;
+        slot.Wrapper.Content = content;
+        slot.Content = content;
+
+        slot.HeightMeasured += RememberHeight;
+        content.SizeChanged += slot.OnContentSizeChanged;
+
+        if (animate)
+            PlayEntrance(content);
+    }
+
+    private void RememberHeight(string key, double height)
+    {
+        if (height > 0)
+            _heights[key] = height;
+    }
+
+    private void OnScrollChanged(object sender, ScrollChangedEventArgs e) => RealizeVisible();
+
+    private void OnScrollSizeChanged(object sender, SizeChangedEventArgs e) => RealizeVisible();
+
+    private static void PlayEntrance(FrameworkElement content)
+    {
+        // Slide only. Animating Opacity on a section subtree makes WPF allocate an intermediate render
+        // surface for it, which is the most expensive part of showing a section.
+        var slide = new TranslateTransform();
+        content.RenderTransform = slide;
+
+        slide.BeginAnimation(TranslateTransform.YProperty, new DoubleAnimation(14.0, 0.0, new Duration(TimeSpan.FromMilliseconds(160)))
+        {
+            FillBehavior = FillBehavior.Stop,
+            EasingFunction = new CubicEase { EasingMode = EasingMode.EaseOut },
+        });
+    }
+
+    private sealed class Slot
+    {
+        public Slot(string key, ContentControl wrapper, Func<FrameworkElement> factory, string dataContextPath)
+        {
+            Key = key;
+            Wrapper = wrapper;
+            Factory = factory;
+            DataContextPath = dataContextPath;
+        }
+
+        public string Key { get; }
+
+        public ContentControl Wrapper { get; }
+
+        public Func<FrameworkElement> Factory { get; }
+
+        public string DataContextPath { get; }
+
+        public bool IsRealized { get; set; }
+
+        public FrameworkElement? Content { get; set; }
+
+        public event Action<string, double>? HeightMeasured;
+
+        public void OnContentSizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            if (e.NewSize.Height > 0)
+                HeightMeasured?.Invoke(Key, e.NewSize.Height);
+        }
+    }
+}

--- a/vrcosc-magicchatbox/UI/Controls/SectionRealizer.cs
+++ b/vrcosc-magicchatbox/UI/Controls/SectionRealizer.cs
@@ -180,7 +180,9 @@ public sealed class SectionRealizer
         slot.HeightMeasured += RememberHeight;
         content.SizeChanged += slot.OnContentSizeChanged;
 
-        if (animate)
+        ReducedVisuals.Refresh(content);
+
+        if (animate && !ReducedVisuals.IsEnabled)
             PlayEntrance(content);
     }
 

--- a/vrcosc-magicchatbox/UI/Controls/SegmentPreview.xaml.cs
+++ b/vrcosc-magicchatbox/UI/Controls/SegmentPreview.xaml.cs
@@ -7,6 +7,19 @@ namespace vrcosc_magicchatbox.UI.Controls;
 
 public partial class SegmentPreview : UserControl
 {
+    private static readonly Brush FullFill = Frozen(Color.FromRgb(0x7A, 0x2E, 0x3E));
+
+    private static readonly Brush TightFill = Frozen(Color.FromRgb(0x6B, 0x54, 0x22));
+
+    private static readonly Brush RoomFill = Frozen(Color.FromArgb(0x26, 0xFF, 0xFF, 0xFF));
+
+    private static Brush Frozen(Color color)
+    {
+        var brush = new SolidColorBrush(color);
+        brush.Freeze();
+        return brush;
+    }
+
     public static readonly DependencyProperty CaptionProperty = DependencyProperty.Register(
         nameof(Caption), typeof(string), typeof(SegmentPreview), new PropertyMetadata(string.Empty, OnCaptionChanged));
 
@@ -60,11 +73,15 @@ public partial class SegmentPreview : UserControl
         int length = Line?.Length ?? 0;
         CostText = $"{length}/{OscBuildContext.MaxOscLength}";
 
-        CostChip.Background = OscPreviewFillLevel.Classify(length) switch
+        // Three fixed colours, so they are built and frozen once rather than per keystroke.
+        Brush fill = OscPreviewFillLevel.Classify(length) switch
         {
-            OscPreviewFill.Full => new SolidColorBrush(Color.FromRgb(0x7A, 0x2E, 0x3E)),
-            OscPreviewFill.Tight => new SolidColorBrush(Color.FromRgb(0x6B, 0x54, 0x22)),
-            _ => new SolidColorBrush(Color.FromArgb(0x26, 0xFF, 0xFF, 0xFF)),
+            OscPreviewFill.Full => FullFill,
+            OscPreviewFill.Tight => TightFill,
+            _ => RoomFill,
         };
+
+        if (!ReferenceEquals(CostChip.Background, fill))
+            CostChip.Background = fill;
     }
 }

--- a/vrcosc-magicchatbox/UI/Dialogs/ApplicationError.xaml
+++ b/vrcosc-magicchatbox/UI/Dialogs/ApplicationError.xaml
@@ -226,7 +226,7 @@
                     </Button>
 
                     <Button
-                        x:Name="Close"
+                        x:Name="CloseButton"
                         Margin="6,0,0,0"
                         Click="Close_Click"
                         Style="{StaticResource DialogIconButton}"

--- a/vrcosc-magicchatbox/UI/Dialogs/ConfirmationDialog.xaml
+++ b/vrcosc-magicchatbox/UI/Dialogs/ConfirmationDialog.xaml
@@ -1,107 +1,261 @@
-<Window
+﻿<Window
     x:Class="vrcosc_magicchatbox.UI.Dialogs.ConfirmationDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     Title="Confirm"
-    Width="520"
-    Background="{StaticResource SurfaceCardBrush}"
+    Width="480"
+    AllowsTransparency="True"
+    Background="Transparent"
     FontFamily="{DynamicResource FontPrimary}"
+    Icon="pack://application:,,,/MagicChatbox;component/Img/MagicOSC_icon.png"
     ResizeMode="NoResize"
     SizeToContent="Height"
     WindowStyle="None">
 
+    <Window.Resources>
+        <Style x:Key="DialogGhostButton" TargetType="Button">
+            <Setter Property="Height" Value="34" />
+            <Setter Property="MinWidth" Value="96" />
+            <Setter Property="Padding" Value="18,0" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="FontFamily" Value="{StaticResource FontPrimary}" />
+            <Setter Property="FontSize" Value="{StaticResource FontSizeSecondary}" />
+            <Setter Property="Foreground" Value="{StaticResource TextSoftPurpleBrush}" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border
+                            x:Name="bg"
+                            Padding="{TemplateBinding Padding}"
+                            Background="Transparent"
+                            BorderBrush="#33FFFFFF"
+                            BorderThickness="1"
+                            CornerRadius="6">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="bg" Property="Background" Value="#1AFFFFFF" />
+                                <Setter Property="Foreground" Value="White" />
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="bg" Property="Background" Value="#0DFFFFFF" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style
+            x:Key="DialogPrimaryButton"
+            BasedOn="{StaticResource DialogGhostButton}"
+            TargetType="Button">
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border
+                            x:Name="bg"
+                            Padding="{TemplateBinding Padding}"
+                            BorderBrush="#FF6E4FB5"
+                            BorderThickness="1"
+                            CornerRadius="7">
+                            <Border.Background>
+                                <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+                                    <GradientStop Offset="0" Color="#FF3A1F73" />
+                                    <GradientStop Offset="1" Color="#FF4B2A8F" />
+                                </LinearGradientBrush>
+                            </Border.Background>
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="bg" Property="BorderBrush" Value="{StaticResource AccentLightPurpleBrush}" />
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="bg" Property="Background" Value="{StaticResource SurfacePrimaryBrush}" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style
+            x:Key="DialogDangerButton"
+            BasedOn="{StaticResource DialogPrimaryButton}"
+            TargetType="Button">
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border
+                            x:Name="bg"
+                            Padding="{TemplateBinding Padding}"
+                            Background="{StaticResource StatusErrorDarkerBrush}"
+                            BorderBrush="{StaticResource StatusErrorBrush}"
+                            BorderThickness="1"
+                            CornerRadius="7">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="bg" Property="BorderBrush" Value="{StaticResource TextDangerRedBrush}" />
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="bg" Property="Background" Value="{StaticResource StatusErrorDarkBrush}" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="DialogIconButton" TargetType="Button">
+            <Setter Property="Width" Value="28" />
+            <Setter Property="Height" Value="28" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border
+                            x:Name="bg"
+                            Background="Transparent"
+                            CornerRadius="6">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="bg" Property="Background" Value="#22FFFFFF" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </Window.Resources>
+
     <WindowChrome.WindowChrome>
         <WindowChrome
-            CaptionHeight="35"
+            CaptionHeight="52"
             CornerRadius="0"
-            GlassFrameThickness="1"
-            ResizeBorderThickness="8"
+            GlassFrameThickness="0"
+            ResizeBorderThickness="0"
             UseAeroCaptionButtons="False" />
     </WindowChrome.WindowChrome>
 
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="35" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="62" />
-        </Grid.RowDefinitions>
+    <Border
+        Margin="12"
+        BorderBrush="#FF4A3E78"
+        BorderThickness="1"
+        CornerRadius="14"
+        FocusManager.FocusedElement="{Binding ElementName=CancelButton}">
+        <Border.Background>
+            <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+                <GradientStop Offset="0" Color="#FF1C1245" />
+                <GradientStop Offset="1" Color="#FF251660" />
+            </LinearGradientBrush>
+        </Border.Background>
+        <Border.Effect>
+            <DropShadowEffect
+                BlurRadius="28"
+                Direction="270"
+                Opacity="0.7"
+                ShadowDepth="8"
+                Color="#FF0B0620" />
+        </Border.Effect>
 
-        <Border Grid.Row="0">
-            <Border.Background>
-                <LinearGradientBrush StartPoint="0,1" EndPoint="1,0">
-                    <GradientStop Color="{StaticResource SurfaceDarkColor}" />
-                    <GradientStop Offset="0.55" Color="{StaticResource SurfacePrimaryColor}" />
-                    <GradientStop Offset="1" Color="{StaticResource AccentDeepPurpleColor}" />
-                </LinearGradientBrush>
-            </Border.Background>
-        </Border>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
 
-        <Grid
-            x:Name="DragArea"
-            Grid.Row="0"
-            MouseLeftButtonDown="DragArea_MouseLeftButtonDown">
-            <StackPanel Orientation="Horizontal">
-                <Image Margin="5" Source="/Img/MagicOSC_icon.png" />
+            <Grid Grid.Row="0" Height="52">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <Border
+                    x:Name="SeverityRail"
+                    Width="4"
+                    Height="22"
+                    Margin="18,0,12,0"
+                    VerticalAlignment="Center"
+                    Background="{StaticResource StatusErrorBrush}"
+                    CornerRadius="2" />
+
                 <TextBlock
                     x:Name="TitleTextBlock"
-                    Margin="6,1,0,0"
+                    Grid.Column="1"
                     VerticalAlignment="Center"
-                    FontFamily="/Fonts/#Albert Sans"
-                    FontSize="14"
-                    Foreground="White" />
-            </StackPanel>
-        </Grid>
+                    FontFamily="{StaticResource FontSecondary}"
+                    FontSize="{StaticResource FontSizeBody}"
+                    FontWeight="SemiBold"
+                    Foreground="White"
+                    TextTrimming="CharacterEllipsis" />
 
-        <Button
-            Grid.Row="0"
-            Width="40"
-            Height="35"
-            HorizontalAlignment="Right"
-            VerticalAlignment="Top"
-            Click="Cancel_Click"
-            Cursor="Hand"
-            Style="{DynamicResource CloseButtonStyle}"
-            WindowChrome.IsHitTestVisibleInChrome="True">
-            <Image Height="15" Source="/img/icons/Close_ico.png" />
-        </Button>
-
-        <StackPanel Grid.Row="1" Margin="22,18,22,10">
-            <TextBlock
-                x:Name="MessageTextBlock"
-                FontFamily="/Fonts/#Albert Sans"
-                FontSize="14"
-                Foreground="{StaticResource TextPrimaryBrush}"
-                TextWrapping="Wrap" />
-            <TextBlock
-                x:Name="HintTextBlock"
-                Margin="0,10,0,0"
-                FontFamily="/Fonts/#Albert Sans"
-                FontSize="12"
-                Foreground="{StaticResource TextMutedBrush}"
-                TextWrapping="Wrap" />
-        </StackPanel>
-
-        <Grid Grid.Row="2" Background="{StaticResource SurfaceDarkBrush}">
-            <StackPanel
-                Margin="0,0,18,0"
-                HorizontalAlignment="Right"
-                VerticalAlignment="Center"
-                Orientation="Horizontal">
                 <Button
-                    Width="110"
-                    Height="34"
-                    Margin="0,0,8,0"
+                    Grid.Column="2"
+                    Margin="0,0,12,0"
+                    VerticalAlignment="Center"
+                    AutomationProperties.Name="Close"
                     Click="Cancel_Click"
-                    Content="Cancel"
-                    Style="{StaticResource Status_Button_style}" />
-                <Button
-                    x:Name="ConfirmButton"
-                    Width="130"
-                    Height="34"
-                    Click="Confirm_Click"
-                    Content="Confirm"
-                    Style="{StaticResource Status_Button_style}" />
+                    Style="{StaticResource DialogIconButton}"
+                    ToolTip="Close"
+                    WindowChrome.IsHitTestVisibleInChrome="True">
+                    <TextBlock
+                        FontSize="{StaticResource FontSizeCaption}"
+                        Foreground="{StaticResource TextSoftPurpleBrush}"
+                        Text="&#x2715;" />
+                </Button>
+            </Grid>
+
+            <Border
+                Grid.Row="0"
+                VerticalAlignment="Bottom"
+                BorderBrush="#22FFFFFF"
+                BorderThickness="0,0,0,1" />
+
+            <StackPanel Grid.Row="1" Margin="22,18,22,20">
+                <TextBlock
+                    x:Name="MessageTextBlock"
+                    FontSize="{StaticResource FontSizeSubheading}"
+                    Foreground="White"
+                    LineHeight="23"
+                    TextWrapping="Wrap" />
+                <TextBlock
+                    x:Name="HintTextBlock"
+                    Margin="0,8,0,0"
+                    FontSize="{StaticResource FontSizeCaption}"
+                    Foreground="{StaticResource TextMutedBrush}"
+                    LineHeight="17"
+                    TextWrapping="Wrap" />
             </StackPanel>
+
+            <Border
+                Grid.Row="2"
+                Padding="22,14"
+                Background="#26110A2E"
+                BorderBrush="#22FFFFFF"
+                BorderThickness="0,1,0,0"
+                CornerRadius="0,0,13,13">
+                <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
+                    <Button
+                        x:Name="CancelButton"
+                        Margin="0,0,8,0"
+                        Content="Cancel"
+                        IsCancel="True"
+                        Style="{StaticResource DialogGhostButton}" />
+                    <Button
+                        x:Name="ConfirmButton"
+                        Click="Confirm_Click"
+                        Style="{StaticResource DialogDangerButton}" />
+                </StackPanel>
+            </Border>
         </Grid>
-    </Grid>
+    </Border>
 </Window>

--- a/vrcosc-magicchatbox/UI/Dialogs/ConfirmationDialog.xaml.cs
+++ b/vrcosc-magicchatbox/UI/Dialogs/ConfirmationDialog.xaml.cs
@@ -1,15 +1,19 @@
 using System.Windows;
-using System.Windows.Input;
+using System.Windows.Automation;
+using System.Windows.Media;
 
 namespace vrcosc_magicchatbox.UI.Dialogs;
 
 public partial class ConfirmationDialog : Window
 {
+    // Destructive is the default because a confirmation is only ever asked for when saying yes
+    // costs the user something; a caller with a harmless action opts out and gets the accent styling.
     public ConfirmationDialog(
         string title,
         string message,
         string hint,
-        string confirmText = "Confirm")
+        string confirmText = "Confirm",
+        bool isDestructive = true)
     {
         InitializeComponent();
         Title = title;
@@ -18,6 +22,12 @@ public partial class ConfirmationDialog : Window
         HintTextBlock.Text = hint;
         HintTextBlock.Visibility = string.IsNullOrWhiteSpace(hint) ? Visibility.Collapsed : Visibility.Visible;
         ConfirmButton.Content = confirmText;
+
+        ConfirmButton.Style = (Style)FindResource(isDestructive ? "DialogDangerButton" : "DialogPrimaryButton");
+        SeverityRail.Background = (Brush)FindResource(isDestructive ? "StatusErrorBrush" : "AccentLightPurpleBrush");
+
+        AutomationProperties.SetName(this, title);
+        AutomationProperties.SetName(ConfirmButton, confirmText);
     }
 
     public static bool Show(
@@ -25,9 +35,10 @@ public partial class ConfirmationDialog : Window
         string message,
         string hint,
         string confirmText = "Confirm",
-        Window? owner = null)
+        Window? owner = null,
+        bool isDestructive = true)
     {
-        var dialog = new ConfirmationDialog(title, message, hint, confirmText);
+        var dialog = new ConfirmationDialog(title, message, hint, confirmText, isDestructive);
         DialogWindowHelper.PrepareModal(dialog, owner);
         return dialog.ShowDialog() == true;
     }
@@ -42,11 +53,5 @@ public partial class ConfirmationDialog : Window
     {
         DialogResult = false;
         Close();
-    }
-
-    private void DragArea_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
-    {
-        if (e.ButtonState == MouseButtonState.Pressed)
-            DragMove();
     }
 }

--- a/vrcosc-magicchatbox/UI/Dialogs/OpenAIAuth.xaml.cs
+++ b/vrcosc-magicchatbox/UI/Dialogs/OpenAIAuth.xaml.cs
@@ -105,7 +105,7 @@ namespace vrcosc_magicchatbox.UI.Dialogs
         {
             _openAISettings.AccessToken = OpenAIToken.Password;
             _openAISettings.OrganizationID = OrganizationID.Password;
-            _openAIModule.InitializeClient(_openAISettings.AccessToken, _openAISettings.OrganizationID);
+            _ = _openAIModule.InitializeClient(_openAISettings.AccessToken, _openAISettings.OrganizationID);
             this.Close();
         }
 

--- a/vrcosc-magicchatbox/UI/Dialogs/PrivacyConsentDialog.xaml.cs
+++ b/vrcosc-magicchatbox/UI/Dialogs/PrivacyConsentDialog.xaml.cs
@@ -132,12 +132,12 @@ public partial class HookItem : ObservableObject
     public PrivacyHook Hook { get; }
     public string Title { get; }
     public string Description { get; }
-    public string Warning { get; }
+    public string? Warning { get; }
     public Visibility WarningVisibility => string.IsNullOrEmpty(Warning) ? Visibility.Collapsed : Visibility.Visible;
 
     [ObservableProperty] private bool _isApproved;
 
-    public HookItem(PrivacyHook hook, string title, string description, string warning, bool isApproved)
+    public HookItem(PrivacyHook hook, string title, string description, string? warning, bool isApproved)
     {
         Hook = hook;
         Title = title;

--- a/vrcosc-magicchatbox/UI/Pages/ChattingPage.xaml.cs
+++ b/vrcosc-magicchatbox/UI/Pages/ChattingPage.xaml.cs
@@ -77,7 +77,7 @@ namespace vrcosc_magicchatbox.UI.Pages
                 NewChattingTxt.CaretIndex = NewChattingTxt.Text.Length;
             }, DispatcherPriority.Input);
 
-        private void ButtonChattingTxt_Click(object sender, RoutedEventArgs e)
+        private void ButtonChattingTxt_Click(object? sender, RoutedEventArgs? e)
             => VM.SendChat();
 
         private void CancelEditChatbutton_Click(object sender, RoutedEventArgs e)

--- a/vrcosc-magicchatbox/UI/Pages/IntegrationsPage.xaml
+++ b/vrcosc-magicchatbox/UI/Pages/IntegrationsPage.xaml
@@ -2905,7 +2905,17 @@
                         BorderThickness="1"
                         CornerRadius="6"
                         Visibility="{Binding IntegrationSettings.IntgrVoicemod, Converter={StaticResource BoolToVisibilityConverter}}">
-                        <controls:VoicemodControlPanel ViewModel="{Binding Voicemod}" />
+                        <!--  Declared as a template, not a child: a direct child is built when the page's
+                              BAML loads even though the Border above it is collapsed, while a
+                              ContentPresenter builds its template during Measure, which a collapsed
+                              subtree never gets. Switching the integration on is what builds the panel.  -->
+                        <ContentControl Content="{Binding}">
+                            <ContentControl.ContentTemplate>
+                                <DataTemplate>
+                                    <controls:VoicemodControlPanel ViewModel="{Binding Voicemod}" />
+                                </DataTemplate>
+                            </ContentControl.ContentTemplate>
+                        </ContentControl>
                     </Border>
                 </Grid>
             </ListBoxItem>

--- a/vrcosc-magicchatbox/UI/Pages/IntegrationsPage.xaml.cs
+++ b/vrcosc-magicchatbox/UI/Pages/IntegrationsPage.xaml.cs
@@ -155,9 +155,9 @@ namespace vrcosc_magicchatbox.UI.Pages
             IntegrationsList.EndInit();
         }
 
-        private void OnTileLayoutChanged(object sender, EventArgs e) => ApplyIntegrationOrder();
+        private void OnTileLayoutChanged(object? sender, EventArgs e) => ApplyIntegrationOrder();
 
-        private void OnTileShown(object sender, string key)
+        private void OnTileShown(object? sender, string key)
         {
             if (!IntegrationTileCatalog.TryGet(key, out var tile)) return;
 
@@ -196,10 +196,10 @@ namespace vrcosc_magicchatbox.UI.Pages
                 _integrationSortOrder.CollectionChanged += IntegrationSortOrder_CollectionChanged;
         }
 
-        private void IntegrationSortOrder_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        private void IntegrationSortOrder_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
             => ApplyIntegrationOrder();
 
-        private void IntegrationDisplay_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void IntegrationDisplay_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == nameof(IntegrationDisplayState.IntegrationSortOrder))
             {

--- a/vrcosc-magicchatbox/UI/Pages/Options/AppOptionsSection.xaml
+++ b/vrcosc-magicchatbox/UI/Pages/Options/AppOptionsSection.xaml
@@ -1,4 +1,4 @@
-<UserControl
+﻿<UserControl
     x:Class="vrcosc_magicchatbox.UI.Pages.Options.AppOptionsSection"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -88,6 +88,9 @@
                         </CheckBox>
                         <CheckBox x:Name="OpenTrayWithAltX_checkbox" IsChecked="{Binding AppSettings.OpenTrayWithAltX, Mode=TwoWay}">
                             Open the tray menu with Alt+X
+                        </CheckBox>
+                        <CheckBox x:Name="HiddenIntegrationWarning_checkbox" IsChecked="{Binding AppSettings.ShowHiddenIntegrationWarning, Mode=TwoWay}">
+                            Warn me when something is on but not shown in the mode I am in
                         </CheckBox>
                         <TextBlock
                             Margin="2,6,20,4"

--- a/vrcosc-magicchatbox/UI/Pages/Options/AppOptionsSection.xaml
+++ b/vrcosc-magicchatbox/UI/Pages/Options/AppOptionsSection.xaml
@@ -411,28 +411,77 @@
                             IsChecked="{Binding TtsSettings.ToggleVoiceWithV, Mode=TwoWay}">
                             Mute and unmute VRChat with the V key
                         </CheckBox>
+                    </StackPanel>
+                </Border>
+
+                <!--  Updates  -->
+                <Border Style="{StaticResource OptionCardStyle}">
+                    <StackPanel>
+                        <TextBlock Style="{StaticResource OptionSubsectionHeaderStyle}" Text="Updates" />
+
                         <CheckBox
                             x:Name="CheckUpdateOnStartup"
-                            Margin="0,6,0,0"
                             IsChecked="{Binding AppSettings.CheckUpdateOnStartup, Mode=TwoWay}">
                             Look for a newer version at startup (recommended)
                         </CheckBox>
-                        <CheckBox
-                            x:Name="ToggleJoinedApha"
-                            Margin="0,6,0,4"
-                            Content="Include test versions"
-                            Foreground="{Binding UpdateState.VersionTxtColor}"
-                            IsChecked="{Binding AppSettings.JoinedAlphaChannel, Mode=TwoWay}"
-                            RenderOptions.BitmapScalingMode="NearestNeighbor">
-                            <CheckBox.Effect>
-                                <DropShadowEffect
-                                    BlurRadius="15"
-                                    Opacity="0.7"
-                                    ShadowDepth="0"
-                                    Color="{Binding UpdateState.VersionTxtColor}" />
-                            </CheckBox.Effect>
-                        </CheckBox>
-                        <TextBlock Style="{StaticResource OptionHelpTextStyle}" Text="Test versions get new features first and can be rough. You can go back to the last version you had from the button below." />
+                        <TextBlock Style="{StaticResource OptionHelpTextStyle}" Text="MagicChatbox also checks every so often while it is running." />
+
+                        <TextBlock
+                            Margin="2,12,0,5"
+                            Style="{StaticResource OptionFieldLabelStyle}"
+                            Text="Stable releases" />
+                        <Border Style="{StaticResource SegmentedChoiceContainerStyle}">
+                            <StackPanel Orientation="Horizontal">
+                                <RadioButton
+                                    Content="Ignore"
+                                    GroupName="StableUpdateMode"
+                                    IsChecked="{Binding AppSettings.StableUpdateMode, Converter={StaticResource EnumEqualsConverter}, ConverterParameter=Off, Mode=TwoWay}"
+                                    Style="{StaticResource SegmentedChoiceStyle}" />
+                                <RadioButton
+                                    Content="Tell me"
+                                    GroupName="StableUpdateMode"
+                                    IsChecked="{Binding AppSettings.StableUpdateMode, Converter={StaticResource EnumEqualsConverter}, ConverterParameter=Notify, Mode=TwoWay}"
+                                    Style="{StaticResource SegmentedChoiceStyle}" />
+                                <RadioButton
+                                    Content="Install for me"
+                                    GroupName="StableUpdateMode"
+                                    IsChecked="{Binding AppSettings.StableUpdateMode, Converter={StaticResource EnumEqualsConverter}, ConverterParameter=Auto, Mode=TwoWay}"
+                                    Style="{StaticResource SegmentedChoiceStyle}" />
+                            </StackPanel>
+                        </Border>
+
+                        <TextBlock
+                            Margin="2,14,0,5"
+                            Style="{StaticResource OptionFieldLabelStyle}"
+                            Text="Test versions" />
+                        <Border Style="{StaticResource SegmentedChoiceContainerStyle}">
+                            <StackPanel Orientation="Horizontal">
+                                <RadioButton
+                                    Content="Ignore"
+                                    GroupName="PreReleaseUpdateMode"
+                                    IsChecked="{Binding AppSettings.PreReleaseUpdateMode, Converter={StaticResource EnumEqualsConverter}, ConverterParameter=Off, Mode=TwoWay}"
+                                    Style="{StaticResource SegmentedChoiceStyle}" />
+                                <RadioButton
+                                    Content="Tell me"
+                                    GroupName="PreReleaseUpdateMode"
+                                    IsChecked="{Binding AppSettings.PreReleaseUpdateMode, Converter={StaticResource EnumEqualsConverter}, ConverterParameter=Notify, Mode=TwoWay}"
+                                    Style="{StaticResource SegmentedChoiceStyle}" />
+                                <RadioButton
+                                    Content="Install for me"
+                                    GroupName="PreReleaseUpdateMode"
+                                    IsChecked="{Binding AppSettings.PreReleaseUpdateMode, Converter={StaticResource EnumEqualsConverter}, ConverterParameter=Auto, Mode=TwoWay}"
+                                    Style="{StaticResource SegmentedChoiceStyle}" />
+                            </StackPanel>
+                        </Border>
+
+                        <TextBlock
+                            Margin="2,10,20,0"
+                            Style="{StaticResource OptionHelpTextStyle}"
+                            Text="Each row decides what happens to updates from that channel, whichever version you are on now. Test versions get new features first and can be rough." />
+                        <TextBlock
+                            Margin="2,0,20,4"
+                            Style="{StaticResource OptionHelpTextStyle}"
+                            Text="&quot;Install for me&quot; downloads in the background and swaps the files the next time you start MagicChatbox, so nothing interrupts you mid-session. You can always go back with the button below." />
                     </StackPanel>
                 </Border>
 

--- a/vrcosc-magicchatbox/UI/Pages/Options/AppOptionsSection.xaml
+++ b/vrcosc-magicchatbox/UI/Pages/Options/AppOptionsSection.xaml
@@ -445,7 +445,7 @@
                             IsChecked="{Binding AppSettings.CheckUpdateOnStartup, Mode=TwoWay}">
                             Look for a newer version at startup (recommended)
                         </CheckBox>
-                        <TextBlock Style="{StaticResource OptionHelpTextStyle}" Text="MagicChatbox also checks every so often while it is running." />
+                        <TextBlock Style="{StaticResource OptionHelpTextStyle}" Text="Otherwise it only looks when you press the button on the version card." />
 
                         <TextBlock
                             Margin="2,12,0,5"
@@ -506,62 +506,32 @@
                     </StackPanel>
                 </Border>
 
-                <Button
-                    x:Name="Rollback"
-                    Width="auto"
-                    Height="30"
-                    Margin="0,5,0,5"
-                    Padding="5"
-                    HorizontalAlignment="Left"
-                    Command="{Binding RollbackCommand}"
-                    Opacity="0.7"
-                    Style="{StaticResource UpdatedGreenButtonStyle}"
-                    Visibility="{Binding UpdateState.RollBackUpdateAvailable, Converter={StaticResource InverseBoolToHiddenConverter}}">
-                    <Button.ContentTemplate>
-                        <DataTemplate>
-                            <StackPanel Orientation="Horizontal">
-                                <Image
-                                    Height="18"
-                                    Margin="0,0,4,0"
-                                    RenderOptions.BitmapScalingMode="HighQuality"
-                                    Source="/Img/Icons/downgrade.png" />
-                                <TextBlock
-                                    x:Name="RollBackVersion"
-                                    Margin="0,-2,5,0"
-                                    VerticalAlignment="Center"
-                                    FontSize="{StaticResource FontSizeBody}"
-                                    Text="{Binding UpdateState.RollBackVersion, Converter={StaticResource VersionDisplayConverter}, ConverterParameter='Go back to {0}', UpdateSourceTrigger=PropertyChanged}" />
-                            </StackPanel>
-                        </DataTemplate>
-                    </Button.ContentTemplate>
-                </Button>
+                <!--
+                    Content, not ContentTemplate: a ContentTemplate takes its DataContext from the
+                    button's Content, which was never set, so the version binding below resolved against
+                    nothing and the button showed its icon with no text at all.
+                -->
+                <StackPanel Margin="0,5,0,15" Orientation="Horizontal">
+                    <Button
+                        x:Name="Rollback"
+                        Height="25"
+                        Margin="0,0,5,0"
+                        Padding="10,0"
+                        HorizontalAlignment="Left"
+                        Command="{Binding RollbackCommand}"
+                        Content="{Binding UpdateState.RollBackVersion, Converter={StaticResource VersionDisplayConverter}, ConverterParameter='Go back to {0}', UpdateSourceTrigger=PropertyChanged}"
+                        Style="{DynamicResource Status_Button_style}"
+                        Visibility="{Binding UpdateState.RollBackUpdateAvailable, Converter={StaticResource InverseBoolToHiddenConverter}}" />
 
-                <Button
-                    x:Name="UpdateByZipFile"
-                    Width="auto"
-                    Height="30"
-                    Margin="0,0,0,15"
-                    Padding="5"
-                    HorizontalAlignment="Left"
-                    Command="{Binding UpdateByZipCommand}"
-                    Opacity="0.7"
-                    Style="{StaticResource UpdatedGreenButtonStyle}">
-                    <Button.ContentTemplate>
-                        <DataTemplate>
-                            <StackPanel Orientation="Horizontal">
-                                <Image
-                                    Height="18"
-                                    Margin="0,0,4,0"
-                                    Source="/Img/Icons/Upload.png" />
-                                <TextBlock
-                                    Margin="0,-2,5,0"
-                                    VerticalAlignment="Center"
-                                    FontSize="{StaticResource FontSizeBody}"
-                                    Text="Install from a ZIP file" />
-                            </StackPanel>
-                        </DataTemplate>
-                    </Button.ContentTemplate>
-                </Button>
+                    <Button
+                        x:Name="UpdateByZipFile"
+                        Height="25"
+                        Padding="10,0"
+                        HorizontalAlignment="Left"
+                        Command="{Binding UpdateByZipCommand}"
+                        Content="Install from a ZIP file"
+                        Style="{DynamicResource Status_Button_style}" />
+                </StackPanel>
 
                 <StackPanel Orientation="Horizontal">
                     <Button

--- a/vrcosc-magicchatbox/UI/Pages/Options/AppOptionsSection.xaml
+++ b/vrcosc-magicchatbox/UI/Pages/Options/AppOptionsSection.xaml
@@ -46,6 +46,27 @@
             Visibility="{Binding AppSettings.Settings_AppOptions, Converter={StaticResource InverseBoolToHiddenConverter}, UpdateSourceTrigger=PropertyChanged}">
             <StackPanel>
 
+                <!--  Appearance and performance  -->
+                <Border Style="{StaticResource OptionCardStyle}">
+                    <StackPanel>
+                        <TextBlock Style="{StaticResource OptionSubsectionHeaderStyle}" Text="Appearance and performance" />
+                        <CheckBox x:Name="ReducedVisuals_checkbox" IsChecked="{Binding AppSettings.ReducedVisuals, Mode=TwoWay}">
+                            Reduced visuals
+                        </CheckBox>
+                        <TextBlock Style="{StaticResource OptionHelpTextStyle}">
+                            Turns off the shadows, the fades and the page transitions. Measured here it takes the
+                            window from around 19% of the graphics card down to under 3%.
+                        </TextBlock>
+                        <CheckBox x:Name="ReducedVisualsInVr_checkbox" IsChecked="{Binding AppSettings.ReducedVisualsInVr, Mode=TwoWay}">
+                            Turn it on by itself while VR is running
+                        </CheckBox>
+                        <TextBlock Style="{StaticResource OptionHelpTextStyle}">
+                            VR is when the graphics card is busiest and when you are least likely to be looking at
+                            this window.
+                        </TextBlock>
+                    </StackPanel>
+                </Border>
+
                 <!--  Window and tray  -->
                 <Border Style="{StaticResource OptionCardStyle}">
                     <StackPanel>

--- a/vrcosc-magicchatbox/UI/Pages/Options/AppOptionsSection.xaml
+++ b/vrcosc-magicchatbox/UI/Pages/Options/AppOptionsSection.xaml
@@ -379,6 +379,24 @@
                     </StackPanel>
                 </Border>
 
+                <!--  SteamVR  -->
+                <Border Style="{StaticResource OptionCardStyle}">
+                    <StackPanel>
+                        <TextBlock Style="{StaticResource OptionSubsectionHeaderStyle}" Text="SteamVR" />
+                        <CheckBox x:Name="StartWithSteamVr_checkbox" IsChecked="{Binding AppSettings.StartWithSteamVr, Mode=TwoWay}">
+                            Start MagicChatbox when SteamVR starts
+                        </CheckBox>
+                        <TextBlock Style="{StaticResource OptionHelpTextStyle}" Text="MagicChatbox adds itself to SteamVR's startup apps and opens straight to the tray, so it is already sending to the chatbox by the time you are in. SteamVR keeps its own switch for this under Settings → Startup / Shutdown." />
+                        <CheckBox
+                            x:Name="QuitWithSteamVr_checkbox"
+                            IsChecked="{Binding AppSettings.QuitWithSteamVr, Mode=TwoWay}"
+                            IsEnabled="{Binding AppSettings.StartWithSteamVr}">
+                            Close it again when SteamVR closes
+                        </CheckBox>
+                        <TextBlock Style="{StaticResource OptionHelpTextStyle}" Text="Leave this off to keep MagicChatbox running at the desk after you take the headset off." />
+                    </StackPanel>
+                </Border>
+
                 <!--  Everything else  -->
                 <Border Style="{StaticResource OptionCardStyle}">
                     <StackPanel>

--- a/vrcosc-magicchatbox/UI/Pages/Options/WindowActivitySection.xaml
+++ b/vrcosc-magicchatbox/UI/Pages/Options/WindowActivitySection.xaml
@@ -545,16 +545,23 @@
                         Color="black" />
                 </Border.Effect>
             </Border>
-            <ScrollViewer
-                Grid.Row="5"
-                MaxHeight="600"
-                CanContentScroll="True"
-                VerticalScrollBarVisibility="Auto">
+                <!--  The scroll viewer lives inside the template: an ItemsControl wrapped in an outer one
+                      hands its panel an infinite height, so every row realizes and virtualization does nothing.  -->
                 <ItemsControl
+                    Grid.Row="5"
+                    MaxHeight="600"
                     HorizontalAlignment="Stretch"
+                    ScrollViewer.CanContentScroll="True"
                     VirtualizingPanel.IsVirtualizing="True"
                     VirtualizingPanel.VirtualizationMode="Recycling"
                     ItemsSource="{Binding WindowActivity.ScannedAppsView, UpdateSourceTrigger=PropertyChanged, NotifyOnTargetUpdated=True}">
+                <ItemsControl.Template>
+                    <ControlTemplate TargetType="ItemsControl">
+                        <ScrollViewer CanContentScroll="True" VerticalScrollBarVisibility="Auto">
+                            <ItemsPresenter />
+                        </ScrollViewer>
+                    </ControlTemplate>
+                </ItemsControl.Template>
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
                         <VirtualizingStackPanel VirtualizingPanel.IsVirtualizing="True" VirtualizingPanel.VirtualizationMode="Recycling" />
@@ -702,7 +709,6 @@
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
                 </ItemsControl>
-            </ScrollViewer>
         </Grid>
 
     </Grid>

--- a/vrcosc-magicchatbox/UI/Pages/OptionsPage.xaml.cs
+++ b/vrcosc-magicchatbox/UI/Pages/OptionsPage.xaml.cs
@@ -8,7 +8,11 @@ using System.Windows.Data;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using vrcosc_magicchatbox.Classes.Modules;
+using vrcosc_magicchatbox.Core.Configuration;
 using vrcosc_magicchatbox.Services;
+using vrcosc_magicchatbox.UI.Controls;
 using vrcosc_magicchatbox.UI.Pages.Options;
 using vrcosc_magicchatbox.ViewModels;
 
@@ -16,20 +20,7 @@ namespace vrcosc_magicchatbox.UI.Pages;
 
 public partial class OptionsPage : UserControl
 {
-    private static readonly string[] DeferredChunkKeys =
-    {
-        "OptionsDeferredChunk1",
-        "OptionsDeferredChunk2",
-        "OptionsDeferredChunk3",
-        "OptionsDeferredChunk4",
-        "OptionsDeferredChunk5",
-        "OptionsDeferredChunk6",
-        "OptionsDeferredChunk7",
-    };
-
-    private static readonly TimeSpan ChunkTickBudget = TimeSpan.FromMilliseconds(6);
-
-    private readonly Queue<string> _pendingChunkKeys = new(DeferredChunkKeys);
+    private const string ScrollMemoryKey = "options";
 
     private PrivacySection? PrivacySectionControl;
     private TtsOptionsSection? TtsOptionsSectionControl;
@@ -38,11 +29,12 @@ public partial class OptionsPage : UserControl
 
     private OptionsPageViewModel? _attachedVm;
 
-    private bool _chunkQueued;
+    private SectionRealizer? _realizer;
 
     public OptionsPage()
     {
         InitializeComponent();
+        BuildSectionRealizer();
 
         AddHandler(System.Windows.Controls.Primitives.ToggleButton.CheckedEvent,
             new RoutedEventHandler(OnSettingToggled));
@@ -62,10 +54,16 @@ public partial class OptionsPage : UserControl
             _attachedVm = vm;
         }
 
-        QueueNextChunk();
+        _realizer?.Start();
+        ScrollMemory.Restore(MainScroll, ScrollMemoryKey, () => _realizer?.RealizeVisible());
     }
 
-    private void OnUnloaded(object sender, RoutedEventArgs e) => DetachViewModel();
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        ScrollMemory.Detach(MainScroll);
+        _realizer?.Stop();
+        DetachViewModel();
+    }
 
     private void DetachViewModel()
     {
@@ -88,108 +86,46 @@ public partial class OptionsPage : UserControl
         }
     }
 
-    private void QueueNextChunk()
+    /// <summary>
+    /// Registers all 23 sections in layout order. Nothing is constructed here: the realizer builds each
+    /// section only when it approaches the viewport, which is what keeps a visit to Options cheap.
+    /// </summary>
+    private void BuildSectionRealizer()
     {
-        if (_chunkQueued || _pendingChunkKeys.Count == 0)
-            return;
+        // Falls back to a throwaway map when the container is not up, so the page still builds.
+        var heights = App.Services?.GetService<ISettingsProvider<AppSettings>>()?.Value.OptionsSectionHeights
+            ?? new Dictionary<string, double>();
 
-        _chunkQueued = true;
-        Dispatcher.BeginInvoke(DispatcherPriority.Input, new Action(LoadNextChunk));
+        _realizer = new SectionRealizer(MainScroll, heights);
+
+        // Chatting, Status and MediaLink stay declared inline in the XAML: they are the first thing on
+        // screen, so deferring them would only trade build cost for a visible placeholder.
+        _realizer.Add("spotify", OptionsWrapper_Spotify, () => new SpotifySection(), nameof(OptionsPageViewModel.SpotifySection));
+        _realizer.Add("lyrics", OptionsWrapper_Lyrics, () => new LyricsSection(), nameof(OptionsPageViewModel.LyricsSection));
+        _realizer.Add("twitch", OptionsWrapper_Twitch, () => new TwitchSection(), nameof(OptionsPageViewModel.TwitchSection));
+        _realizer.Add("tiktoklive", OptionsWrapper_TikTokLive, () => new TikTokLiveSection(), nameof(OptionsPageViewModel.TikTokLiveSection));
+        _realizer.Add("discord", OptionsWrapper_Discord, () => new DiscordSection(), nameof(OptionsPageViewModel.DiscordSection));
+        _realizer.Add("vrcradar", OptionsWrapper_VrcRadar, () => new VrcRadarSection(), nameof(OptionsPageViewModel.VrcRadarSection));
+        _realizer.Add("time", OptionsWrapper_Time, () => new TimeOptionsSection(), nameof(OptionsPageViewModel.TimeOptionsSection));
+        _realizer.Add("weather", OptionsWrapper_Weather, () => new WeatherSection(), nameof(OptionsPageViewModel.WeatherSection));
+        _realizer.Add("pulsoid", OptionsWrapper_Pulsoid, () => new PulsoidSection(), nameof(OptionsPageViewModel.PulsoidSection));
+        _realizer.Add("componentstats", OptionsWrapper_ComponentStats, () => new ComponentStatsSection(), nameof(OptionsPageViewModel.ComponentStatsSection));
+        _realizer.Add("networkstatistics", OptionsWrapper_NetworkStatistics, () => new NetworkStatisticsSection(), nameof(OptionsPageViewModel.NetworkStatisticsSection));
+        _realizer.Add("windowactivity", OptionsWrapper_WindowActivity, () => new WindowActivitySection(), nameof(OptionsPageViewModel.WindowActivitySection));
+        _realizer.Add("vrperformance", OptionsWrapper_VrPerformance, () => new VrPerformanceSection(), nameof(OptionsPageViewModel.VrPerformanceSection));
+        _realizer.Add("trackerbattery", OptionsWrapper_TrackerBattery, () => new TrackerBatterySection(), nameof(OptionsPageViewModel.TrackerBatterySection));
+        _realizer.Add("voicemod", OptionsWrapper_Voicemod, () => new VoicemodSection(), nameof(OptionsPageViewModel.VoicemodSection));
+        _realizer.Add("openai", OptionsWrapper_OpenAI, () => new OpenAISection(), nameof(OptionsPageViewModel.OpenAISection));
+        _realizer.Add("tts", OptionsWrapper_Tts, () => TtsOptionsSectionControl = new TtsOptionsSection(), nameof(OptionsPageViewModel.TtsSection));
+        _realizer.Add("appoptions", OptionsWrapper_AppOptions, () => new AppOptionsSection(), nameof(OptionsPageViewModel.AppOptionsSection));
+        _realizer.Add("privacy", OptionsWrapper_Privacy, () => PrivacySectionControl = new PrivacySection(), nameof(OptionsPageViewModel.PrivacySection));
+        _realizer.Add("eggdev", OptionsWrapper_EggDev, () => new EggDevSection(), nameof(OptionsPageViewModel.EggDevSection));
     }
 
-    private void LoadNextChunk()
-    {
-        _chunkQueued = false;
+    private void EnsureSectionsRealized() => _realizer?.RealizeAll();
 
-        if (_pendingChunkKeys.Count == 0 || !IsLoaded)
-            return;
-
-        var tick = Stopwatch.StartNew();
-        do
-        {
-            LoadChunk(_pendingChunkKeys.Dequeue());
-        }
-        while (_pendingChunkKeys.Count > 0 && tick.Elapsed < ChunkTickBudget);
-
-        QueueNextChunk();
-    }
-
-    private void EnsureSectionsRealized()
-    {
-        while (_pendingChunkKeys.Count > 0)
-            LoadChunk(_pendingChunkKeys.Dequeue());
-    }
-
-    private void LoadChunk(string key)
-    {
-        switch (key)
-        {
-            case "OptionsDeferredChunk1":
-                Realize(OptionsWrapper_Spotify, new SpotifySection(), nameof(OptionsPageViewModel.SpotifySection));
-                Realize(OptionsWrapper_Lyrics, new LyricsSection(), nameof(OptionsPageViewModel.LyricsSection));
-                Realize(OptionsWrapper_Twitch, new TwitchSection(), nameof(OptionsPageViewModel.TwitchSection));
-                break;
-            case "OptionsDeferredChunk2":
-                Realize(OptionsWrapper_TikTokLive, new TikTokLiveSection(), nameof(OptionsPageViewModel.TikTokLiveSection));
-                Realize(OptionsWrapper_Discord, new DiscordSection(), nameof(OptionsPageViewModel.DiscordSection));
-                Realize(OptionsWrapper_VrcRadar, new VrcRadarSection(), nameof(OptionsPageViewModel.VrcRadarSection));
-                break;
-            case "OptionsDeferredChunk3":
-                Realize(OptionsWrapper_Time, new TimeOptionsSection(), nameof(OptionsPageViewModel.TimeOptionsSection));
-                Realize(OptionsWrapper_Weather, new WeatherSection(), nameof(OptionsPageViewModel.WeatherSection));
-                Realize(OptionsWrapper_Pulsoid, new PulsoidSection(), nameof(OptionsPageViewModel.PulsoidSection));
-                break;
-            case "OptionsDeferredChunk4":
-                Realize(OptionsWrapper_ComponentStats, new ComponentStatsSection(), nameof(OptionsPageViewModel.ComponentStatsSection));
-                Realize(OptionsWrapper_NetworkStatistics, new NetworkStatisticsSection(), nameof(OptionsPageViewModel.NetworkStatisticsSection));
-                Realize(OptionsWrapper_WindowActivity, new WindowActivitySection(), nameof(OptionsPageViewModel.WindowActivitySection));
-                break;
-            case "OptionsDeferredChunk5":
-                Realize(OptionsWrapper_VrPerformance, new VrPerformanceSection(), nameof(OptionsPageViewModel.VrPerformanceSection));
-                Realize(OptionsWrapper_TrackerBattery, new TrackerBatterySection(), nameof(OptionsPageViewModel.TrackerBatterySection));
-                Realize(OptionsWrapper_Voicemod, new VoicemodSection(), nameof(OptionsPageViewModel.VoicemodSection));
-                Realize(OptionsWrapper_OpenAI, new OpenAISection(), nameof(OptionsPageViewModel.OpenAISection));
-                break;
-            case "OptionsDeferredChunk6":
-                TtsOptionsSectionControl = new TtsOptionsSection();
-                Realize(OptionsWrapper_Tts, TtsOptionsSectionControl, nameof(OptionsPageViewModel.TtsSection));
-                Realize(OptionsWrapper_AppOptions, new AppOptionsSection(), nameof(OptionsPageViewModel.AppOptionsSection));
-                PrivacySectionControl = new PrivacySection();
-                Realize(OptionsWrapper_Privacy, PrivacySectionControl, nameof(OptionsPageViewModel.PrivacySection));
-                break;
-            case "OptionsDeferredChunk7":
-                Realize(OptionsWrapper_EggDev, new EggDevSection(), nameof(OptionsPageViewModel.EggDevSection));
-                break;
-        }
-    }
-
-    private static void Realize(ContentControl wrapper, FrameworkElement content, string vmPropertyPath)
-    {
-        content.SetBinding(DataContextProperty, new Binding(vmPropertyPath));
-        wrapper.Content = content;
-        PlayChunkEntrance(content);
-    }
-
-    private static void PlayChunkEntrance(FrameworkElement chunk)
-    {
-        var slide = new TranslateTransform();
-        chunk.RenderTransform = slide;
-
-        var ease = new CubicEase { EasingMode = EasingMode.EaseOut };
-        var duration = new Duration(TimeSpan.FromMilliseconds(160));
-
-        chunk.BeginAnimation(OpacityProperty, new DoubleAnimation(0.0, 1.0, duration)
-        {
-            FillBehavior = FillBehavior.Stop,
-            EasingFunction = ease,
-        });
-
-        slide.BeginAnimation(TranslateTransform.YProperty, new DoubleAnimation(14.0, 0.0, duration)
-        {
-            FillBehavior = FillBehavior.Stop,
-            EasingFunction = ease,
-        });
-    }
+    /// <summary>Forces every section to exist so a scripted run has something to click.</summary>
+    internal void RealizeAllSectionsForDiagnostics() => EnsureSectionsRealized();
 
     private void EnsureSectionMap()
     {

--- a/vrcosc-magicchatbox/UI/Pages/StatusPage.xaml
+++ b/vrcosc-magicchatbox/UI/Pages/StatusPage.xaml
@@ -398,6 +398,7 @@
                                                         FontSize="13"
                                                         Foreground="WhiteSmoke"
                                                         KeyDown="RenameGroupTextBox_KeyDown"
+                                                        MaxLength="50"
                                                         Tag="{Binding}"
                                                         Text="{Binding RenameBuffer, UpdateSourceTrigger=PropertyChanged}"
                                                         Visibility="{Binding IsRenaming, Converter={StaticResource BoolToVisibilityConverter}}">
@@ -475,6 +476,7 @@
                                         FontSize="12"
                                         Foreground="WhiteSmoke"
                                         KeyDown="NewGroupTextBox_KeyDown"
+                                        MaxLength="50"
                                         Text="{Binding NewGroupName, UpdateSourceTrigger=PropertyChanged}" />
                                     <Button
                                         Width="30"

--- a/vrcosc-magicchatbox/UI/Pages/StatusPage.xaml.cs
+++ b/vrcosc-magicchatbox/UI/Pages/StatusPage.xaml.cs
@@ -128,7 +128,43 @@ namespace vrcosc_magicchatbox.UI.Pages
         private void BeginRenameGroup_Click(object sender, RoutedEventArgs e)
         {
             if (sender is Button btn && btn.Tag is StatusGroup group)
+            {
                 VM.BeginRenameGroupCommand.Execute(group);
+                Dispatcher.BeginInvoke(
+                    () => FocusRenameTextBox(group),
+                    DispatcherPriority.Input);
+            }
+        }
+
+        private void FocusRenameTextBox(StatusGroup group)
+        {
+            TextBox? textBox = FindVisualChild<TextBox>(
+                GroupListControl,
+                candidate => ReferenceEquals(candidate.Tag, group));
+            if (textBox == null)
+                return;
+
+            textBox.Focus();
+            Keyboard.Focus(textBox);
+            textBox.SelectAll();
+        }
+
+        private static T? FindVisualChild<T>(DependencyObject parent, Func<T, bool> predicate)
+            where T : DependencyObject
+        {
+            int childCount = VisualTreeHelper.GetChildrenCount(parent);
+            for (int index = 0; index < childCount; index++)
+            {
+                DependencyObject child = VisualTreeHelper.GetChild(parent, index);
+                if (child is T match && predicate(match))
+                    return match;
+
+                T? descendant = FindVisualChild(child, predicate);
+                if (descendant != null)
+                    return descendant;
+            }
+
+            return null;
         }
 
         private void RenameGroupTextBox_KeyDown(object sender, KeyEventArgs e)

--- a/vrcosc-magicchatbox/UI/Resources/SharedConverters.xaml
+++ b/vrcosc-magicchatbox/UI/Resources/SharedConverters.xaml
@@ -14,6 +14,7 @@
     <conv:BoolToOpacityConverter x:Key="BoolToOpacityConverter" />
     <conv:EnumDescriptionConverter x:Key="EnumDescriptionConverter" />
     <conv:EnumEqualsConverter x:Key="EnumEqualsConverter" />
+    <conv:AutoUpdateModeConverter x:Key="AutoUpdateModeConverter" />
     <conv:TwitchAnnouncementColorToBrushConverter x:Key="TwitchAnnouncementColorToBrushConverter" />
     <conv:IndexToVisibilityConverter x:Key="IndexToVisibilityConverter" />
     <conv:IndexToBoolConverter x:Key="IndexToBoolConverter" />

--- a/vrcosc-magicchatbox/UI/Resources/SharedConverters.xaml
+++ b/vrcosc-magicchatbox/UI/Resources/SharedConverters.xaml
@@ -13,6 +13,7 @@
     <conv:CollectionContainsConverter x:Key="CollectionContainsConverter" />
     <conv:BoolToOpacityConverter x:Key="BoolToOpacityConverter" />
     <conv:EnumDescriptionConverter x:Key="EnumDescriptionConverter" />
+    <conv:EnumEqualsConverter x:Key="EnumEqualsConverter" />
     <conv:TwitchAnnouncementColorToBrushConverter x:Key="TwitchAnnouncementColorToBrushConverter" />
     <conv:IndexToVisibilityConverter x:Key="IndexToVisibilityConverter" />
     <conv:IndexToBoolConverter x:Key="IndexToBoolConverter" />

--- a/vrcosc-magicchatbox/UI/Theme.xaml
+++ b/vrcosc-magicchatbox/UI/Theme.xaml
@@ -394,8 +394,8 @@
                                             Color="Black" />
                                     </Border.Effect>
                                 </Border>
-                                <ScrollViewer Margin="2,4" SnapsToDevicePixels="True">
-                                    <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Contained" />
+                                <ScrollViewer Margin="2,4" CanContentScroll="True" SnapsToDevicePixels="True">
+                                    <ItemsPresenter KeyboardNavigation.DirectionalNavigation="Contained" />
                                 </ScrollViewer>
                             </Grid>
                         </Popup>
@@ -502,8 +502,8 @@
                                             Color="Black" />
                                     </Border.Effect>
                                 </Border>
-                                <ScrollViewer Margin="2,4" SnapsToDevicePixels="True">
-                                    <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Contained" />
+                                <ScrollViewer Margin="2,4" CanContentScroll="True" SnapsToDevicePixels="True">
+                                    <ItemsPresenter KeyboardNavigation.DirectionalNavigation="Contained" />
                                 </ScrollViewer>
                             </Grid>
                         </Popup>

--- a/vrcosc-magicchatbox/UI/Theme.xaml
+++ b/vrcosc-magicchatbox/UI/Theme.xaml
@@ -2553,13 +2553,15 @@
         template's parts, so inheriting would leave the base hover trigger fighting this one.
     -->
     <Style x:Key="TileHideButton" TargetType="Button">
-        <Setter Property="Width" Value="26" />
         <Setter Property="Height" Value="22" />
         <Setter Property="Margin" Value="0,0,4,0" />
         <Setter Property="Background" Value="{StaticResource DeckSurfaceBrush}" />
+        <!--  Muted where CUSTOMIZE is not: both sit in this row, but hiding is the lesser action.  -->
         <Setter Property="Foreground" Value="{StaticResource DeckTextMutedBrush}" />
-        <Setter Property="FontSize" Value="10" />
-        <Setter Property="Content" Value="👁" />
+        <Setter Property="FontFamily" Value="{StaticResource FontPrimary}" />
+        <Setter Property="FontSize" Value="{StaticResource FontSizeMicro}" />
+        <Setter Property="Padding" Value="11,0,10,0" />
+        <Setter Property="Content" Value="HIDE" />
         <Setter Property="Cursor" Value="Hand" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="Template">
@@ -2567,6 +2569,7 @@
                 <ControlTemplate TargetType="Button">
                     <Border
                         x:Name="eye"
+                        Padding="{TemplateBinding Padding}"
                         Background="{TemplateBinding Background}"
                         CornerRadius="6"
                         SnapsToDevicePixels="True">

--- a/vrcosc-magicchatbox/UI/Theme.xaml
+++ b/vrcosc-magicchatbox/UI/Theme.xaml
@@ -914,6 +914,84 @@
         BasedOn="{StaticResource {x:Type CheckBox}}"
         TargetType="{x:Type CheckBox}" />
 
+    <!--
+        For sitting beside something else on one line rather than in a list of settings, with the label
+        leading and the box trailing. The default checkbox carries a bottom margin, which is what stacks
+        a settings list evenly and what stops anything next to it from ever looking vertically centred.
+    -->
+    <Style
+        x:Key="CompactCheckBox"
+        BasedOn="{StaticResource {x:Type CheckBox}}"
+        TargetType="{x:Type CheckBox}">
+        <Setter Property="Margin" Value="0" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="FontSize" Value="11" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type CheckBox}">
+                    <Border Padding="{TemplateBinding Padding}" Background="Transparent">
+                        <!--
+                            A star column, so the box is pushed to the far edge when the checkbox is
+                            stretched across a row, and sits right after the label when it is not.
+                        -->
+                        <Grid VerticalAlignment="Center">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <ContentPresenter
+                                Grid.Column="0"
+                                Margin="0,0,6,0"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                RecognizesAccessKey="True" />
+                            <Border
+                                x:Name="CheckBorder"
+                                Grid.Column="1"
+                                Width="14"
+                                Height="14"
+                                VerticalAlignment="Center"
+                                Background="#FF3A2F54"
+                                BorderBrush="#FF6555A0"
+                                BorderThickness="1"
+                                CornerRadius="3">
+                                <Path
+                                    x:Name="CheckMark"
+                                    Width="8"
+                                    Height="6"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Data="M 1,4.5 L 3.5,7 L 9,1.5"
+                                    Stretch="Uniform"
+                                    Stroke="White"
+                                    StrokeEndLineCap="Round"
+                                    StrokeLineJoin="Round"
+                                    StrokeStartLineCap="Round"
+                                    StrokeThickness="2"
+                                    Visibility="Collapsed" />
+                            </Border>
+                        </Grid>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter TargetName="CheckMark" Property="Visibility" Value="Visible" />
+                            <Setter TargetName="CheckBorder" Property="Background" Value="#FF7C5CBF" />
+                            <Setter TargetName="CheckBorder" Property="BorderBrush" Value="#FF9B7DE8" />
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="CheckBorder" Property="BorderBrush" Value="#FF6B5CA0" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.5" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style x:Key="OptionCardStyle" TargetType="{x:Type Border}">
         <Setter Property="Margin" Value="0,0,0,5" />
         <Setter Property="Padding" Value="8" />

--- a/vrcosc-magicchatbox/UI/Theme.xaml
+++ b/vrcosc-magicchatbox/UI/Theme.xaml
@@ -1310,6 +1310,67 @@
         <Setter Property="Orientation" Value="Horizontal" />
     </Style>
 
+    <!--
+        A row of mutually exclusive choices where a dropdown would hide the alternatives. Every
+        option stays on screen, so the cost of each one is readable without opening anything.
+        Put the buttons in a bordered container and give them a shared GroupName.
+    -->
+    <Style x:Key="SegmentedChoiceContainerStyle" TargetType="{x:Type Border}">
+        <Setter Property="Background" Value="{StaticResource SurfaceDarkBrush}" />
+        <Setter Property="BorderBrush" Value="#5B4A86" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="CornerRadius" Value="5" />
+        <Setter Property="Padding" Value="2" />
+        <Setter Property="HorizontalAlignment" Value="Left" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+    </Style>
+
+    <Style x:Key="SegmentedChoiceStyle" TargetType="{x:Type RadioButton}">
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="FontFamily" Value="{StaticResource FontPrimary}" />
+        <Setter Property="FontSize" Value="{StaticResource FontSizeCompact}" />
+        <Setter Property="FontWeight" Value="Medium" />
+        <Setter Property="Foreground" Value="{StaticResource TextMutedBrush}" />
+        <Setter Property="Padding" Value="12,5" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type RadioButton}">
+                    <Border
+                        x:Name="segment"
+                        Background="Transparent"
+                        CornerRadius="3">
+                        <ContentPresenter
+                            Margin="{TemplateBinding Padding}"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            RecognizesAccessKey="True"
+                            TextOptions.TextRenderingMode="ClearType" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="segment" Property="Background" Value="#3A2F5C" />
+                            <Setter Property="Foreground" Value="{StaticResource TextPrimaryBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter TargetName="segment" Property="Background" Value="{StaticResource AccentLightPurpleBrush}" />
+                            <Setter Property="Foreground" Value="#FF241243" />
+                            <Setter Property="FontWeight" Value="SemiBold" />
+                        </Trigger>
+                        <Trigger Property="IsKeyboardFocused" Value="True">
+                            <Setter TargetName="segment" Property="BorderBrush" Value="{StaticResource TextPrimaryBrush}" />
+                            <Setter TargetName="segment" Property="BorderThickness" Value="1" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.45" />
+                            <Setter Property="Cursor" Value="Arrow" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
 
     <ControlTemplate x:Key="DarkSliderThumb" TargetType="{x:Type Thumb}">
         <Ellipse

--- a/vrcosc-magicchatbox/ViewModels/ComponentStatsViewModel.cs
+++ b/vrcosc-magicchatbox/ViewModels/ComponentStatsViewModel.cs
@@ -22,7 +22,7 @@ public partial class ComponentStatsViewModel : ObservableObject
     public void UpdateComponentStat(StatsComponentType type, string newValue)
         => _module.UpdateStatValue(type, newValue);
 
-    public string GetComponentStatValue(StatsComponentType type)
+    public string? GetComponentStatValue(StatsComponentType type)
         => _module.GetStatValue(type);
 
     public void SetComponentStatMaxValue(StatsComponentType type, string maxValue)
@@ -76,13 +76,13 @@ public partial class ComponentStatsViewModel : ObservableObject
         set { _module.SetShowSmallName(StatsComponentType.CPU, value); OnPropertyChanged(); }
     }
 
-    public string CPUCustomHardwareName
+    public string? CPUCustomHardwareName
     {
         get => _module.GetCustomHardwareName(StatsComponentType.CPU);
         set { _module.SetCustomHardwareName(StatsComponentType.CPU, value); OnPropertyChanged(); }
     }
 
-    public string CPUHardwareName => _module.GetHardwareName(StatsComponentType.CPU);
+    public string? CPUHardwareName => _module.GetHardwareName(StatsComponentType.CPU);
 
     public bool GPU_EnableHardwareTitle
     {
@@ -108,13 +108,13 @@ public partial class ComponentStatsViewModel : ObservableObject
         set { _module.SetShowSmallName(StatsComponentType.GPU, value); OnPropertyChanged(); }
     }
 
-    public string GPUCustomHardwareName
+    public string? GPUCustomHardwareName
     {
         get => _module.GetCustomHardwareName(StatsComponentType.GPU);
         set { _module.SetCustomHardwareName(StatsComponentType.GPU, value); OnPropertyChanged(); }
     }
 
-    public string GPUHardwareName => _module.GetHardwareName(StatsComponentType.GPU);
+    public string? GPUHardwareName => _module.GetHardwareName(StatsComponentType.GPU);
 
     public bool isCPUAvailable
     {
@@ -247,13 +247,13 @@ public partial class ComponentStatsViewModel : ObservableObject
         set { _module.SetShowSmallName(StatsComponentType.RAM, value); OnPropertyChanged(); }
     }
 
-    public string RAMCustomHardwareName
+    public string? RAMCustomHardwareName
     {
         get => _module.GetCustomHardwareName(StatsComponentType.RAM);
         set { _module.SetCustomHardwareName(StatsComponentType.RAM, value); OnPropertyChanged(); }
     }
 
-    public string RAMHardwareName => _module.GetHardwareName(StatsComponentType.RAM);
+    public string? RAMHardwareName => _module.GetHardwareName(StatsComponentType.RAM);
 
     public bool isVRAMAvailable
     {
@@ -319,13 +319,13 @@ public partial class ComponentStatsViewModel : ObservableObject
         set { _module.SetShowSmallName(StatsComponentType.VRAM, value); OnPropertyChanged(); }
     }
 
-    public string VRAMCustomHardwareName
+    public string? VRAMCustomHardwareName
     {
         get => _module.GetCustomHardwareName(StatsComponentType.VRAM);
         set { _module.SetCustomHardwareName(StatsComponentType.VRAM, value); OnPropertyChanged(); }
     }
 
-    public string VRAMHardwareName => _module.GetHardwareName(StatsComponentType.VRAM);
+    public string? VRAMHardwareName => _module.GetHardwareName(StatsComponentType.VRAM);
 
     public void RefreshAllProperties()
     {

--- a/vrcosc-magicchatbox/ViewModels/IntegrationsPageViewModel.cs
+++ b/vrcosc-magicchatbox/ViewModels/IntegrationsPageViewModel.cs
@@ -29,6 +29,7 @@ public partial class IntegrationsPageViewModel : ObservableObject
     private readonly Lazy<IModuleHost> _moduleHost;
     private readonly Lazy<OSCController> _osc;
     private readonly ISettingsProvider<IntegrationSettings> _integrationSettingsProvider;
+    private readonly AppSettings _appSettings;
     private readonly ISettingsProvider<SpotifySettings> _spotifySettingsProvider;
     private readonly IMenuNavigationService _menuNav;
     private readonly INavigationService _nav;
@@ -100,6 +101,7 @@ public partial class IntegrationsPageViewModel : ObservableObject
         Lazy<IModuleHost> moduleHost,
         Lazy<OSCController> osc,
         ISettingsProvider<IntegrationSettings> integrationSettingsProvider,
+        ISettingsProvider<AppSettings> appSettingsProvider,
         ISettingsProvider<MediaLinkSettings> mediaLinkSettingsProvider,
         ISettingsProvider<SpotifySettings> spotifySettingsProvider,
         ISettingsProvider<WeatherSettings> weatherSettingsProvider,
@@ -124,6 +126,7 @@ public partial class IntegrationsPageViewModel : ObservableObject
         _moduleHost = moduleHost;
         _osc = osc;
         _integrationSettingsProvider = integrationSettingsProvider;
+        _appSettings = appSettingsProvider.Value;
         _spotifySettingsProvider = spotifySettingsProvider;
         _componentStats = componentStats;
         _scanLoop = scanLoop;
@@ -310,6 +313,13 @@ public partial class IntegrationsPageViewModel : ObservableObject
         if (!propertyName.StartsWith("Intgr", StringComparison.Ordinal))
             return;
 
+        if (!_appSettings.ShowHiddenIntegrationWarning)
+        {
+            OnPropertyChanged(nameof(ModeVisibilityWarning));
+            OnPropertyChanged(nameof(HasModeVisibilityWarning));
+            return;
+        }
+
         if (IntegrationModeVisibility.TryDescribeHiddenMode(
                 IntegrationSettings, propertyName, AppState.IsVRRunning, out var hidden))
         {
@@ -341,7 +351,9 @@ public partial class IntegrationsPageViewModel : ObservableObject
     }
 
     public string? ModeVisibilityWarning
-        => IntegrationModeVisibility.BuildWarning(IntegrationSettings, AppState.IsVRRunning);
+        => _appSettings.ShowHiddenIntegrationWarning
+            ? IntegrationModeVisibility.BuildWarning(IntegrationSettings, AppState.IsVRRunning)
+            : null;
 
     public bool HasModeVisibilityWarning => ModeVisibilityWarning != null;
 

--- a/vrcosc-magicchatbox/ViewModels/Models/ChatItem.cs
+++ b/vrcosc-magicchatbox/ViewModels/Models/ChatItem.cs
@@ -30,10 +30,10 @@ namespace vrcosc_magicchatbox.ViewModels.Models
         private string _msg = "";
 
         private string _MsgReplace = "";
-        private string _opacity;
+        private string? _opacity;
 
 
-        private string _Opacity_backup;
+        private string? _Opacity_backup;
 
         public ChatItem(ChatStatusDisplayState chatStatus)
         {
@@ -194,7 +194,7 @@ namespace vrcosc_magicchatbox.ViewModels.Models
         }
 
 
-        public string Opacity
+        public string? Opacity
         {
             get { return _opacity; }
             set
@@ -207,7 +207,7 @@ namespace vrcosc_magicchatbox.ViewModels.Models
             }
         }
 
-        public string Opacity_backup
+        public string? Opacity_backup
         {
             get { return _Opacity_backup; }
             set

--- a/vrcosc-magicchatbox/ViewModels/Models/ComponentStatsItem.cs
+++ b/vrcosc-magicchatbox/ViewModels/Models/ComponentStatsItem.cs
@@ -8,12 +8,12 @@ namespace vrcosc_magicchatbox.ViewModels.Models
         public DateTime LastUpdated { get; set; }
         public string SystemMainName { get; set; }
         public string SystemMailSmallName { get; set; }
-        public string HardwareFriendlyName { get; set; }
-        public string HardwareFriendlyNameSmall { get; set; }
+        public string? HardwareFriendlyName { get; set; }
+        public string? HardwareFriendlyNameSmall { get; set; }
         public bool ShowPrefixHardwareTitle { get; set; } = false;
         public bool ReplaceWithHardwareName { get; set; } = false;
-        public string CustomHardwarenameValue { get; set; }
-        public string CustomHardwarenameValueSmall { get; set; }
+        public string? CustomHardwarenameValue { get; set; }
+        public string? CustomHardwarenameValueSmall { get; set; }
         public StatsComponentType ComponentType { get; set; }
         public string Unit { get; set; }
         public bool ShowTemperature { get; set; } = false;
@@ -31,7 +31,7 @@ namespace vrcosc_magicchatbox.ViewModels.Models
         public bool IsEnabled { get; set; } = true;
         public bool ShowSmallName { get; set; } = true;
         public bool ShowDDRVersion { get; set; } = true;
-        public string DDRVersion { get; set; } = null;
+        public string? DDRVersion { get; set; } = null;
 
         public string GetFormattedValue() { return ShowUnit ? $"{ComponentValue}{Unit}" : ComponentValue; }
         public string GetFormattedMaxValue()
@@ -47,11 +47,11 @@ namespace vrcosc_magicchatbox.ViewModels.Models
 
         public string GetDescription()
         {
-            string name = ShowPrefixHardwareTitle
+            string? name = ShowPrefixHardwareTitle
                 ? ReplaceWithHardwareName && !string.IsNullOrEmpty(CustomHardwarenameValue) && !string.IsNullOrEmpty(CustomHardwarenameValueSmall) ? CustomHardwarenameValue : HardwareFriendlyName
                 : SystemMainName;
 
-            string smallName = ShowPrefixHardwareTitle
+            string? smallName = ShowPrefixHardwareTitle
                 ? ReplaceWithHardwareName && !string.IsNullOrEmpty(CustomHardwarenameValue) && !string.IsNullOrEmpty(CustomHardwarenameValueSmall)
                     ? CustomHardwarenameValueSmall
                     : HardwareFriendlyNameSmall
@@ -89,9 +89,9 @@ namespace vrcosc_magicchatbox.ViewModels.Models
 
         public class Gpu
         {
-            public string Name { get; set; }
-            public string Identifier { get; set; }
-            public string HardwareType { get; set; }
+            public string? Name { get; set; }
+            public string? Identifier { get; set; }
+            public string? HardwareType { get; set; }
         }
     }
 }

--- a/vrcosc-magicchatbox/ViewModels/Models/EnumExtensions.cs
+++ b/vrcosc-magicchatbox/ViewModels/Models/EnumExtensions.cs
@@ -8,9 +8,9 @@ namespace vrcosc_magicchatbox.ViewModels.Models
     {
         public static string GetDescription(this Enum value)
         {
-            FieldInfo field = value.GetType().GetField(value.ToString());
+            FieldInfo? field = value.GetType().GetField(value.ToString());
 
-            DescriptionAttribute attribute = field.GetCustomAttribute<DescriptionAttribute>(false);
+            DescriptionAttribute? attribute = field?.GetCustomAttribute<DescriptionAttribute>(false);
 
             return attribute != null ? attribute.Description : value.ToString();
         }

--- a/vrcosc-magicchatbox/ViewModels/Models/MediaSessionInfo.cs
+++ b/vrcosc-magicchatbox/ViewModels/Models/MediaSessionInfo.cs
@@ -49,7 +49,8 @@ namespace vrcosc_magicchatbox.ViewModels.Models
         }
 
         private bool _TimeoutRestore = false;
-        private MediaSession session;
+        // Every construction site sets Session via an object initializer right after `new`, so this is never read null.
+        private MediaSession session = null!;
 
         private string _albumArtist = "Album-Artist";
         public string AlbumArtist
@@ -132,7 +133,7 @@ namespace vrcosc_magicchatbox.ViewModels.Models
             }
         }
 
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
 
         private void SaveOrDeleteSettings()
         {
@@ -227,7 +228,8 @@ namespace vrcosc_magicchatbox.ViewModels.Models
             }
         }
 
-        public string FriendlyAppName { get; private set; }
+        // Derived from Session in the Session setter, which every construction site calls right after `new`.
+        public string FriendlyAppName { get; private set; } = null!;
 
         public bool IsActive
         {
@@ -474,7 +476,7 @@ namespace vrcosc_magicchatbox.ViewModels.Models
 
         public bool KeepSaved { get; set; }
 
-        public string SessionId { get; set; }
+        public string? SessionId { get; set; }
 
         public bool ShowArtist { get; set; }
 

--- a/vrcosc-magicchatbox/ViewModels/Models/ProcessInfo.cs
+++ b/vrcosc-magicchatbox/ViewModels/Models/ProcessInfo.cs
@@ -5,13 +5,13 @@ namespace vrcosc_magicchatbox.ViewModels
     public class ProcessInfo : INotifyPropertyChanged
     {
         private bool _applyCustomAppName;
-        private string _customAppName;
+        private string _customAppName = string.Empty;
         private int _focusCount;
         private bool _isPrivateApp;
 
 
         private string? _lastTitle = "";
-        private string _processName;
+        private string _processName = string.Empty;
 
 
         private bool _ShowTitle = false;
@@ -20,7 +20,7 @@ namespace vrcosc_magicchatbox.ViewModels
         private string _customRegex = string.Empty;
         private string _contentFilter = string.Empty;
         private int _contentFilterMode;
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
 
         private void NotifyPropertyChanged(string propertyName)
         { PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName)); }

--- a/vrcosc-magicchatbox/ViewModels/Models/TrackerDevice.cs
+++ b/vrcosc-magicchatbox/ViewModels/Models/TrackerDevice.cs
@@ -21,7 +21,7 @@ namespace vrcosc_magicchatbox.ViewModels.Models
         private string _originalModelName = string.Empty;
         private string _deviceKind = string.Empty;
 
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
 
         public string SerialNumber
         {

--- a/vrcosc-magicchatbox/ViewModels/Models/Version.cs
+++ b/vrcosc-magicchatbox/ViewModels/Models/Version.cs
@@ -16,7 +16,7 @@ namespace vrcosc_magicchatbox.ViewModels.Models
 
         public string ReleaseNotes { get; set; }
 
-        private string _versionNumber;
+        private string _versionNumber = string.Empty;
 
         public string VersionNumber
         {

--- a/vrcosc-magicchatbox/ViewModels/Models/Version.cs
+++ b/vrcosc-magicchatbox/ViewModels/Models/Version.cs
@@ -26,7 +26,7 @@ namespace vrcosc_magicchatbox.ViewModels.Models
 
         private string EnsureCorrectFormat(string version)
         {
-            var parts = version.Split('.');
+            var parts = (version ?? string.Empty).Split('.');
 
             if (parts.Length > 3)
             {
@@ -38,12 +38,17 @@ namespace vrcosc_magicchatbox.ViewModels.Models
                 Array.Resize(ref parts, 3);
             }
 
+            // A tag is not obliged to carry three segments, and one that does not used to take
+            // the version check down with it rather than reading as the zero it means.
             parts[0] = "0";
-            parts[1] = int.Parse(parts[1]).ToString();
-            parts[2] = int.Parse(parts[2]).ToString().PadLeft(3, '0');
+            parts[1] = SegmentOrZero(parts[1]).ToString();
+            parts[2] = SegmentOrZero(parts[2]).ToString().PadLeft(3, '0');
 
             return string.Join(".", parts);
         }
+
+        private static int SegmentOrZero(string segment)
+            => int.TryParse(segment, out int value) ? value : 0;
 
     }
 }

--- a/vrcosc-magicchatbox/ViewModels/Models/Voice.cs
+++ b/vrcosc-magicchatbox/ViewModels/Models/Voice.cs
@@ -2,8 +2,8 @@
 {
     public class Voice
     {
-        public string DisplayName { get; set; }
-        public string ApiName { get; set; }
+        public string DisplayName { get; set; } = string.Empty;
+        public string ApiName { get; set; } = string.Empty;
 
     }
 }

--- a/vrcosc-magicchatbox/ViewModels/Models/WeatherConditionOverrideItem.cs
+++ b/vrcosc-magicchatbox/ViewModels/Models/WeatherConditionOverrideItem.cs
@@ -7,7 +7,7 @@ namespace vrcosc_magicchatbox.ViewModels.Models
         private string _customIcon = string.Empty;
         private string _customText = string.Empty;
 
-        public WeatherConditionOverrideItem(int code, string defaultIcon, string defaultText)
+        public WeatherConditionOverrideItem(int code, string? defaultIcon, string defaultText)
         {
             Code = code;
             DefaultIcon = defaultIcon ?? string.Empty;
@@ -53,7 +53,7 @@ namespace vrcosc_magicchatbox.ViewModels.Models
             }
         }
 
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
 
         private void NotifyPropertyChanged(string propertyName)
         {

--- a/vrcosc-magicchatbox/ViewModels/OptionsPageViewModel.cs
+++ b/vrcosc-magicchatbox/ViewModels/OptionsPageViewModel.cs
@@ -136,7 +136,7 @@ namespace vrcosc_magicchatbox.ViewModels
             bool confirmed = ConfirmationDialog.Show(
                 "Reset section",
                 "Reset this section to default settings?",
-                "Saved tokens and client IDs are preserved where possible. Running modules are restarted only when the reset service can do that safely.",
+                "Saved tokens, client IDs and the integration's on/off switch are kept. A module that is running is stopped, reset, and started again.",
                 "Reset");
 
             if (!confirmed)

--- a/vrcosc-magicchatbox/ViewModels/Sections/ComponentStatsSectionViewModel.cs
+++ b/vrcosc-magicchatbox/ViewModels/Sections/ComponentStatsSectionViewModel.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.Windows.Threading;
 using vrcosc_magicchatbox.Classes.Modules;
 using vrcosc_magicchatbox.Core.Configuration;
+using vrcosc_magicchatbox.Core.State;
 using vrcosc_magicchatbox.Core.Units;
 using static vrcosc_magicchatbox.Classes.Modules.ComponentStatsModule;
 
@@ -166,6 +167,8 @@ public partial class ComponentStatsSectionViewModel : ObservableObject
 
     private readonly DispatcherTimer? _temperatureTimer;
 
+    private readonly IAppState _appState;
+
     public AppSettings AppSettings { get; }
     public ComponentStatsModule StatsManager { get; }
     public ComponentStatsViewModel ComponentStats { get; }
@@ -175,15 +178,20 @@ public partial class ComponentStatsSectionViewModel : ObservableObject
     public ComponentStatsSectionViewModel(
         ISettingsProvider<AppSettings> appSettingsProvider,
         Lazy<ComponentStatsModule> statsManager,
-        Lazy<ComponentStatsViewModel> componentStats)
+        Lazy<ComponentStatsViewModel> componentStats,
+        IAppState appState)
     {
         AppSettings = appSettingsProvider.Value;
         StatsManager = statsManager.Value;
         ComponentStats = componentStats.Value;
+        _appState = appState;
 
         StatsManager.Settings.PropertyChanged += OnAnythingChanged;
         ComponentStats.PropertyChanged += OnAnythingChanged;
         AppSettings.PropertyChanged += OnAppSettingsChanged;
+
+        if (_appState is INotifyPropertyChanged observable)
+            observable.PropertyChanged += OnAppStateChanged;
 
         var dispatcher = System.Windows.Application.Current?.Dispatcher;
         if (dispatcher != null)
@@ -277,12 +285,26 @@ public partial class ComponentStatsSectionViewModel : ObservableObject
             UpdateTemperatureTimer();
     }
 
+    private void OnAppStateChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(IAppState.IsWindowOnScreen)
+            or nameof(IAppState.IsTrayMenuOpen)
+            or nameof(IAppState.IsUiObservable))
+        {
+            UpdateTemperatureTimer();
+        }
+    }
+
     private void UpdateTemperatureTimer()
     {
         if (_temperatureTimer == null)
             return;
 
-        bool wanted = AppSettings.Settings_ComponentStats && StatsManager.Settings.TemperatureRotates;
+        // The tick only rewrites a preview string on the Options page. This view model is a singleton, so
+        // without the visibility gate it keeps rendering that string while the app sits in the tray.
+        bool wanted = _appState.IsUiObservable
+            && AppSettings.Settings_ComponentStats
+            && StatsManager.Settings.TemperatureRotates;
         if (wanted == _temperatureTimer.IsEnabled)
             return;
 

--- a/vrcosc-magicchatbox/ViewModels/Sections/DiscordSectionViewModel.cs
+++ b/vrcosc-magicchatbox/ViewModels/Sections/DiscordSectionViewModel.cs
@@ -172,6 +172,7 @@ public partial class DiscordSectionViewModel : ObservableObject
             discord.Settings.AccessToken = result.AccessToken;
             discord.Settings.HasRpcScope = hasRpcScope;
             discord.Settings.RefreshToken = string.Empty;
+            discord.Settings.RefreshTokenEncrypted = string.Empty;
             discord.Settings.TokenExpiresAtUtcTicks = 0;
             discord.SaveSettings();
             HasSavedToken = true;
@@ -203,6 +204,12 @@ public partial class DiscordSectionViewModel : ObservableObject
             await discord.StopAsync();
             discord.Settings.AccessToken = string.Empty;
             discord.Settings.RefreshToken = string.Empty;
+
+            // Clear the stored ciphertext directly as well: when the plaintext is already
+            // empty (a stored token that no longer decrypts on this machine) the assignments
+            // above are no-ops, and the unusable ciphertext would survive the disconnect.
+            discord.Settings.AccessTokenEncrypted = string.Empty;
+            discord.Settings.RefreshTokenEncrypted = string.Empty;
             discord.Settings.TokenExpiresAtUtcTicks = 0;
             discord.Settings.HasRpcScope = false;
             discord.SaveSettings();

--- a/vrcosc-magicchatbox/ViewModels/Sections/PulsoidSectionViewModel.cs
+++ b/vrcosc-magicchatbox/ViewModels/Sections/PulsoidSectionViewModel.cs
@@ -171,7 +171,7 @@ public partial class PulsoidSectionViewModel : ObservableObject
                 return;
             }
 
-            string fragmentString = await oAuth.AuthenticateUserAsync(authEndpoint);
+            string? fragmentString = await oAuth.AuthenticateUserAsync(authEndpoint);
 
             if (string.IsNullOrEmpty(fragmentString))
             {
@@ -180,7 +180,7 @@ public partial class PulsoidSectionViewModel : ObservableObject
             }
 
             var fragment = PulsoidOAuthHandler.ParseQueryString(fragmentString);
-            if (fragment.TryGetValue("access_token", out string accessToken) && !string.IsNullOrEmpty(accessToken))
+            if (fragment.TryGetValue("access_token", out string? accessToken) && !string.IsNullOrEmpty(accessToken))
             {
                 var validation = await oAuth.ValidateTokenAsync(accessToken);
                 if (validation == PulsoidTokenValidation.Invalid)

--- a/vrcosc-magicchatbox/ViewModels/Sections/PulsoidSectionViewModel.cs
+++ b/vrcosc-magicchatbox/ViewModels/Sections/PulsoidSectionViewModel.cs
@@ -153,11 +153,11 @@ public partial class PulsoidSectionViewModel : ObservableObject
             if (pulsoid == null) return;
 
             await pulsoid.DisconnectSession();
-            string state = Convert.ToBase64String(Guid.NewGuid().ToByteArray());
+            string state = Guid.NewGuid().ToString("N");
             const string clientId = Core.Constants.PulsoidClientId;
             const string redirectUri = Core.Constants.PulsoidOAuthRedirectUri;
             const string scope = Core.Constants.PulsoidOAuthScope;
-            var authEndpoint = $"{Core.Constants.PulsoidOAuthEndpoint}?response_type=token&client_id={clientId}&redirect_uri={Uri.EscapeDataString(redirectUri)}&scope={scope}&state={state}";
+            var authEndpoint = $"{Core.Constants.PulsoidOAuthEndpoint}?response_type=token&client_id={clientId}&redirect_uri={Uri.EscapeDataString(redirectUri)}&scope={scope}&state={Uri.EscapeDataString(state)}";
 
             var oAuth = PulsoidOAuth;
             try
@@ -171,7 +171,7 @@ public partial class PulsoidSectionViewModel : ObservableObject
                 return;
             }
 
-            string? fragmentString = await oAuth.AuthenticateUserAsync(authEndpoint);
+            string? fragmentString = await oAuth.AuthenticateUserAsync(authEndpoint, state);
 
             if (string.IsNullOrEmpty(fragmentString))
             {

--- a/vrcosc-magicchatbox/ViewModels/Sections/VoicemodSectionViewModel.cs
+++ b/vrcosc-magicchatbox/ViewModels/Sections/VoicemodSectionViewModel.cs
@@ -467,6 +467,8 @@ public partial class VoicemodSectionViewModel : ObservableObject
             : VoicemodSoundSort.Recent;
         _settingsProvider.Save();
         OnPropertyChanged(nameof(SoundSortButtonText));
+        // Reset the page silently: the property's changed hook rebuilds the current page from the
+        // still-unsorted list, which RebuildSounds() below then immediately rebuilds again.
         _soundPageIndex = 0;
         OnPropertyChanged(nameof(SoundPageIndex));
         RebuildSounds();
@@ -742,6 +744,8 @@ public partial class VoicemodSectionViewModel : ObservableObject
         {
             case nameof(VoicemodSettings.SoundsPerPage):
                 OnPropertyChanged(nameof(SoundsPerPage));
+                // Silent for the same reason as CycleSoundSort: the changed hook would rebuild the
+                // page against the page size still in effect.
                 _soundPageIndex = 0;
                 OnPropertyChanged(nameof(SoundPageIndex));
                 RebuildSounds();

--- a/vrcosc-magicchatbox/ViewModels/State/AppUpdateState.cs
+++ b/vrcosc-magicchatbox/ViewModels/State/AppUpdateState.cs
@@ -15,6 +15,8 @@ public partial class AppUpdateState : ObservableObject
     [ObservableProperty] private string _updateStatustxt = string.Empty;
     [ObservableProperty] private string _updateURL = string.Empty;
     [ObservableProperty] private string _updateDigest = string.Empty;
+    [ObservableProperty] private string _updateVersion = string.Empty;
+    [ObservableProperty] private UpdateChannel? _pendingUpdateChannel;
     [ObservableProperty] private string _latestReleaseURL = string.Empty;
     [ObservableProperty] private string _latestReleaseDigest = string.Empty;
     [ObservableProperty] private string _preReleaseURL = string.Empty;

--- a/vrcosc-magicchatbox/ViewModels/State/AppUpdateState.cs
+++ b/vrcosc-magicchatbox/ViewModels/State/AppUpdateState.cs
@@ -26,29 +26,29 @@ public partial class AppUpdateState : ObservableObject
     [ObservableProperty] private bool _rollBackUpdateAvailable;
     [ObservableProperty] private System.Version _rollBackVersion = new(0, 0, 0, 0);
 
-    private Models.Version _appVersion;
-    public Models.Version AppVersion
+    private Models.Version? _appVersion;
+    public Models.Version? AppVersion
     {
         get => _appVersion;
         set => SetProperty(ref _appVersion, value);
     }
 
-    private Models.Version _gitHubVersion;
-    public Models.Version GitHubVersion
+    private Models.Version? _gitHubVersion;
+    public Models.Version? GitHubVersion
     {
         get => _gitHubVersion;
         set => SetProperty(ref _gitHubVersion, value);
     }
 
-    private Models.Version _preReleaseVersion;
-    public Models.Version PreReleaseVersion
+    private Models.Version? _preReleaseVersion;
+    public Models.Version? PreReleaseVersion
     {
         get => _preReleaseVersion;
         set => SetProperty(ref _preReleaseVersion, value);
     }
 
-    private Models.Version _latestReleaseVersion;
-    public Models.Version LatestReleaseVersion
+    private Models.Version? _latestReleaseVersion;
+    public Models.Version? LatestReleaseVersion
     {
         get => _latestReleaseVersion;
         set => SetProperty(ref _latestReleaseVersion, value);

--- a/vrcosc-magicchatbox/ViewModels/State/MediaLinkDisplayState.cs
+++ b/vrcosc-magicchatbox/ViewModels/State/MediaLinkDisplayState.cs
@@ -78,8 +78,8 @@ public sealed partial class MediaLinkDisplayState : ObservableObject
         }
     }
 
-    private MediaLinkStyle _selectedMediaLinkSeekbarStyle;
-    public MediaLinkStyle SelectedMediaLinkSeekbarStyle
+    private MediaLinkStyle? _selectedMediaLinkSeekbarStyle;
+    public MediaLinkStyle? SelectedMediaLinkSeekbarStyle
     {
         get => _selectedMediaLinkSeekbarStyle;
         set

--- a/vrcosc-magicchatbox/ViewModels/State/OpenAIDisplayState.cs
+++ b/vrcosc-magicchatbox/ViewModels/State/OpenAIDisplayState.cs
@@ -8,7 +8,7 @@ public sealed partial class OpenAIDisplayState : ObservableObject
     private bool _connected = false;
 
     [ObservableProperty]
-    private string _accessErrorTxt;
+    private string _accessErrorTxt = string.Empty;
 
     [ObservableProperty]
     private bool _accessError = false;

--- a/vrcosc-magicchatbox/ViewModels/State/TtsAudioDisplayState.cs
+++ b/vrcosc-magicchatbox/ViewModels/State/TtsAudioDisplayState.cs
@@ -30,15 +30,15 @@ public sealed partial class TtsAudioDisplayState : ObservableObject
         set { _TTSBtnShadow = value; OnPropertyChanged(); }
     }
 
-    private List<Voice> _tikTokTTSVoices;
-    public List<Voice> TikTokTTSVoices
+    private List<Voice>? _tikTokTTSVoices = new();
+    public List<Voice>? TikTokTTSVoices
     {
         get => _tikTokTTSVoices;
         set { _tikTokTTSVoices = value; OnPropertyChanged(); }
     }
 
-    private Voice _selectedTikTokTTSVoice;
-    public Voice SelectedTikTokTTSVoice
+    private Voice? _selectedTikTokTTSVoice;
+    public Voice? SelectedTikTokTTSVoice
     {
         get => _selectedTikTokTTSVoice;
         set
@@ -65,15 +65,15 @@ public sealed partial class TtsAudioDisplayState : ObservableObject
         set { _playbackOutputDevices = value; OnPropertyChanged(); }
     }
 
-    private AudioDevice _selectedAuxOutputDevice;
-    public AudioDevice SelectedAuxOutputDevice
+    private AudioDevice? _selectedAuxOutputDevice;
+    public AudioDevice? SelectedAuxOutputDevice
     {
         get => _selectedAuxOutputDevice;
         set { _selectedAuxOutputDevice = value; OnPropertyChanged(); }
     }
 
-    private AudioDevice _selectedPlaybackOutputDevice;
-    public AudioDevice SelectedPlaybackOutputDevice
+    private AudioDevice? _selectedPlaybackOutputDevice;
+    public AudioDevice? SelectedPlaybackOutputDevice
     {
         get => _selectedPlaybackOutputDevice;
         set

--- a/vrcosc-magicchatbox/ViewModels/State/WeatherOverrideState.cs
+++ b/vrcosc-magicchatbox/ViewModels/State/WeatherOverrideState.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -14,9 +15,9 @@ namespace vrcosc_magicchatbox.ViewModels.State;
 
 public partial class WeatherOverrideState : ObservableObject
 {
-    private ObservableCollection<WeatherConditionOverrideItem> _items;
+    private ObservableCollection<WeatherConditionOverrideItem>? _items;
     private bool _isUpdating;
-    private WeatherSettings _settings;
+    private WeatherSettings? _settings;
     private readonly IWeatherService _weatherService;
 
     public WeatherOverrideState(IWeatherService weatherService)
@@ -30,9 +31,9 @@ public partial class WeatherOverrideState : ObservableObject
         _settings.PropertyChanged += OnSettingsPropertyChanged;
     }
 
-    private void OnSettingsPropertyChanged(object sender, PropertyChangedEventArgs e)
+    private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName == nameof(WeatherSettings.WeatherConditionOverrides) && !_isUpdating && _items != null)
+        if (e.PropertyName == nameof(WeatherSettings.WeatherConditionOverrides) && !_isUpdating && _items != null && _settings != null)
         {
             ApplyOverridesToItems(_settings.WeatherConditionOverrides);
         }
@@ -47,6 +48,7 @@ public partial class WeatherOverrideState : ObservableObject
         }
     }
 
+    [MemberNotNull(nameof(_items))]
     private void EnsureItems()
     {
         if (_items != null) return;
@@ -70,13 +72,13 @@ public partial class WeatherOverrideState : ObservableObject
         var defaultIconMap = _weatherService.GetDefaultConditionIconMap();
         foreach (var entry in defaultMap.OrderBy(pair => pair.Key))
         {
-            defaultIconMap.TryGetValue(entry.Key, out string icon);
+            defaultIconMap.TryGetValue(entry.Key, out string? icon);
             items.Add(new WeatherConditionOverrideItem(entry.Key, icon, entry.Value));
         }
         return items;
     }
 
-    private void OnItemPropertyChanged(object sender, PropertyChangedEventArgs e)
+    private void OnItemPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (e.PropertyName != nameof(WeatherConditionOverrideItem.CustomText) &&
             e.PropertyName != nameof(WeatherConditionOverrideItem.CustomIcon))
@@ -116,7 +118,7 @@ public partial class WeatherOverrideState : ObservableObject
         _isUpdating = false;
     }
 
-    private static string BuildOverridesString(IEnumerable<WeatherConditionOverrideItem> items)
+    private static string BuildOverridesString(IEnumerable<WeatherConditionOverrideItem>? items)
     {
         if (items == null) return string.Empty;
 

--- a/vrcosc-magicchatbox/ViewModels/State/WindowActivityDisplayState.cs
+++ b/vrcosc-magicchatbox/ViewModels/State/WindowActivityDisplayState.cs
@@ -50,8 +50,8 @@ public partial class WindowActivityDisplayState : ObservableObject
     [ObservableProperty] private int _minimumFocusCount = 0;
     [ObservableProperty] private string _filteredAppsSummary = "Showing 0 / 0 apps";
 
-    private ProcessInfo _lastProcessFocused;
-    public ProcessInfo LastProcessFocused
+    private ProcessInfo? _lastProcessFocused;
+    public ProcessInfo? LastProcessFocused
     {
         get => _lastProcessFocused;
         set { if (SetProperty(ref _lastProcessFocused, value)) { } }
@@ -188,7 +188,7 @@ public partial class WindowActivityDisplayState : ObservableObject
             ApplySortDescription();
     }
 
-    private void ScannedApps_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+    private void ScannedApps_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
         Resort();
         if (e.OldItems != null)
@@ -205,7 +205,7 @@ public partial class WindowActivityDisplayState : ObservableObject
         RefreshScannedAppsView();
     }
 
-    private void ProcessInfo_PropertyChanged(object sender, PropertyChangedEventArgs e)
+    private void ProcessInfo_PropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (IsScannedAppTextEditActive)
         {
@@ -242,7 +242,8 @@ public partial class WindowActivityDisplayState : ObservableObject
         void UpdateSource()
         {
             InitializeScannedAppsViewSource();
-            _scannedAppsViewSource.Source = ScannedApps;
+            // InitializeScannedAppsViewSource always assigns _scannedAppsViewSource before returning.
+            _scannedAppsViewSource!.Source = ScannedApps;
             OnPropertyChanged(nameof(ScannedAppsView));
             RefreshScannedAppsView();
         }

--- a/vrcosc-magicchatbox/ViewModels/StatusPageViewModel.cs
+++ b/vrcosc-magicchatbox/ViewModels/StatusPageViewModel.cs
@@ -13,6 +13,7 @@ using vrcosc_magicchatbox.Classes.Modules;
 using vrcosc_magicchatbox.Core.Configuration;
 using vrcosc_magicchatbox.Core.Services;
 using vrcosc_magicchatbox.Core.State;
+using vrcosc_magicchatbox.Core.Toast;
 using vrcosc_magicchatbox.Services;
 using vrcosc_magicchatbox.ViewModels.Models;
 using vrcosc_magicchatbox.ViewModels.State;
@@ -22,6 +23,7 @@ namespace vrcosc_magicchatbox.ViewModels
     public partial class StatusPageViewModel : ObservableObject
     {
         private const string DefaultGroupName = "Default";
+        private const int MaxGroupNameLength = 50;
         private const string BoxColorNormal = "#FF6B5F98";
         private const string BoxColorWarning = "#FFFF9393";
 
@@ -30,6 +32,7 @@ namespace vrcosc_magicchatbox.ViewModels
         private readonly IStatusListService _statusListService;
         private readonly IMenuNavigationService _menuNav;
         private readonly IUiDispatcher _dispatcher;
+        private readonly IToastService _toast;
 
         private ICollectionView? _filteredView;
         private readonly Dictionary<StatusSortField, bool> _sortDirections = new();
@@ -71,13 +74,15 @@ namespace vrcosc_magicchatbox.ViewModels
             IStatusListService statusListService,
             IMenuNavigationService menuNav,
             ISettingsProvider<AppSettings> appSettingsProvider,
-            IUiDispatcher dispatcher)
+            IUiDispatcher dispatcher,
+            IToastService toast)
         {
             _chatStatus = chatStatus;
             _appState = appState;
             _statusListService = statusListService;
             _menuNav = menuNav;
             _dispatcher = dispatcher;
+            _toast = toast;
             ChatStatus = chatStatus;
             AppSettings = appSettingsProvider.Value;
 
@@ -222,8 +227,9 @@ namespace vrcosc_magicchatbox.ViewModels
         [RelayCommand]
         private void ConfirmAddGroup()
         {
-            string trimmed = NewGroupName?.Trim() ?? "";
-            if (string.IsNullOrWhiteSpace(trimmed) || trimmed.Length > 50) return;
+            if (!TryNormalizeGroupName(NewGroupName, out string trimmed))
+                return;
+
             _statusListService.AddGroup(trimmed);
             NewGroupName = string.Empty;
         }
@@ -239,10 +245,32 @@ namespace vrcosc_magicchatbox.ViewModels
         [RelayCommand]
         private void ConfirmRenameGroup(StatusGroup? group)
         {
-            if (group == null || string.IsNullOrWhiteSpace(group.RenameBuffer)) return;
-            _statusListService.RenameGroup(group.GroupId, group.RenameBuffer);
+            if (group == null || !TryNormalizeGroupName(group.RenameBuffer, out string trimmed))
+                return;
+
+            _statusListService.RenameGroup(group.GroupId, trimmed);
             group.IsRenaming = false;
             OnPropertyChanged(nameof(SelectedGroupDisplayName));
+        }
+
+        private bool TryNormalizeGroupName(string? candidate, out string normalized)
+        {
+            normalized = candidate?.Trim() ?? string.Empty;
+            string? message = normalized.Length switch
+            {
+                0 => "Enter a group name.",
+                > MaxGroupNameLength => $"Group names can contain at most {MaxGroupNameLength} characters.",
+                _ => null,
+            };
+            if (message == null)
+                return true;
+
+            _toast.Show(
+                "Status groups",
+                message,
+                ToastType.Warning,
+                key: "status-group-name-invalid");
+            return false;
         }
 
         [RelayCommand]


### PR DESCRIPTION
## SteamVR lifecycle

MagicChatbox can now register itself as a SteamVR startup application. A SteamVR launch opens it directly in the tray instead of placing a window over the headset startup flow.

There is also an optional **Close when SteamVR closes** setting. Registration automatically follows the current executable location, so portable moves and updates do not leave SteamVR pointing at an old path.

The sidebar’s TopMost shortcut has been replaced with the more useful SteamVR auto-start switch. TopMost remains available under Options.

## Updates that can manage themselves

Stable and test releases now have independent policies:

- **Ignore**
- **Tell me**
- **Install for me**

Automatic updates download and verify in the background, then install on the next suitable launch instead of replacing files during an active session. Stable releases install automatically by default for new users.

Unattended updates now:

- Require a published checksum.
- Check available disk space before downloading and installing.
- Automatically restore the previous version after three failed starts.
- Block the failed build from being offered repeatedly.
- Avoid interrupting the user with modal failure dialogs.
- Leave SteamVR-started sessions alone.

Release comparison now handles prerelease tags correctly: `0.9.223-rc1` sorts before `0.9.223`, build metadata is ignored, and shortened tags such as `v1.0` no longer break update checks.

GitHub rate limiting is treated as a temporary wait rather than an update failure. MagicChatbox preserves the current update state, shows when checking can resume, and no longer attempts to use a machine-bound fallback token that cannot decrypt elsewhere.

The update UI now shows the rollback target correctly, completes background progress cards, uses consistent button styling, and includes a compact automatic-update switch on the version card.

## Startup and UI performance

Several expensive tasks have been moved away from startup or eliminated:

- OpenAI client verification now runs after the window opens instead of blocking startup.
- ReadyToRun precompiles MagicChatbox itself.
- Runtime-compiled regular expressions were replaced with build-time generated matchers.
- Settings no longer rewrite themselves because rapidly changing `[JsonIgnore]` properties fired save notifications.
- Shared shadows, brushes and enum labels are reused instead of repeatedly allocated.
- Dropdowns and the Window Activity list now virtualize their rows correctly.
- Voicemod’s full control panel and artwork are loaded only when needed.
- Component Stats stops its preview timer while the window is hidden.

The Options page now realizes sections as they approach the viewport and remembers the scroll position for each page. Opening Options dropped from roughly **1,221 ms to 172 ms**, while its initial visual tree dropped from about **13,226 elements to 1,578**.

Startup measurements reduced the OpenAI startup step from roughly **2,478 ms to 54 ms**, with startup to a working state dropping from about **3,158 ms to 1,107 ms** before the additional ReadyToRun improvement.

## Reduced visuals

A new reduced-visuals mode removes expensive effects, blurred glows and partial-opacity composition while preserving the actual controls.

It can be enabled permanently or activated automatically while VR is running. In the measured full-app scenario, average GPU usage dropped from **19.3% to 0.2%**, while CPU usage dropped from **63.7% to 6.8%**.

## Performance diagnostics

The opt-in performance harness records:

- Page construction and teardown cost.
- Dispatcher stalls.
- Visual-tree size and depth.
- Live effects and unfrozen brushes.
- Realized ItemsControl panels.
- Binding failures.
- Memory before and after compacting garbage collection.

It can create periodic and shutdown snapshots, run navigation benchmarks, and drive a scripted whole-app scenario through WPF automation peers.

The documented `--perf` switch now works consistently, while the legacy `-perf` spelling remains supported.

## Safer settings resets

Integration reset now stops a running module before changing its settings, preserves the master enable state and stored credentials, flushes the reset before restarting, and only reports a successful restart when the module is actually running again.

Lyrics and VR Performance now participate in reset, and Network Statistics restarts correctly.

The reset confirmation dialog was also rebuilt to match the current card design. Destructive actions are visually distinct, section reset buttons align with their headers, and the integration hide control now says what it does.

## Integration reliability and security

- **Discord:** reconnect attempts continue until the integration is stopped, using capped exponential backoff.
- **Twitch:** compact counts use invariant decimal formatting, and expired or wrapped token failures follow the authentication recovery path.
- **Spotify:** temporary refresh failures and rate limits no longer discard valid sessions; revoked credentials still request authentication.
- **Weather:** invalid cities, coordinates and IP lookups now explain what failed.
- **Pulsoid:** OAuth callbacks require matching URL-safe state, the expected method and origin, and a bounded request body. Invalid callbacks no longer complete authentication.
- **OSC:** unavailable endpoints are retried after a cooldown instead of remaining disabled for the session.
- **NVIDIA monitoring:** concurrent cold reads share one `nvidia-smi` sample instead of launching duplicate processes.
- **TikTok:** profile lookup errors now distinguish missing accounts from bot checks, and requests use normal browser headers.
- **Lyrics:** visibility warnings only appear when Lyrics has an active music source to accompany.

## UI and persistence polish

- Chatbox timing now stays precisely on the tenth selected by its slider.
- Status-group add and rename operations trim names, enforce the same 50-character limit, explain rejected input, and focus/select the rename field.
- Recurring settings-save failures are reported again after storage recovers instead of being suppressed forever.
- CPU, GPU, RAM and VRAM custom names are now written during normal shutdown instead of relying on hardware monitoring stopping first.
- The automatic-update row has tighter spacing and consistent alignment.
- Integration visibility advice can be disabled when the layout is intentional.

## Build health

Release publishing now restores and publishes under the same configuration, keeps ReadyToRun focused on the application rather than expanding every dependency, and keeps the archive below the scanning limit.

The obsolete ProtectedData package reference was removed, and hundreds of nullability and event-handler warnings were corrected at their source rather than suppressed.

## Verification

- **1,946 tests pass.**
- Release build succeeds.
- Restart coverage confirms CPU, GPU, RAM and VRAM custom names persist.
- Performance scenarios cover navigation, section realization, integration activation and reduced-visual rendering.